### PR TITLE
Update check

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -85,6 +85,7 @@ def create_app(config='CTFd.config.Config'):
                 migrate_upgrade()
 
         app.db = db
+        app.VERSION = __version__
 
         cache.init_app(app)
         app.cache = cache

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -10,7 +10,7 @@ from sqlalchemy_utils import database_exists, create_database
 from sqlalchemy_utils.functions import get_tables
 from six.moves import input
 
-from CTFd.utils import cache, migrate, migrate_upgrade, migrate_stamp
+from CTFd.utils import cache, migrate, migrate_upgrade, migrate_stamp, update_check
 from CTFd import utils
 
 # Hack to support Unicode in Python 2 properly
@@ -88,6 +88,8 @@ def create_app(config='CTFd.config.Config'):
 
         cache.init_app(app)
         app.cache = cache
+
+        update_check()
 
         version = utils.get_config('ctf_version')
 

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -121,6 +121,11 @@ class Config(object):
     else:
         CACHE_TYPE = 'simple'
 
+    '''
+    UPDATE_CHECK specifies whether or not CTFd will check whether or not there is a new version of CTFd
+    '''
+    UPDATE_CHECK = True
+
 
 class TestingConfig(Config):
     SECRET_KEY = 'AAAAAAAAAAAAAAAAAAAA'
@@ -129,3 +134,4 @@ class TestingConfig(Config):
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = os.environ.get('TESTING_DATABASE_URL') or 'sqlite://'
     SERVER_NAME = 'localhost'
+    UPDATE_CHECK = False

--- a/CTFd/themes/admin/templates/base.html
+++ b/CTFd/themes/admin/templates/base.html
@@ -85,6 +85,19 @@
 		</div>
 	</nav>
 
+	{% if get_config('version_latest') %}
+	<div class="container-fluid bg-warning text-center py-3">
+		<div class="row">
+			<div class="col-md-12">
+				<a class="btn btn-warning" href="{{ get_config('version_latest') }}">
+					A new CTFd version is available!
+				</a>
+			</div>
+		</div>
+	</div>
+	{% endif %}
+
+
 	<main role="main">
 		{% block content %}
 		{% endblock %}

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -678,7 +678,7 @@ def update_check():
     if update:
         try:
             check = requests.get('https://versioning.ctfd.io/versions/latest', timeout=0.001).json()
-        except requests.Timeout:
+        except requests.exceptions.RequestException as e:
             pass
         else:
             try:

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -677,7 +677,14 @@ def update_check():
     update = app.config.get('UPDATE_CHECK')
     if update:
         try:
-            check = requests.get('https://versioning.ctfd.io/versions/latest', timeout=0.001).json()
+            params = {
+                'current': CTFd.__version__
+            }
+            check = requests.get(
+                'https://versioning.ctfd.io/versions/latest',
+                params=params,
+                timeout=0.1
+            ).json()
         except requests.exceptions.RequestException as e:
             pass
         else:

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -678,7 +678,7 @@ def update_check():
     if update:
         try:
             params = {
-                'current': CTFd.__version__
+                'current': app.VERSION
             }
             check = requests.get(
                 'https://versioning.ctfd.io/versions/latest',
@@ -690,12 +690,13 @@ def update_check():
         else:
             try:
                 latest = check['resource']['tag']
-                if StrictVersion(latest) > StrictVersion(CTFd.__version__):
-                    set_config('version_latest', latest)
-                elif StrictVersion(latest) <= StrictVersion(CTFd.__version__):
+                html_url = check['resource']['html_url']
+                if StrictVersion(latest) > StrictVersion(app.VERSION):
+                    set_config('version_latest', html_url)
+                elif StrictVersion(latest) <= StrictVersion(app.VERSION):
                     set_config('version_latest', None)
             except KeyError:
-                pass
+                set_config('version_latest', None)
 
 
 def export_ctf(segments=None):

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -674,7 +674,6 @@ def base64decode(s, urldecode=False):
 
 
 def update_check():
-    print "called update_check"
     update = app.config.get('UPDATE_CHECK')
     if update:
         try:
@@ -698,6 +697,8 @@ def update_check():
                     set_config('version_latest', None)
             except KeyError:
                 set_config('version_latest', None)
+    else:
+        set_config('version_latest', None)
 
 
 def export_ctf(segments=None):

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -674,6 +674,7 @@ def base64decode(s, urldecode=False):
 
 
 def update_check():
+    print "called update_check"
     update = app.config.get('UPDATE_CHECK')
     if update:
         try:

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -36,6 +36,8 @@ from CTFd.models import db, WrongKeys, Pages, Config, Tracking, Teams, Files, ip
 from datafreeze.format import SERIALIZERS
 from datafreeze.format.fjson import JSONSerializer, JSONEncoder
 
+from distutils.version import StrictVersion
+
 if six.PY2:
     text_type = unicode
     binary_type = str
@@ -669,6 +671,24 @@ def base64decode(s, urldecode=False):
     if six.PY3:
         decoded = decoded.decode('utf-8')
     return decoded
+
+
+def update_check():
+    update = app.config.get('UPDATE_CHECK')
+    if update:
+        try:
+            check = requests.get('https://versioning.ctfd.io/versions/latest', timeout=0.001).json()
+        except requests.Timeout:
+            pass
+        else:
+            try:
+                latest = check['resource']['tag']
+                if StrictVersion(latest) > StrictVersion(CTFd.__version__):
+                    set_config('version_latest', latest)
+                elif StrictVersion(latest) <= StrictVersion(CTFd.__version__):
+                    set_config('version_latest', None)
+            except KeyError:
+                pass
 
 
 def export_ctf(segments=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -374,6 +374,13 @@ def test_check_email_format():
             print(invalid_email, 'did not pass validation')
 
 
+def test_update_check_is_called():
+    """Update checks happen on start"""
+    app = create_ctfd()
+    with app.app_context():
+        assert get_config('version_latest') == None
+
+
 @patch.object(requests, 'get')
 def test_update_check_identifies_update(fake_get_request):
     """Update checks properly identify new versions"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -378,7 +378,7 @@ def test_update_check_is_called():
     """Update checks happen on start"""
     app = create_ctfd()
     with app.app_context():
-        assert get_config('version_latest') == None
+        assert get_config('version_latest') is None
 
 
 @patch.object(requests, 'get')
@@ -442,7 +442,7 @@ def test_update_check_ignores_downgrades(fake_get_request):
             }
         }
         update_check()
-        assert get_config('version_latest') == None
+        assert get_config('version_latest') is None
 
         fake_response = Mock()
         fake_get_request.return_value = fake_response
@@ -458,5 +458,5 @@ def test_update_check_ignores_downgrades(fake_get_request):
             }
         }
         update_check()
-        assert get_config('version_latest') == None
+        assert get_config('version_latest') is None
     destroy_ctfd(app)


### PR DESCRIPTION
Closes #480 

This implements a simple version check so that we can direct users to blog posts or Github releases when there is a new CTFd version. 