### PR TITLE
Improve caching and config

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -108,14 +108,18 @@ class Config(object):
     CACHE_TYPE specifies how CTFd should cache configuration values. If CACHE_TYPE is set to 'redis', CTFd will make use
     of the REDIS_URL specified in environment variables. You can also choose to hardcode the REDIS_URL here.
 
+    It is important that you specify some sort of cache as CTFd uses it to store values received from the database.
+
     CACHE_REDIS_URL is the URL to connect to Redis server.
-    Example: redis://user:password@localhost:6379/2.
+    Example: redis://user:password@localhost:6379
 
     http://pythonhosted.org/Flask-Caching/#configuring-flask-caching
     '''
-    CACHE_TYPE = "simple"
-    if CACHE_TYPE == 'redis':
-        CACHE_REDIS_URL = os.environ.get('REDIS_URL')
+    CACHE_REDIS_URL = os.environ.get('REDIS_URL')
+    if CACHE_REDIS_URL:
+        CACHE_TYPE = 'redis'
+    else:
+        CACHE_TYPE = 'simple'
 
 
 class TestingConfig(Config):

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -406,7 +406,7 @@ def delete_file(file_id):
 @cache.memoize()
 def get_config(key):
     with app.app_context():
-        value = app.config.get(key)
+        value = app.config.get(key.upper()) or app.config.get(key.lower())
         if value:
             if value and value.isdigit():
                 return int(value)


### PR DESCRIPTION
Update `get_config` to check both upper & lower case, add more caching documentation, simplify example REDIS URL, and let us specify the REDIS_URL automatically.

Closes #354