### PR TITLE
Only need to clear cache once in admin_plugin_config()

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -49,8 +49,8 @@ def admin_plugin_config(plugin):
             if k == "nonce":
                 continue
             utils.set_config(k, v)
-            with app.app_context():
-                cache.clear()
+        with app.app_context():
+            cache.clear()
         return '1'
 
 


### PR DESCRIPTION
Hi, I just noticed the cache clearing in my PR yesterday called for each key in POST request to `/admin/plugins/<plugin>`. Actually it only needs to be called once.