### PR TITLE
Added trailing '/' in path of CTFd logo on main page

### DIFF
--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -38,7 +38,7 @@ def setup():
 
             # Index page
             page = Pages('index', """<div class="container main-container">
-    <img class="logo" src="themes/original/static/img/logo.png" />
+    <img class="logo" src="/themes/original/static/img/logo.png" />
     <h3 class="text-center">
         <p>A cool CTF platform from <a href="https://ctfd.io">ctfd.io</a></p>
         <p>Follow us on social media:</p>


### PR DESCRIPTION
When you are viewing a preview of the index page in the admin panel, the CTFd
logo is not shown correctly as the path for the logo i relative and thus becomes
'/admin/pages/themes/original/static/img/logo.png' instead of
'/themes/original/static/img/logo.png'.