### PR TITLE
Added check for SMTP AUTH support

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -442,7 +442,8 @@ def get_smtp(host, port, username=None, password=None, TLS=None, SSL=None):
     if TLS:
         smtp.starttls()
         smtp.ehlo()
-    smtp.login(username, password)
+    if smtp.has_extn('AUTH'):
+        smtp.login(username, password)
     return smtp
 
 


### PR DESCRIPTION
An error condition exists where the configured smtp server does not support the AUTH extension, as may be the case with a local smtp server configured to provide mail relay for services on the ctf box.  

This modification is on line 445 and will verify whether the smtp server has reported AUTH support before attempting to log in. 

Note, that this change will result in skipping the login quietly when AUTH is not supported, regardless of whether a user/pass has been configured.