### PR TITLE
Before this change imports did not work when a model referenced another by its id.

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -791,7 +791,6 @@ def import_ctf(backup, segments=None, erase=False):
             if data:
                 saved = json.loads(data)
                 for entry in saved['results']:
-                    entry_id = entry.pop('id', None)
                     # This is a hack to get SQlite to properly accept datetime values from dataset
                     # See Issue #246
                     if get_config('SQLALCHEMY_DATABASE_URI').startswith('sqlite'):
@@ -801,7 +800,7 @@ def import_ctf(backup, segments=None, erase=False):
                                     entry[k] = datetime.datetime.strptime(v, '%Y-%m-%dT%H:%M:%S')
                                 except ValueError as e:
                                     pass
-                    table.insert(entry)
+                    table.upsert(entry, ['id'])
             else:
                 continue
 


### PR DESCRIPTION
However, now instead of dropping the entry_id it is now used to upsert data.

Signed-off-by: David Black <dblack@atlassian.com>