### PR TITLE
Authed only

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -285,7 +285,17 @@ def admins_only(f):
         if session.get('admin'):
             return f(*args, **kwargs)
         else:
-            return redirect(url_for('auth.login'))
+            return redirect(url_for('auth.login', next=request.path))
+    return decorated_function
+
+
+def authed_only(f):
+    @functools.wraps(f)
+    def decorated_function(*args, **kwargs):
+        if session.get('id'):
+            return f(*args, **kwargs)
+        else:
+            return redirect(url_for('auth.login', next=request.path))
     return decorated_function
 
 

--- a/tests/user/test_user_facing.py
+++ b/tests/user/test_user_facing.py
@@ -115,7 +115,7 @@ def test_user_isnt_admin():
         client = login_as_user(app)
         for page in ['pages', 'teams', 'scoreboard', 'chals', 'statistics', 'config']:
             r = client.get('/admin/{}'.format(page))
-            assert r.location == "http://localhost/login"
+            assert r.location.startswith("http://localhost/login?next=")
             assert r.status_code == 302
     destroy_ctfd(app)
 


### PR DESCRIPTION
Closes #472 

Add an `authed_only` decorator. Doesn't seem worth it to change much of the existing logic yet but plugins can make use of it. 