### PR TITLE
Plugins can register global javascript files

### DIFF
--- a/CTFd/themes/original/static/js/templates/challenges/standard/standard-challenge-modal.hbs
+++ b/CTFd/themes/original/static/js/templates/challenges/standard/standard-challenge-modal.hbs
@@ -68,7 +68,7 @@
                             </div>
                         </div>
                         <div class="row notification-row">
-                            <div id="result-notification" class="alert alert-dismissable text-center" role="alert">
+                            <div id="result-notification" class="alert alert-dismissable text-center" role="alert" style="display: none;">
                               <strong id="result-message"></strong>
                             </div>
                         </div>

--- a/CTFd/themes/original/templates/base.html
+++ b/CTFd/themes/original/templates/base.html
@@ -74,5 +74,9 @@
 	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/bootstrap.min.js"></script>
 	{% block scripts %}
 	{% endblock %}
+
+	{% for script in get_registered_scripts() %}
+	<script src="{% if script.startswith('http')%}{{ request.script_root }}{% endif %}{{ script }}"></script>
+	{% endfor %}
 </body>
 </html>

--- a/CTFd/themes/original/templates/chals.html
+++ b/CTFd/themes/original/templates/chals.html
@@ -4,7 +4,6 @@
 <style>
 	.hide-text { text-overflow: ellipsis; overflow: hidden; }
 	.dialog-inner {padding-bottom: 30px;}
-	.alert {display: none}
 	.category-header {text-align: center}
 	.challenge-wrapper {padding: 5px;}
 	.challenge-button {width: 100%; height:100px;}

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -34,6 +34,7 @@ from CTFd.models import db, WrongKeys, Pages, Config, Tracking, Teams, Files, ip
 cache = Cache()
 migrate = Migrate()
 markdown = mistune.Markdown()
+plugin_scripts = []
 
 
 def init_logs(app):
@@ -106,6 +107,7 @@ def init_utils(app):
     app.jinja_env.globals.update(ctf_name=ctf_name)
     app.jinja_env.globals.update(ctf_theme=ctf_theme)
     app.jinja_env.globals.update(get_configurable_plugins=get_configurable_plugins)
+    app.jinja_env.globals.update(get_registered_scripts=get_registered_scripts)
     app.jinja_env.globals.update(get_config=get_config)
     app.jinja_env.globals.update(hide_scores=hide_scores)
 
@@ -174,6 +176,10 @@ def hide_scores():
 def override_template(template, html):
     with app.app_context():
         app.jinja_loader.overriden_templates[template] = html
+
+
+def register_plugin_script(url):
+    plugin_scripts.append(url)
 
 
 def pages():
@@ -347,6 +353,10 @@ def get_configurable_plugins():
     dir = os.path.join(app.root_path, 'plugins')
     return [name for name in os.listdir(dir)
             if os.path.isfile(os.path.join(dir, name, 'config.html'))]
+
+
+def get_registered_scripts():
+    return plugin_scripts
 
 
 def upload_file(file, chalid):


### PR DESCRIPTION
This is an enhancement to the plugin system to allow a developer to add javascript files to the theme templates. 

This is being done to support an upcoming plugin but it is a useful feature for other plugin developers. 