### PR TITLE
Import export

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -1,13 +1,14 @@
 import hashlib
 import json
 import os
+import datetime
 
 from flask import current_app as app, render_template, request, redirect, jsonify, url_for, Blueprint, \
-    abort, render_template_string
+    abort, render_template_string, send_file
 from passlib.hash import bcrypt_sha256
 from sqlalchemy.sql import not_
 
-from CTFd.utils import admins_only, is_admin, cache
+from CTFd.utils import admins_only, is_admin, cache, export_ctf, import_ctf
 from CTFd.models import db, Teams, Solves, Awards, Containers, Challenges, WrongKeys, Keys, Tags, Files, Tracking, Pages, Config, DatabaseError
 from CTFd.scoreboard import get_standings
 from CTFd.plugins.keys import get_key_class, KEY_CLASSES
@@ -46,6 +47,16 @@ def admin_plugin_config(plugin):
         for k, v in request.form.items():
             utils.set_config(k, v)
         return '1'
+
+
+@admin.route('/admin/export', methods=['GET', 'POST'])
+@admins_only
+def admin_export_ctf():
+    backup = export_ctf()
+    ctf_name = utils.ctf_name()
+    day = datetime.datetime.now().strftime("%Y-%m-%d")
+    full_name = "{}.{}.zip".format(ctf_name, day)
+    return send_file(backup, as_attachment=True, attachment_filename=full_name)
 
 
 @admin.route('/admin/config', methods=['GET', 'POST'])

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -53,15 +53,20 @@ def admin_plugin_config(plugin):
 @admins_only
 def admin_import_ctf():
     backup = request.files['backup']
-    segments = request.post.get('tables')
+    segments = request.form.get('segments')
     errors = []
     try:
-        import_ctf(backup, segments=segments)
+        if segments:
+            import_ctf(backup, segments=segments.split(','))
+        else:
+            import_ctf(backup)
     except TypeError:
-        errors.append['The backup file is invalid']
+        errors.append('The backup file is invalid')
+    except:
+        errors.append('An unknown error occurred.')
 
     if errors:
-        return ""
+        return "", 500
     else:
         return redirect(url_for('admin.admin_config'))
 
@@ -78,7 +83,6 @@ def admin_export_ctf():
     day = datetime.datetime.now().strftime("%Y-%m-%d")
     full_name = "{}.{}.zip".format(ctf_name, day)
     return send_file(backup, as_attachment=True, attachment_filename=full_name)
-
 
 
 @admin.route('/admin/config', methods=['GET', 'POST'])

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -49,14 +49,36 @@ def admin_plugin_config(plugin):
         return '1'
 
 
+@admin.route('/admin/import', methods=['GET', 'POST'])
+@admins_only
+def admin_import_ctf():
+    backup = request.files['backup']
+    segments = request.post.get('tables')
+    errors = []
+    try:
+        import_ctf(backup, segments=segments)
+    except TypeError:
+        errors.append['The backup file is invalid']
+
+    if errors:
+        return ""
+    else:
+        return redirect(url_for('admin.admin_config'))
+
+
 @admin.route('/admin/export', methods=['GET', 'POST'])
 @admins_only
 def admin_export_ctf():
-    backup = export_ctf()
+    tables = request.args.get('tables')
+    if tables:
+        backup = export_ctf(tables.split(','))
+    else:
+        backup = export_ctf()
     ctf_name = utils.ctf_name()
     day = datetime.datetime.now().strftime("%Y-%m-%d")
     full_name = "{}.{}.zip".format(ctf_name, day)
     return send_file(backup, as_attachment=True, attachment_filename=full_name)
+
 
 
 @admin.route('/admin/config', methods=['GET', 'POST'])

--- a/CTFd/templates/admin/config.html
+++ b/CTFd/templates/admin/config.html
@@ -35,7 +35,7 @@
                             aria-hidden="true">×</span></button>
                 </div>
             {% endfor %}
-            <input name='nonce' type='hidden' value="{{ nonce }}">
+            <input id="nonce" name='nonce' type='hidden' value="{{ nonce }}">
 
             <div class="tab-content">
                 <div role="tabpanel" class="tab-pane active" id="appearance-section">
@@ -401,22 +401,22 @@
                                 <div class="form-group col-xs-8">
                                     <div class="checkbox">
                                         <label>
-                                            <input id="export-challenges" type="checkbox" checked>Challenges
+                                            <input class="export-config" value="challenges" type="checkbox" checked>Challenges
                                         </label>
                                     </div>
                                     <div class="checkbox">
                                         <label>
-                                            <input id="export-challenges" type="checkbox" checked>Teams
+                                            <input class="export-config" value="teams" type="checkbox" checked>Teams
                                         </label>
                                     </div>
                                     <div class="checkbox">
                                         <label>
-                                            <input id="export-challenges" type="checkbox" checked>Solves, Wrong Keys, Unlocks
+                                            <input class="export-config" value="both" type="checkbox" checked>Solves, Wrong Keys, Unlocks
                                         </label>
                                     </div>
                                     <div class="checkbox">
                                         <label>
-                                            <input id="export-challenges" type="checkbox" checked>Configuration
+                                            <input class="export-config" value="metadata" type="checkbox" checked>Configuration
                                         </label>
                                     </div>
 
@@ -425,39 +425,37 @@
                             </div>
                         </div>
                         <div role="tabpanel" class="tab-pane" id="import-ctf">
-                            <div class="row">
-                                <form method="POST" action="{{ request.script_root }}/admin/import">
-                                    <br>
-                                    <div class="form-group col-xs-8">
-                                        <label for="container-files">Import File
-                                            <input type="file" name="backup" id="backup-file" accept=".zip">
+                            <div class="row" id="import-div">
+                                <br>
+                                <div class="form-group col-xs-8">
+                                    <label for="container-files">Import File
+                                        <input type="file" name="backup" id="import-file" accept=".zip">
+                                    </label>
+                                </div>
+
+                                <div class="form-group col-xs-8">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input class="import-config" value="challenges" type="checkbox" checked>Challenges
                                         </label>
                                     </div>
-
-                                    <div class="form-group col-xs-8">
-                                        <div class="checkbox">
-                                            <label>
-                                                <input id="export-challenges" type="checkbox" checked>Challenges
-                                            </label>
-                                        </div>
-                                        <div class="checkbox">
-                                            <label>
-                                                <input id="export-challenges" type="checkbox" checked>Teams
-                                            </label>
-                                        </div>
-                                        <div class="checkbox">
-                                            <label>
-                                                <input id="export-challenges" type="checkbox" checked>Solves, Wrong Keys, Unlocks
-                                            </label>
-                                        </div>
-                                        <div class="checkbox">
-                                            <label>
-                                                <input id="export-challenges" type="checkbox" checked>Configuration
-                                            </label>
-                                        </div>
-                                        <input type="submit" class="btn btn-default" value="Import">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input class="import-config" value="teams" type="checkbox" checked>Teams
+                                        </label>
                                     </div>
-                                </form>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input class="import-config" value="both" type="checkbox" checked>Solves, Wrong Keys, Unlocks
+                                        </label>
+                                    </div>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input class="import-config" value="metadata" type="checkbox" checked>Configuration
+                                        </label>
+                                    </div>
+                                    <input id="import-button" type="submit" class="btn btn-default" value="Import">
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -552,6 +550,47 @@
 
         $('.freeze-date').change(function () {
             load_date_values('freeze');
+        });
+
+        $('#export-button').click(function(e){
+            e.preventDefault();
+            var segments = [];
+            $.each($('.export-config:checked'), function(key, value){
+                segments.push($(value).val());
+            });
+            segments = segments.join(',');
+            var href = script_root + '/admin/export';
+            $('#export-button').attr('href', href+'?segments='+segments);
+            window.location.href = $('#export-button').attr('href');
+        });
+
+        $('#import-button').click(function(e){
+            e.preventDefault();
+            var segments = [];
+            $.each($('.import-config:checked'), function(key, value){
+                segments.push($(value).val());
+            });
+            segments = segments.join(',');
+            console.log(segments);
+
+            var import_file = document.getElementById('import-file').files[0];
+            var nonce = $('#nonce').val();
+
+            var form_data = new FormData();
+            form_data.append('segments', segments);
+            form_data.append('backup', import_file);
+            form_data.append('nonce', nonce);
+
+            $.ajax({
+                url : script_root + '/admin/import',
+                type : 'POST',
+                data : form_data,
+                processData: false,
+                contentType: false,
+                success : function(data) {
+                    window.location.reload()
+                }
+            });
         });
 
         $(function () {

--- a/CTFd/templates/admin/config.html
+++ b/CTFd/templates/admin/config.html
@@ -587,6 +587,12 @@
                 data : form_data,
                 processData: false,
                 contentType: false,
+                statusCode: {
+                        500: function(resp) {
+                            console.log(resp.responseText);
+                            alert(resp.responseText);
+                        }
+                },
                 success : function(data) {
                     window.location.reload()
                 }

--- a/CTFd/templates/admin/config.html
+++ b/CTFd/templates/admin/config.html
@@ -19,6 +19,9 @@
                 <li role="presentation">
                     <a href="#ctftime-section" aria-controls="ctftime-section" role="tab" data-toggle="tab">CTF Time</a>
                 </li>
+                <li role="presentation">
+                    <a href="#backup-section" aria-controls="backup-section" role="tab" data-toggle="tab">Backup</a>
+                </li>
             </ul>
             <br><br>
             <button type="submit" id="submit" tabindex="5" class="btn btn-md btn-primary btn-theme btn-outlined pull-left">Update</button>
@@ -171,7 +174,6 @@
                     </div>
                 </div>
                 <div role="tabpanel" class="tab-pane" id="ctftime-section">
-                    <div>
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation" class="active">
                             <a href="#start-date" aria-controls="start-date" role="tab" data-toggle="tab">Start Time</a>
@@ -381,6 +383,83 @@
                             <input id="view_after_ctf" name="view_after_ctf" type="checkbox" {% if view_after_ctf %}checked{% endif %}>
                             Allow challenges to be viewed after CTF end
                         </label>
+                    </div>
+                </div>
+
+                <div role="tabpanel" class="tab-pane" id="backup-section">
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li role="presentation" class="active">
+                            <a href="#export-ctf" aria-controls="export-ctf" role="tab" data-toggle="tab">Export</a>
+                        </li>
+                        <li role="presentation">
+                            <a href="#import-ctf" aria-controls="import-ctf" role="tab" data-toggle="tab">Import</a>
+                        </li>
+                    </ul>
+                    <div class="tab-content">
+                        <div role="tabpanel" class="tab-pane active" id="export-ctf">
+                            <div class="row">
+                                <div class="form-group col-xs-8">
+                                    <div class="checkbox">
+                                        <label>
+                                            <input id="export-challenges" type="checkbox" checked>Challenges
+                                        </label>
+                                    </div>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input id="export-challenges" type="checkbox" checked>Teams
+                                        </label>
+                                    </div>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input id="export-challenges" type="checkbox" checked>Solves, Wrong Keys, Unlocks
+                                        </label>
+                                    </div>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input id="export-challenges" type="checkbox" checked>Configuration
+                                        </label>
+                                    </div>
+
+                                    <a href="{{ request.script_root }}/admin/export" id="export-button" class="btn btn-default">Export</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div role="tabpanel" class="tab-pane" id="import-ctf">
+                            <div class="row">
+                                <form method="POST" action="{{ request.script_root }}/admin/import">
+                                    <br>
+                                    <div class="form-group col-xs-8">
+                                        <label for="container-files">Import File
+                                            <input type="file" name="backup" id="backup-file" accept=".zip">
+                                        </label>
+                                    </div>
+
+                                    <div class="form-group col-xs-8">
+                                        <div class="checkbox">
+                                            <label>
+                                                <input id="export-challenges" type="checkbox" checked>Challenges
+                                            </label>
+                                        </div>
+                                        <div class="checkbox">
+                                            <label>
+                                                <input id="export-challenges" type="checkbox" checked>Teams
+                                            </label>
+                                        </div>
+                                        <div class="checkbox">
+                                            <label>
+                                                <input id="export-challenges" type="checkbox" checked>Solves, Wrong Keys, Unlocks
+                                            </label>
+                                        </div>
+                                        <div class="checkbox">
+                                            <label>
+                                                <input id="export-challenges" type="checkbox" checked>Configuration
+                                            </label>
+                                        </div>
+                                        <input type="submit" class="btn btn-default" value="Import">
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -645,7 +645,6 @@ def export_ctf():
     backup = io.BytesIO()
     backup_zip = zipfile.ZipFile(backup, 'w')
     for table in db.tables:
-        print table
         result = db[table].all()
         result_file = io.BytesIO()
         dataset.freeze(result, format='json', fileobj=result_file)

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -638,7 +638,7 @@ def container_ports(name, verbose=False):
         return []
 
 
-def export_ctf():
+def export_ctf(segments=None):
     db = dataset.connect(get_config('SQLALCHEMY_DATABASE_URI'))
 
     ## Backup database
@@ -668,6 +668,11 @@ def import_ctf(backup, segments=None):
     if segments is None:
         segments = ['challenges', 'teams', 'both', 'metadata']
 
+    if not zipfile.is_zipfile(backup):
+        raise TypeError
+
+    backup = zipfile.ZipFile(backup)
+
     groups = {
         'challenges': [
             'challenges',
@@ -693,6 +698,11 @@ def import_ctf(backup, segments=None):
             'containers',
         ]
     }
+
+    ## Need special handling of metadata
+    metadata = segments.get('metadata')
+    if metadata:
+        pass
 
     for segment in segments:
         group = groups[segment]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ itsdangerous==0.24
 requests==2.13.0
 PyMySQL==0.7.10
 gunicorn==19.7.0
+dataset==0.8.0


### PR DESCRIPTION
This is the beginning of the the import/export feature which allows CTF organizers to backup portions of their CTF and others can add the challenges back into CTFd at a later time. 

The entire database is backed up as JSON and uploads folder is bundled into a zip file. 

Additional thoughts:
* Should the backup file be named .ctf? 
* At the moment CTFd stops on Integrity errors. Should we skip over the bad data and report it to the user?
* Error messages are show to the user in an alert. Should we do something prettier? 