### PR TITLE
Update the amount of solves shown on the chal window when solves are listed

### DIFF
--- a/CTFd/themes/original/static/js/chalboard.js
+++ b/CTFd/themes/original/static/js/chalboard.js
@@ -189,6 +189,7 @@ function updatesolves(cb){
 function getsolves(id){
   $.get(script_root + '/chal/'+id+'/solves', function (data) {
     var teams = data['teams'];
+    $('.chal-solves').text((parseInt(teams.length) + " Solves"));
     var box = $('#chal-solves-names');
     box.empty();
     for (var i = 0; i < teams.length; i++) {


### PR DESCRIPTION
Occasionally the amount of solves shown ("17 Solves") and the amount of solves shown in the modal can differ due to the time the values are gotten. Instead, always update the value shown so that people don't get scared that CTFd might be broken.
Closes #402 
