### PR TITLE
Admin Team List - New Team

### DIFF
--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -59,8 +59,6 @@ def admin_create_team():
 
     errors = []
 
-    valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
-
     if not name:
         errors.append('The team requires a name')
     elif Teams.query.filter(Teams.name == name).first():
@@ -71,8 +69,10 @@ def admin_create_team():
     elif Teams.query.filter(Teams.email == email).first():
         errors.append('That email is taken')
 
-    if not valid_email:
-        errors.append("That email address is invalid")
+    if email:
+        valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+        if not valid_email:
+            errors.append("That email address is invalid")
 
     if not password:
         errors.append('The team requires a password')
@@ -143,9 +143,10 @@ def admin_team(teamid):
 
         errors = []
 
-        valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
-        if not valid_email:
-            errors.append("That email address is invalid")
+        if email:
+            valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+            if not valid_email:
+                errors.append("That email address is invalid")
 
         name_used = Teams.query.filter(Teams.name == name).first()
         if name_used and int(name_used.id) != int(teamid):

--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -6,6 +6,8 @@ from sqlalchemy.sql import not_
 
 from CTFd import utils
 
+import re
+
 admin_teams = Blueprint('admin_teams', __name__)
 
 
@@ -56,18 +58,28 @@ def admin_create_team():
     country = request.form.get('country', None)
 
     errors = []
+
+    valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+
     if not name:
         errors.append('The team requires a name')
     elif Teams.query.filter(Teams.name == name).first():
         errors.append('That name is taken')
+
     if not email:
         errors.append('The team requires an email')
     elif Teams.query.filter(Teams.email == email).first():
         errors.append('That email is taken')
+
+    if not valid_email:
+        errors.append("That email address is invalid")
+
     if not password:
         errors.append('The team requires a password')
-    if website and not (website.startswith('http://') or website.startswith('https://')):
+
+    if website and (website.startswith('http://') or website.startswith('https://')) is False:
         errors.append('Websites must start with http:// or https://')
+
     if errors:
         db.session.close()
         return jsonify({'data': errors})
@@ -131,6 +143,10 @@ def admin_team(teamid):
 
         errors = []
 
+        valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+        if not valid_email:
+            errors.append("That email address is invalid")
+
         name_used = Teams.query.filter(Teams.name == name).first()
         if name_used and int(name_used.id) != int(teamid):
             errors.append('That name is taken')
@@ -138,6 +154,9 @@ def admin_team(teamid):
         email_used = Teams.query.filter(Teams.email == email).first()
         if email_used and int(email_used.id) != int(teamid):
             errors.append('That email is taken')
+
+        if website and (website.startswith('http://') or website.startswith('https://')) is False:
+            errors.append('Websites must start with http:// or https://')
 
         if errors:
             db.session.close()

--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -45,6 +45,44 @@ def admin_teams_view(page):
     return render_template('admin/teams.html', teams=teams, pages=pages, curr_page=page)
 
 
+@admin_teams.route('/admin/team/new', methods=['POST'])
+@admins_only
+def admin_create_team():
+    name = request.form.get('name', None)
+    password = request.form.get('password', None)
+    email = request.form.get('email', None)
+    website = request.form.get('website', None)
+    affiliation = request.form.get('affiliation', None)
+    country = request.form.get('country', None)
+
+    errors = []
+    if not name:
+        errors.append('The team requires a name')
+    elif Teams.query.filter(Teams.name == name).first():
+        errors.append('That name is taken')
+    if not email:
+        errors.append('The team requires an email')
+    elif Teams.query.filter(Teams.email == email).first():
+        errors.append('That email is taken')
+    if not password:
+        errors.append('The team requires a password')
+    if website and not (website.startswith('http://') or website.startswith('https://')):
+        errors.append('Websites must start with http:// or https://')
+    if errors:
+        db.session.close()
+        return jsonify({'data': errors})
+
+    team = Teams(name, email, password)
+    team.website = website
+    team.affiliation = affiliation
+    team.country = country
+
+    db.session.add(team)
+    db.session.commit()
+    db.session.close()
+    return jsonify({'data': ['success']})
+
+
 @admin_teams.route('/admin/team/<int:teamid>', methods=['GET', 'POST'])
 @admins_only
 def admin_team(teamid):

--- a/CTFd/themes/admin/templates/teams.html
+++ b/CTFd/themes/admin/templates/teams.html
@@ -97,7 +97,7 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 						<div id="results">
 
 						</div>
-						<button id="update-user" type="submit" class="btn btn-theme btn-outlined pull-right">Update</button>
+						<button id="update-user" type="submit" class="btn btn-theme btn-outlined pull-right modal-action">Update</button>
 					</form>
 				</div>
 			</div>

--- a/CTFd/themes/admin/templates/teams.html
+++ b/CTFd/themes/admin/templates/teams.html
@@ -9,7 +9,7 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 {% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row" style="text-align:center">
 	<h1>Teams</h1>
 	<div id="confirm" class="modal fade" tabindex="-1">
 		<div class="modal-dialog">
@@ -185,6 +185,7 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 			{% endfor %}
 		</tbody>
 	</table>
+	<span class="btn btn-theme btn-outlined create-team" role="button">New Team</span>
 	{% if pages > 1 %}
 	<div class="text-center">Page
 		<br>
@@ -304,6 +305,10 @@ $('.fa-pencil-square-o').click(function(){
 	var country = elem.find('.team-country').attr('value')  || '';
 
 	load_update_modal(id, name, email, website, affiliation, country);
+});
+
+$('.create-team').click(function(){
+	load_update_modal('new', '', '', '', '', '');
 });
 
 function load_confirm_modal(id, name){

--- a/CTFd/themes/admin/templates/teams.html
+++ b/CTFd/themes/admin/templates/teams.html
@@ -10,7 +10,10 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 
 {% block content %}
 <div class="row">
-	<h1>Teams</h1>
+	<h1>
+		Teams
+		<i class="fa fa-plus-circle create-team" role="button" data-toggle="tooltip" title="Create Team"></i>
+	</h1>
 	<div id="confirm" class="modal fade" tabindex="-1">
 		<div class="modal-dialog">
 			<div class="modal-content">
@@ -41,7 +44,7 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal">&times;</button>
-					<h2 class="text-center">Email User</h2>
+					<h2 class="text-center">Email Team</h2>
 				</div>
 				<div class="modal-body">
 					<form method="POST">
@@ -61,9 +64,9 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal">&times;</button>
-					<h2 class="text-center">Edit User</h2>
+					<h2 class="text-center modal-action">Edit Team</h2>
 				</div>
-				<div class="modal-body" style="padding:20px; height:525px;">
+				<div class="modal-body clearfix" style="padding:20px;">
 					<form method="POST" action="{{ request.script_root }}/admin/teams/">
 						<input type="hidden" name="nonce" value="{{ nonce }}">
 						<input type="hidden" name="id">
@@ -158,8 +161,8 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 				<td class="team-id" value="{{ team.id }}">{{ team.id }}</td>
 				<td class="team-name" value="{{ team.name }}"><a href="{{ request.script_root }}/admin/team/{{ team.id }}">{{ team.name | truncate(32) }}</a>
 				</td>
-				<td class="team-email">{{ team.email | truncate(32) }}</td>
-				<td class="team-website">{% if team.website and (team.website.startswith('http://') or team.website.startswith('https://')) %}<a href="{{ team.website }}">{{ team.website | truncate(32) }}</a>{% endif %}
+				<td class="team-email" value="{{ team.email }}">{{ team.email | truncate(32) }}</td>
+				<td class="team-website">{% if team.website %}<a href="{{ team.website }}">{{ team.website | truncate(32) }}</a>{% endif %}
 				</td>
 				<td class="team-affiliation" value="{{ team.affiliation if team.affiliation is not none }}"><span>{% if team.affiliation %}{{ team.affiliation | truncate(20) }}{% endif %}</span>
 				</td>
@@ -185,9 +188,6 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 			{% endfor %}
 		</tbody>
 	</table>
-	<div class="text-center">
-		<span class="btn btn-theme btn-outlined create-team" role="button">New Team</span>
-	</div>
 	{% if pages > 1 %}
 	<div class="text-center">Page
 		<br>
@@ -210,13 +210,22 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 function load_update_modal(id, name, email, website, affiliation, country){
 	var modal_form = $('#user form');
 
-	modal_form.find('input[name=name]').val(name)
-	modal_form.find('input[name=id]').val(id)
-	modal_form.find('input[name=email]').val(email)
-	modal_form.find('input[name=website]').val(website)
-	modal_form.find('input[name=affiliation]').val(affiliation)
-	modal_form.find('input[name=country]').val(country)
-	$('#user form').attr('action', '{{ request.script_root }}/admin/team/'+id)
+	modal_form.find('input[name=name]').val(name);
+	modal_form.find('input[name=id]').val(id);
+	modal_form.find('input[name=email]').val(email);
+	modal_form.find('input[name=website]').val(website);
+	modal_form.find('input[name=affiliation]').val(affiliation);
+	modal_form.find('input[name=country]').val(country);
+	modal_form.find('input[name=password]').val('');
+
+	if (id == 'new'){
+		$('#user .modal-action').text('Create Team');
+	} else {
+		$('#user .modal-action').text('Edit Team');
+	}
+
+	$('#results').empty();
+	$('#user form').attr('action', '{{ request.script_root }}/admin/team/'+id);
 	$('#user').modal("show");
 }
 
@@ -224,28 +233,20 @@ $('#update-user').click(function(e){
 	e.preventDefault();
 	var id = $('#user input[name="id"]').val()
 	var user_data = $('#user form').serializeArray()
+	$('#results').empty();
 	$.post($('#user form').attr('action'), $('#user form').serialize(), function(data){
 		var data = $.parseJSON(JSON.stringify(data))
 		for (var i = 0; i < data['data'].length; i++) {
 			if (data['data'][i] == 'success'){
-				var row = $('tr[name='+id+']')
-				console.log($.grep(user_data, function(e){ return e.name == 'name'; })[0]['value'])
-				console.log(row.find('.team-name > a'))
-				row.find('.team-name > a').text( $.grep(user_data, function(e){ return e.name == 'name'; })[0]['value'] );
-				var new_email = $.grep(user_data, function(e){ return e.name == 'email'; })[0]['value'];
-				if (new_email){
-					row.find('.team-email').text( new_email );
-				}
-				row.find('.team-website > a').empty()
-				var website = $.grep(user_data, function(e){ return e.name == 'website'; })[0]['value']
-				row.find('.team-website').append($('<a>').attr('href', website).text(website));
-
-				row.find('.team-affiliation').text( $.grep(user_data, function(e){ return e.name == 'affiliation'; })[0]['value'] );
-				row.find('.team-country').text( $.grep(user_data, function(e){ return e.name == 'country'; })[0]['value'] );
 				$('#user').modal('hide');
+				location.reload();
 			}
 			else{
-				$('#results').append($('p').text( data['data'][i] ))
+				var error = $('<div class="alert alert-danger alert-dismissable">\n' +
+					'  <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>\n' +
+					'  {0}\n'.format(data['data'][i]) +
+					'</div>');
+				$('#results').append(error);
 			}
 		};
 	})

--- a/CTFd/themes/admin/templates/teams.html
+++ b/CTFd/themes/admin/templates/teams.html
@@ -9,7 +9,7 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 {% endblock %}
 
 {% block content %}
-<div class="row" style="text-align:center">
+<div class="row">
 	<h1>Teams</h1>
 	<div id="confirm" class="modal fade" tabindex="-1">
 		<div class="modal-dialog">
@@ -185,7 +185,9 @@ input[type="checkbox"] { margin: 0px !important; position: relative; top: 5px; }
 			{% endfor %}
 		</tbody>
 	</table>
-	<span class="btn btn-theme btn-outlined create-team" role="button">New Team</span>
+	<div class="text-center">
+		<span class="btn btn-theme btn-outlined create-team" role="button">New Team</span>
+	</div>
 	{% if pages > 1 %}
 	<div class="text-center">Page
 		<br>


### PR DESCRIPTION
Closes #469

 - Adds a "New Team" button to the admin "Teams" page
 - Reuses the update team modal for for creating new teams
 - Adds an API route to allow admins to create a new team
 - Adds unit tests to cover added python code