### PR TITLE
Don't try to log in when no username is given

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -442,7 +442,8 @@ def get_smtp(host, port, username=None, password=None, TLS=None, SSL=None):
     if TLS:
         smtp.starttls()
         smtp.ehlo()
-    smtp.login(username, password)
+    if username:
+        smtp.login(username, password)
     return smtp
 
 


### PR DESCRIPTION
It might be that no login is required to send mails (e.g. if the
mail server filters by network). In this case, CTFd should not
try to log in with an empty user/password.