### PR TITLE
Add APPLICATION_ROOT in config.py

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -63,6 +63,11 @@ class Config(object):
     PERMANENT_SESSION_LIFETIME = 604800  # 7 days in seconds
 
     '''
+    APPLICATION_ROOT is the directory where CTFd runs. You need to change that when you deploy CTFd in a subdirectory.
+    '''
+    APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT') or '/'
+    
+    '''
     HOST specifies the hostname where the CTFd instance will exist. It is currently unused.
     '''
     HOST = ".ctfd.io"


### PR DESCRIPTION
If someone want to deploy CTFd in a subdirectory (by setting reverse-proxy) with Docker, he will need this way to change that without rebuilding the image.