### PR TITLE
Add Tags as a CSS class on challenge boxes

### DIFF
--- a/CTFd/themes/original/static/js/chalboard.js
+++ b/CTFd/themes/original/static/js/chalboard.js
@@ -231,8 +231,8 @@ function loadchals(refresh) {
             var chalheader = $("<h5>{0}</h5>".format(chalinfo.name));
             var chalscore = $("<span>{0}</span>".format(chalinfo.value));
             for (var j = 0; j < chalinfo.tags.length; j++) {
-                chalwrap.addClass(chalinfo.tags[j]);
-                console.log(chalinfo.tags[j]);
+                var tag = 'tag-' + chalinfo.tags[j].replace(/ /g, '-');
+                chalwrap.addClass(tag);
             }
 
             chalbutton.append(chalheader);

--- a/CTFd/themes/original/static/js/chalboard.js
+++ b/CTFd/themes/original/static/js/chalboard.js
@@ -230,6 +230,11 @@ function loadchals(refresh) {
             var chalbutton = $("<button class='challenge-button trigger theme-background hide-text' value='{0}'></div>".format(chalinfo.id));
             var chalheader = $("<h5>{0}</h5>".format(chalinfo.name));
             var chalscore = $("<span>{0}</span>".format(chalinfo.value));
+            for (var j = 0; j < chalinfo.tags.length; j++) {
+                chalwrap.addClass(chalinfo.tags[j]);
+                console.log(chalinfo.tags[j]);
+            }
+
             chalbutton.append(chalheader);
             chalbutton.append(chalscore);
             chalwrap.append(chalbutton);


### PR DESCRIPTION
Previously, there was no way to know what tags were on a challenge on the client-side without making a separate query. This was inconvenient for theme authors who might want to add some styling based on Tags, without needing to insert or modify JS in the middle of the chalboard files.

This will, for instance, allow theme authors to give admins an easy way to customize challenges (imagine a "Hot" set of challenges, moderated by Tags, or challenges sorted on the client-side by tag).

I put the tag on the outermost element for each challenge, though it wouldn't be unreasonable to move it to one of the inner ones.