### PR TITLE
Fixes #315

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=mysql+pymysql://ctfd:ctfd@db/ctfd
+      - DATABASE_URL=mysql+pymysql://root:ctfd@db/ctfd
     volumes:
       - .data/CTFd/logs:/opt/CTFd/CTFd/logs
       - .data/CTFd/uploads:/opt/CTFd/CTFd/uploads
@@ -15,11 +15,10 @@ services:
       - db
 
   db:
-    image: mariadb
+    image: mariadb:10.2
     environment:
       - MYSQL_ROOT_PASSWORD=ctfd
       - MYSQL_USER=ctfd
       - MYSQL_PASSWORD=ctfd
-      - MYSQL_DATABASE=ctfd
     volumes:
       - .data/mysql:/var/lib/mysql

--- a/tests/test_user_facing.py
+++ b/tests/test_user_facing.py
@@ -18,10 +18,20 @@ def test_index():
 
 
 def test_register_user():
-    """Can a user can be registered"""
+    """Can a user be registered"""
     app = create_ctfd()
     with app.app_context():
         register_user(app)
+        team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
+        assert team_count == 2  # There's the admin user and the created user
+    destroy_ctfd(app)
+
+
+def test_register_unicode_user():
+    """Can a user with a unicode name be registered"""
+    app = create_ctfd()
+    with app.app_context():
+        register_user(app, name="你好")
         team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
         assert team_count == 2  # There's the admin user and the created user
     destroy_ctfd(app)


### PR DESCRIPTION
CTFd creates the database instead of the docker-compose files which allows us to control encoding. Also adds a test for registering with a unicode team name. 