### PR TITLE
Clear cache after set config in admin_plugin_config()

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -49,6 +49,8 @@ def admin_plugin_config(plugin):
             if k == "nonce":
                 continue
             utils.set_config(k, v)
+            with app.app_context():
+                cache.clear()
         return '1'
 
 


### PR DESCRIPTION
The `/admin/plugins/<plugin>` route for POST method does not clear the cache after `utils.set_config(k, v)` so the results for `utils.get_config(k)` are not updated immediately.