### PR TITLE
Added documentation for mysql in docker + formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,30 @@
 
 CTFd is a CTF in a can. Easily modifiable and has everything you need to run a jeopardy style CTF.
 
-Install: 
+# Installation: 
  1. `./prepare.sh` to install dependencies using apt.
  2. Modify [CTFd/config.py](https://github.com/isislab/CTFd/blob/master/CTFd/config.py) to your liking.
  3. Use `python serve.py` in a terminal to drop into debug mode.
  4. [Here](https://github.com/isislab/CTFd/wiki/Deployment) are some deployment options
 
-Live Demo:
+# Creating a quick docker based database:
+If you just want to try CTFd with mysql and don't want to deal with setting up a database, you can use docker for it!
+ 1. Install docker via `apt-get install docker.io` or get it via the official installer script (recommended)
+ 2. Execute the follwing command to create a mysql container:
+    `sudo docker run \
+        -d \
+        --net=host \
+        --name ctfd-data \
+        -v $PWD/ctfd-data:/var/lib/mysql \
+        -e MYSQL_ROOT_PASSWORD=changeme \
+        mysql:latest`
+    
+    This will instaniate the mysql container with persistent storage in the folder $PWD/ctfd-data.
+ 3. Edit the config file `CTFd/config.py` accordingly (Use mysql, set to localhost and set the root password for mysql)
+    e.g.: SQLALCHEMY_DATABASE_URI = 'mysql://root:changeme@localhost/ctfd-data'
+ 4. Connect to the container and create a db called `ctfd-data`
+ 5. Run the webservice with gunicorn
+# Live Demo:
 [http://demo.ctfd.io/](http://demo.ctfd.io/)
 
 Logo by [Laura Barbera](http://www.laurabb.com/)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ CTFd is a CTF in a can. Easily modifiable and has everything you need to run a j
 If you just want to try CTFd with mysql and don't want to deal with setting up a database, you can use docker for it!
  1. Install docker via `apt-get install docker.io` or get it via the official installer script (recommended)
  2. Execute the follwing command to create a mysql container:
+    
+    ```
     sudo docker run \
         -d \
         --net=host \
@@ -20,6 +22,7 @@ If you just want to try CTFd with mysql and don't want to deal with setting up a
         -v $PWD/ctfd-data:/var/lib/mysql \
         -e MYSQL_ROOT_PASSWORD=changeme \
         mysql:latest
+    ```
     
     This will instaniate the mysql container with persistent storage in the folder $PWD/ctfd-data.
  3. Edit the config file `CTFd/config.py` accordingly (Use mysql, set to localhost and set the root password for mysql)

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ CTFd is a CTF in a can. Easily modifiable and has everything you need to run a j
 If you just want to try CTFd with mysql and don't want to deal with setting up a database, you can use docker for it!
  1. Install docker via `apt-get install docker.io` or get it via the official installer script (recommended)
  2. Execute the follwing command to create a mysql container:
-    ```sudo docker run \
+    sudo docker run \
         -d \
         --net=host \
         --name ctfd-data \
         -v $PWD/ctfd-data:/var/lib/mysql \
         -e MYSQL_ROOT_PASSWORD=changeme \
-        mysql:latest```
+        mysql:latest
     
     This will instaniate the mysql container with persistent storage in the folder $PWD/ctfd-data.
  3. Edit the config file `CTFd/config.py` accordingly (Use mysql, set to localhost and set the root password for mysql)

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ CTFd is a CTF in a can. Easily modifiable and has everything you need to run a j
 If you just want to try CTFd with mysql and don't want to deal with setting up a database, you can use docker for it!
  1. Install docker via `apt-get install docker.io` or get it via the official installer script (recommended)
  2. Execute the follwing command to create a mysql container:
-    `sudo docker run \
+    ```sudo docker run \
         -d \
         --net=host \
         --name ctfd-data \
         -v $PWD/ctfd-data:/var/lib/mysql \
         -e MYSQL_ROOT_PASSWORD=changeme \
-        mysql:latest`
+        mysql:latest```
     
     This will instaniate the mysql container with persistent storage in the folder $PWD/ctfd-data.
  3. Edit the config file `CTFd/config.py` accordingly (Use mysql, set to localhost and set the root password for mysql)


### PR DESCRIPTION
I added documentation on how to run CTFd along with a dockerized mysql and how to set it up. This allows users to quickly check out CTFd with a running mysql.
