### PR TITLE
Configure mail_server and mail_port from config for easier deployments

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -73,7 +73,7 @@ class Config(object):
     MAILFROM_ADDR = "noreply@ctfd.io"
 
     '''
-    MAIL_SERVER is the name of the mail server emails are sent from if not overriden in the configuration panel. 
+    MAIL_SERVER is the name of the mail server emails are sent from if not overriden in the configuration panel.
     '''
     MAIL_SERVER = "localhost"
 
@@ -81,7 +81,6 @@ class Config(object):
     MAIL_PORT is the port of the mail server emails are sent from if not overridden in the configuration panel.
     '''
     MAIL_PORT = ""
-
 
     '''
     UPLOAD_FOLDER is the location where files are uploaded.

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -73,6 +73,17 @@ class Config(object):
     MAILFROM_ADDR = "noreply@ctfd.io"
 
     '''
+    MAIL_SERVER is the name of the mail server emails are sent from if not overriden in the configuration panel. 
+    '''
+    MAIL_SERVER = "localhost"
+
+    '''
+    MAIL_PORT is the port of the mail server emails are sent from if not overridden in the configuration panel.
+    '''
+    MAIL_PORT = 25
+
+
+    '''
     UPLOAD_FOLDER is the location where files are uploaded.
     The default destination is the CTFd/uploads folder. If you need Amazon S3 files
     you can use the CTFd S3 plugin: https://github.com/ColdHeat/CTFd-S3-plugin

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -80,7 +80,7 @@ class Config(object):
     '''
     MAIL_PORT is the port of the mail server emails are sent from if not overridden in the configuration panel.
     '''
-    MAIL_PORT = 25
+    MAIL_PORT = ""
 
 
     '''

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -429,7 +429,7 @@ def mailgun():
 
 @cache.memoize()
 def mailserver():
-    if (get_config('mail_server') and get_config('mail_port')):
+    if ((get_config('mail_server') or app.config.get('MAIL_SERVER') ) and (get_config('mail_port') or app.config.get('MAIL_PORT'))):
         return True
     return False
 
@@ -451,6 +451,8 @@ def get_smtp(host, port, username=None, password=None, TLS=None, SSL=None, auth=
 def sendmail(addr, text):
     ctf_name = get_config('ctf_name')
     mailfrom_addr = get_config('mailfrom_addr') or app.config.get('MAILFROM_ADDR')
+    mail_server = get_config('mail_server') or app.config.get('MAIL_SERVER')
+    mail_port = get_config('mail_port') or app.config.get('MAIL_PORT')
     if mailgun():
         mg_api_key = get_config('mg_api_key') or app.config.get('MAILGUN_API_KEY')
         mg_base_url = get_config('mg_base_url') or app.config.get('MAILGUN_BASE_URL')
@@ -468,8 +470,8 @@ def sendmail(addr, text):
             return False
     elif mailserver():
         data = {
-            'host': get_config('mail_server'),
-            'port': int(get_config('mail_port'))
+            'host': mail_server,
+            'port': int(mail_port)
         }
         if get_config('mail_username'):
             data['username'] = get_config('mail_username')

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -429,7 +429,7 @@ def mailgun():
 
 @cache.memoize()
 def mailserver():
-    if ((get_config('mail_server') or app.config.get('MAIL_SERVER') ) and (get_config('mail_port') or app.config.get('MAIL_PORT'))):
+    if ((get_config('mail_server') or app.config.get('MAIL_SERVER')) and (get_config('mail_port') or app.config.get('MAIL_PORT'))):
         return True
     return False
 


### PR DESCRIPTION
Add MAIL_SERVER and MAIL_PORT options to config.py to allow for scripted deployments of CTFd. 