### PR TITLE
Fix Image Links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://raw.githubusercontent.com/CTFd/CTFd/master/CTFd/static/original/img/logo.png)
+![](https://github.com/CTFd/CTFd/blob/master/CTFd/themes/original/static/img/logo.png?raw=true)
 ====
 
 [![Build Status](https://travis-ci.org/CTFd/CTFd.svg?branch=master)](https://travis-ci.org/CTFd/CTFd)
@@ -7,7 +7,7 @@
 ## What is CTFd?
 CTFd is a Capture The Flag in a can. It's easy to customize with plugins and themes and has everything you need to run a jeopardy style CTF.
 
-![CTFd is a CTF in a can.](https://github.com/CTFd/CTFd/raw/master/CTFd/static/original/img/scoreboard.png?raw=true)
+![CTFd is a CTF in a can.](https://github.com/CTFd/CTFd/blob/master/CTFd/themes/original/static/img/scoreboard.png?raw=true)
 
 ## Install
  1. `./prepare.sh` to install dependencies using apt.


### PR DESCRIPTION
Latest PR moving around the theme files broke the image links in the README.