### PR TITLE
Fixing unlocking hints for challenges with unicode names

### DIFF
--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -11,6 +11,7 @@ from CTFd.plugins.keys import get_key_class
 from CTFd.plugins.challenges import get_chal_class
 
 from CTFd import utils
+from CTFd.utils import text_type
 
 challenges = Blueprint('challenges', __name__)
 
@@ -40,7 +41,7 @@ def hints_view(hintid):
             if team.score() < hint.cost:
                 return jsonify({'errors': 'Not enough points'})
             unlock = Unlocks(model='hints', teamid=session['id'], itemid=hint.id)
-            award = Awards(teamid=session['id'], name='Hint for {}'.format(chal.name), value=(-hint.cost))
+            award = Awards(teamid=session['id'], name=text_type('Hint for {}'.format(chal.name)), value=(-hint.cost))
             db.session.add(unlock)
             db.session.add(award)
             db.session.commit()

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -31,6 +31,13 @@ from werkzeug.utils import secure_filename
 
 from CTFd.models import db, WrongKeys, Pages, Config, Tracking, Teams, Files, ip2long, long2ip
 
+if six.PY2:
+    text_type = unicode
+    binary_type = str
+else:
+    text_type = str
+    binary_type = bytes
+
 cache = Cache()
 migrate = Migrate()
 markdown = mistune.Markdown()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,14 @@ from CTFd.models import *
 from sqlalchemy_utils import database_exists, create_database, drop_database
 from sqlalchemy.engine.url import make_url
 import datetime
+import six
+
+if six.PY2:
+    text_type = unicode
+    binary_type = str
+else:
+    text_type = str
+    binary_type = bytes
 
 
 def create_ctfd(ctf_name="CTFd", name="admin", email="admin@ctfd.io", password="password", setup=True):

--- a/tests/user/test_challenges.py
+++ b/tests/user/test_challenges.py
@@ -205,7 +205,6 @@ def test_unlocking_hints_with_no_cost():
         r = client.post('/hints/1', data=data)
         output = r.get_data(as_text=True)
         output = json.loads(output)
-        print output
         assert output.get('hint') == 'This is a hint'
     destroy_ctfd(app)
 

--- a/tests/user/test_challenges.py
+++ b/tests/user/test_challenges.py
@@ -227,6 +227,5 @@ def test_unlocking_hint_for_unicode_challenge():
         r = client.post('/hints/1', data=data)
         output = r.get_data(as_text=True)
         output = json.loads(output)
-        print output
         assert output.get('hint') == 'This is a hint'
     destroy_ctfd(app)


### PR DESCRIPTION
Provides functions to cast into unicode in Python 2. I think the underlying SQLite DBAPI is confused about how to deal with the unicode. Also tested this with MySQL.
Closes #377 
