### PR TITLE
34 reduce auth restrictions

### DIFF
--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -64,6 +64,9 @@ def admin_create_team():
     elif Teams.query.filter(Teams.name == name).first():
         errors.append('That name is taken')
 
+    if utils.check_email_format(name) is True:
+        errors.append('Team name cannot be an email address')
+
     if not email:
         errors.append('The team requires an email')
     elif Teams.query.filter(Teams.email == email).first():
@@ -151,6 +154,9 @@ def admin_team(teamid):
         name_used = Teams.query.filter(Teams.name == name).first()
         if name_used and int(name_used.id) != int(teamid):
             errors.append('That name is taken')
+
+        if utils.check_email_format(name) is True:
+            errors.append('Team name cannot be an email address')
 
         email_used = Teams.query.filter(Teams.email == email).first()
         if email_used and int(email_used.id) != int(teamid):

--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -70,7 +70,7 @@ def admin_create_team():
         errors.append('That email is taken')
 
     if email:
-        valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+        valid_email = utils.check_email_format(email)
         if not valid_email:
             errors.append("That email address is invalid")
 
@@ -144,7 +144,7 @@ def admin_team(teamid):
         errors = []
 
         if email:
-            valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+            valid_email = utils.check_email_format(email)
             if not valid_email:
                 errors.append("That email address is invalid")
 

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -86,7 +86,7 @@ def reset_password(data=None):
         except BadTimeSignature:
             return render_template('reset_password.html', errors=['Your link has expired'])
         except:
-            return render_template('reset_password.html', errors=['Your link appears broken, please try again.'])
+            return render_template('reset_password.html', errors=['Your link appears broken, please try again'])
         team = Teams.query.filter_by(name=name).first_or_404()
         team.password = bcrypt_sha256.encrypt(request.form['password'].strip())
         db.session.commit()
@@ -101,6 +101,15 @@ def reset_password(data=None):
     if request.method == 'POST':
         email = request.form['email'].strip()
         team = Teams.query.filter_by(email=email).first()
+
+        errors = []
+
+        if utils.can_send_mail() is False:
+            return render_template(
+                'reset_password.html',
+                errors=['Email could not be sent due to server misconfiguration']
+            )
+
         if not team:
             return render_template(
                 'reset_password.html',
@@ -117,7 +126,10 @@ Did you initiate a password reset?
 
         utils.sendmail(email, text)
 
-        return render_template('reset_password.html', errors=['If that account exists you will receive an email, please check your inbox'])
+        return render_template(
+            'reset_password.html',
+            errors=['If that account exists you will receive an email, please check your inbox']
+        )
     return render_template('reset_password.html')
 
 

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -216,7 +216,6 @@ def login():
         name = request.form['name']
 
         # Check if the user submitted an email address or a team name
-        print utils.check_email_format(name)
         if utils.check_email_format(name) is True:
             team = Teams.query.filter_by(email=name).first()
         else:

--- a/CTFd/themes/original/templates/login.html
+++ b/CTFd/themes/original/templates/login.html
@@ -36,7 +36,7 @@
 						<span class="input">
 							<input class="input-field" type="text" name="name" id="name-input" />
 							<label class="input-label" for="name-input">
-								<span class="label-content">Team Name</span>
+								<span class="label-content">Team Name or Email</span>
 							</label>
 						</span>
 					</div>

--- a/CTFd/themes/original/templates/login.html
+++ b/CTFd/themes/original/templates/login.html
@@ -53,9 +53,7 @@
 				</div>
 				<div class="done-row row">
 					<div class="col-md-6" style="padding-left:0px">
-						{% if can_send_mail() %}
 						<a class="pull-left align-text-to-button" href="{{ request.script_root }}/reset_password">Forgot your password?</a>
-						{% endif %}
 					</div>
 					<div class="col-md-6">
 						<button type="submit" id="submit" tabindex="5" class="btn btn-md btn-theme btn-outlined pull-right">Submit</button>

--- a/CTFd/themes/original/templates/login.html
+++ b/CTFd/themes/original/templates/login.html
@@ -53,7 +53,9 @@
 				</div>
 				<div class="done-row row">
 					<div class="col-md-6" style="padding-left:0px">
+						{% if can_send_mail() %}
 						<a class="pull-left align-text-to-button" href="{{ request.script_root }}/reset_password">Forgot your password?</a>
+						{% endif %}
 					</div>
 					<div class="col-md-6">
 						<button type="submit" id="submit" tabindex="5" class="btn btn-md btn-theme btn-outlined pull-right">Submit</button>

--- a/CTFd/themes/original/templates/reset_password.html
+++ b/CTFd/themes/original/templates/reset_password.html
@@ -19,6 +19,7 @@
 				  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
 				</div>
 			{% endfor %}
+			{% if can_send_mail() %}
 			<form method="post" accept-charset="utf-8" autocomplete="off" role="form" class="form-horizontal">
 				<input name='nonce' type='hidden' value="{{ nonce }}">
 				{% if mode %}
@@ -49,6 +50,15 @@
 					</div>
 				</div>
 			</form>
+			{% else %}
+			<div class="row">
+				<div class="col-md-12">
+					<h3 class="text-center">Contact a CTF organizer</h3>
+					<p>This CTF is not configured to send email.</p>
+					<p>Please contact an organizer to have your password reset</p>
+				</div>
+			</div>
+			{% endif %}
 		</div>
 	</div>
 </div>

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -621,6 +621,10 @@ def validate_url(url):
     return urlparse(url).scheme.startswith('http')
 
 
+def check_email_format(email):
+    return bool(re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email))
+
+
 def sha512(string):
     return hashlib.sha512(string).hexdigest()
 

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -220,7 +220,7 @@ def profile():
                 name_len = len(request.form['name']) == 0
 
             emails = Teams.query.filter_by(email=email).first()
-            valid_email = re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email)
+            valid_email = utils.check_email_format(email)
 
             if ('password' in request.form.keys() and not len(request.form['password']) == 0) and \
                     (not bcrypt_sha256.verify(request.form.get('confirm').strip(), user.password)):

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -222,6 +222,9 @@ def profile():
             emails = Teams.query.filter_by(email=email).first()
             valid_email = utils.check_email_format(email)
 
+            if utils.check_email_format(name) is True:
+                errors.append('Team name cannot be an email address')
+
             if ('password' in request.form.keys() and not len(request.form['password']) == 0) and \
                     (not bcrypt_sha256.verify(request.form.get('confirm').strip(), user.password)):
                 errors.append("Your old password doesn't match what we have.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from CTFd.models import ip2long, long2ip
 from CTFd.utils import get_config, set_config, override_template, sendmail, verify_email, ctf_started, ctf_ended, export_ctf
 from CTFd.utils import register_plugin_script, register_plugin_stylesheet
 from CTFd.utils import base64encode, base64decode
+from CTFd.utils import check_email_format
 from freezegun import freeze_time
 from mock import patch
 import json
@@ -349,3 +350,23 @@ def test_export_ctf():
         with open('export.zip', 'wb') as f:
             f.write(backup.getvalue())
     destroy_ctfd(app)
+
+
+def test_check_email_format():
+    """Test that the check_email_format() works properly"""
+    assert check_email_format('user@ctfd.io') is True
+    assert check_email_format('user+plus@gmail.com') is True
+    assert check_email_format('user.period1234@gmail.com') is True
+    assert check_email_format('user.period1234@b.c') is True
+    assert check_email_format('user.period1234@b') is False
+    assert check_email_format('no.ampersand') is False
+    assert check_email_format('user@') is False
+    assert check_email_format('@ctfd.io') is False
+    assert check_email_format('user.io@ctfd') is False
+    assert check_email_format('user\@ctfd') is False
+
+    for invalid_email in ['user.@ctfd.io', '.user@ctfd.io', 'user@ctfd..io']:
+        try:
+            assert check_email_format(invalid_email) is False
+        except AssertionError:
+            print(invalid_email, 'did not pass validation')


### PR DESCRIPTION
Closes #34 by reducing some auth restrictions:

* Team names cannot be email addresses. 
* Teams can login with team names or email address now
* Password reset isn't shown to the user if the server isn't configured to send mail. 
* `utils.check_email_format()` now exists to check email format