### PR TITLE
Call updatesolves on chal update

### DIFF
--- a/CTFd/themes/original/static/js/chalboard.js
+++ b/CTFd/themes/original/static/js/chalboard.js
@@ -314,6 +314,7 @@ function colorhash (x) {
 
 function update(){
     loadchals(true);
+    updatesolves();
 }
 
 $(function() {


### PR DESCRIPTION
This is an old issue that I never really bothered to fix. Apparently `update()` has some issues with data being ready to be rendered by `updateChalWindow()` but with some callbacks and sorting data should be ready to rendered. 

Before the solves tab could display zero solves, but now the solves tab will correctly show the right amount of solves gotten from the `/chals/solves` endpoint. 