### PR TITLE
Allow importing of longer-running docker builds

### DIFF
--- a/CTFd/admin/containers.py
+++ b/CTFd/admin/containers.py
@@ -65,3 +65,13 @@ def new_container():
     utils.create_image(name=name, buildfile=buildfile, files=files)
     utils.run_image(name)
     return redirect(url_for('admin_containers.list_container'))
+
+
+@admin_containers.route('/admin/containers/import', methods=['POST'])
+@admins_only
+def import_container():
+    name = request.form.get('name')
+    if not set(name) <= set('abcdefghijklmnopqrstuvwxyz0123456789-_'):
+        return redirect(url_for('admin_containers.list_container'))
+    utils.import_image(name=name)
+    return redirect(url_for('admin_containers.list_container'))

--- a/CTFd/themes/admin/templates/containers.html
+++ b/CTFd/themes/admin/templates/containers.html
@@ -35,6 +35,29 @@
 		</div>
 	</div>
 </div>
+<div class="modal fade" id="import-container-modal" tabindex="-1" role="dialog" aria-labelledby="container-modal-label">
+	<div class="modal-dialog" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+						aria-hidden="true">&times;</span></button>
+				<h4 class="modal-title" id="container-modal-label">Create Container</h4>
+			</div>
+			<form method="POST" action="{{ request.script_root }}/admin/containers/import" enctype="multipart/form-data">
+				<div class="modal-body">
+						<div class="form-group">
+							<label for="name">Name</label>
+							<input type="text" class="form-control" name="name" placeholder="Enter container name">
+						</div>
+						<input type="hidden" value="{{ nonce }}" name="nonce" id="nonce">
+				</div>
+				<div class="modal-footer">
+					<button type="submit" class="btn btn-primary">Create</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
 
 
 <div id="confirm" class="modal fade" tabindex="-1">
@@ -68,6 +91,9 @@
 		<h1>Containers</h1>
 		<button class="btn btn-theme btn-outlined create-challenge" data-toggle="modal" data-target="#create-container-modal">
 			New Container
+		</button>
+		<button class="btn btn-theme btn-outlined create-challenge" data-toggle="modal" data-target="#import-container-modal">
+			Import Container
 		</button>
 	</div>
 	<br>

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -577,10 +577,9 @@ def is_port_free(port):
 
 def import_image(name):
     try:
-        #TODO: probably super bad command line injection (only as root, so not super bad)
         info = json.loads(subprocess.check_output(['docker', 'inspect', '--type=image', name]))
         print(info)
-        container = Containers(name,"<none>")
+        container = Containers(name, "<none>")
         db.session.add(container)
         db.session.commit()
         db.session.close()

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -537,6 +537,20 @@ def is_port_free(port):
     return True
 
 
+def import_image(name):
+    try:
+        #TODO: probably super bad command line injection (only as root, so not super bad)
+        info = json.loads(subprocess.check_output(['docker', 'inspect', '--type=image', name]))
+        print(info)
+        container = Containers(name,"<none>")
+        db.session.add(container)
+        db.session.commit()
+        db.session.close()
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
 def create_image(name, buildfile, files):
     if not can_create_container():
         return False


### PR DESCRIPTION
The current docker builds can time out, even for simple things. This pull request allows the user to do their own "docker build" in the background and then import the image into the database so that it can be launched as needed. By default the image is not launched.