### PR TITLE
Cache pages

### DIFF
--- a/CTFd/admin/pages.py
+++ b/CTFd/admin/pages.py
@@ -43,11 +43,15 @@ def admin_pages_view(route):
             page.html = html
             db.session.commit()
             db.session.close()
+            with app.app_context():
+                cache.clear()
             return redirect(url_for('admin_pages.admin_pages_view'))
         page = Pages(route, html)
         db.session.add(page)
         db.session.commit()
         db.session.close()
+        with app.app_context():
+            cache.clear()
         return redirect(url_for('admin_pages.admin_pages_view'))
     pages = Pages.query.all()
     return render_template('admin/pages.html', routes=pages, css=utils.get_config('css'))
@@ -82,4 +86,6 @@ def delete_page(pageroute):
     db.session.delete(page)
     db.session.commit()
     db.session.close()
+    with app.app_context():
+        cache.clear()
     return '1'

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -193,6 +193,11 @@ def pages():
     return pages
 
 
+@cache.memoize()
+def get_page(template):
+    return Pages.query.filter_by(route=template).first()
+
+
 def authed():
     return bool(session.get('id', False))
 

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -107,6 +107,7 @@ def custom_css():
 # Static HTML files
 @views.route("/", defaults={'template': 'index'})
 @views.route("/<template>")
+@cache.cached()
 def static_html(template):
     try:
         return render_template('%s.html' % template)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -107,12 +107,13 @@ def custom_css():
 # Static HTML files
 @views.route("/", defaults={'template': 'index'})
 @views.route("/<template>")
-@cache.cached()
 def static_html(template):
     try:
         return render_template('%s.html' % template)
     except TemplateNotFound:
-        page = Pages.query.filter_by(route=template).first_or_404()
+        page = utils.get_page(template)
+        if page is None:
+            abort(404)
         return render_template('page.html', content=markdown(page.html))
 
 


### PR DESCRIPTION
Cache pages so that the database doesn't get hit as often. This is useful especially with many users hitting the index page. 

Also create the `get_page` function so that we don't inadvertently cache some user data. Only cache the actual page in the database. 