### PR TITLE
Give plugins more control to render config page

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib
 import json
 import os
 import datetime
@@ -39,17 +40,21 @@ def admin_view():
 @admin.route('/admin/plugins/<plugin>', methods=['GET', 'POST'])
 @admins_only
 def admin_plugin_config(plugin):
-    if request.method == 'GET':
-        if plugin in utils.get_configurable_plugins():
-            config = open(os.path.join(app.root_path, 'plugins', plugin, 'config.html')).read()
-            return render_template_string(config)
-        abort(404)
-    elif request.method == 'POST':
+    if plugin in utils.get_configurable_plugins():
+        config_template = open(os.path.join(app.root_path, 'plugins', plugin, 'config.html')).read()
+        plugin_module = '.' + plugin
+        plugin_module = importlib.import_module(plugin_module, package='CTFd.plugins')
+        if ('plugin_config_route' in dir(plugin_module)):
+            return plugin_module.plugin_config_route(config_template, request)
+        elif request.method == 'GET':
+            return render_template_string(config_template)
+    if request.method == 'POST':
         for k, v in request.form.items():
             if k == "nonce":
                 continue
             utils.set_config(k, v)
         return '1'
+    abort(404)
 
 
 @admin.route('/admin/import', methods=['GET', 'POST'])


### PR DESCRIPTION
This is my suggestion to give plugins more control to render config page #309 

Developer can add `plugin_config_route()` method in plugin module so it can render config page with passed variables to Jinja, render a file other than config.html, or simply render a string for `/admin/plugins/<plugin>` route.

By default, request to `/admin/plugins/<plugin>` will call plugin's plugin_config_route(config_template, request) (with config is config.html template string and request is processed request within route) if it's exist. If not exist, the behavior is still the same like before.

Example:
```
def plugin_config_route(config_template, request):
    value = 0
    if request.method == 'POST':
        value = request.form.get('key', value)
    return render_template_string(config_template, key=value)
```