### PR TITLE
Add sorting of labels in the plotly scoreboard chart

### DIFF
--- a/CTFd/themes/original/static/js/scoreboard.js
+++ b/CTFd/themes/original/static/js/scoreboard.js
@@ -50,6 +50,14 @@ function scoregraph () {
             traces.push(trace);
         }
 
+        traces.sort(function(a,b) {
+            var scorediff = b['y'][b['y'].length - 1] - a['y'][a['y'].length - 1];
+            if(!scorediff) {
+                return a['x'][a['x'].length - 1] - b['x'][b['x'].length - 1];
+            }
+            return scorediff;
+        });
+
         var layout = {
             title: 'Top 10 Teams',
             paper_bgcolor: 'rgba(0,0,0,0)',

--- a/CTFd/themes/original/static/js/scoreboard.js
+++ b/CTFd/themes/original/static/js/scoreboard.js
@@ -50,7 +50,7 @@ function scoregraph () {
             traces.push(trace);
         }
 
-        traces.sort(function(a,b) {
+        traces.sort(function(a, b) {
             var scorediff = b['y'][b['y'].length - 1] - a['y'][a['y'].length - 1];
             if(!scorediff) {
                 return a['x'][a['x'].length - 1] - b['x'][b['x'].length - 1];


### PR DESCRIPTION
## Description
Currently, labels in the scoreboard chart are sorted in lexicographic order.
This PR adds sorting in a way that labels appear in the same order as the top 10 (1st team on top, 10th at the bottom).

## Example:
The current scoreboard is:
![scoreboard](https://user-images.githubusercontent.com/6159437/29242457-950d74aa-7f85-11e7-9ddc-3a967ceb9a75.png)

The old way of displaying labels is:
![old](https://user-images.githubusercontent.com/6159437/29242465-ad77c59a-7f85-11e7-9425-2a7cda6ca705.png)

The new way of displaying labels is:
![new](https://user-images.githubusercontent.com/6159437/29242469-b5a71162-7f85-11e7-8939-44b4ad1ff3b0.png)

