### PR TITLE
Changes the default charset for MySQL

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -43,7 +43,11 @@ def create_app(config='CTFd.config.Config'):
 
         # Creates database if the database database does not exist
         if not database_exists(url):
-            create_database(url)
+            if url.drivername.startswith('mysql'):
+                url.query['charset'] = 'utf8mb4'
+                create_database(url, encoding='utf8mb4')
+            else:
+                create_database(url)
 
         # Register database
         db.init_app(app)


### PR DESCRIPTION
MySQL can have some issues with unicode because of it's default understand of UTF8 which is like some kind of stunted version of UTF-8. 

Instead we force the charset to be `utf8mb4`.