### PR TITLE
Improve imports/exports to reduce the likelihood of a conflict

### DIFF
--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -32,7 +32,7 @@ from sqlalchemy.exc import InvalidRequestError, IntegrityError
 from socket import timeout
 from werkzeug.utils import secure_filename
 
-from CTFd.models import db, WrongKeys, Pages, Config, Tracking, Teams, Files, ip2long, long2ip
+from CTFd.models import db, Challenges, WrongKeys, Pages, Config, Tracking, Teams, Files, ip2long, long2ip
 
 from datafreeze.format import SERIALIZERS
 from datafreeze.format.fjson import JSONSerializer, JSONEncoder
@@ -793,6 +793,14 @@ def export_ctf(segments=None):
             result_file.seek(0)
             backup_zip.writestr('db/{}.json'.format(item), result_file.read())
 
+    # Guarantee that alembic_version is saved into the export
+    if 'metadata' not in segments:
+        result = db['alembic_version'].all()
+        result_file = six.BytesIO()
+        datafreeze.freeze(result, format='ctfd', fileobj=result_file)
+        result_file.seek(0)
+        backup_zip.writestr('db/alembic_version.json', result_file.read())
+
     # Backup uploads
     upload_folder = os.path.join(os.path.normpath(app.root_path), get_config('UPLOAD_FOLDER'))
     for root, dirs, files in os.walk(upload_folder):
@@ -864,14 +872,20 @@ def import_ctf(backup, segments=None, erase=False):
                     saved = json.loads(data)
                     for entry in saved['results']:
                         route = entry['route']
+                        title = entry.get('title', route.title())
                         html = entry['html']
+                        draft = entry.get('draft', False)
+                        auth_required = entry.get('auth_required', False)
                         page = Pages.query.filter_by(route=route).first()
                         if page:
                             page.html = html
                         else:
-                            page = Pages(route, html)
+                            page = Pages(title, route, html, draft=draft, auth_required=auth_required)
                             db.session.add(page)
                         db.session.commit()
+
+    teams_base = db.session.query(db.func.max(Teams.id)).scalar() or 0
+    chals_base = db.session.query(db.func.max(Challenges.id)).scalar() or 0
 
     for segment in segments:
         group = groups[segment]
@@ -888,11 +902,24 @@ def import_ctf(backup, segments=None, erase=False):
                     if get_config('SQLALCHEMY_DATABASE_URI').startswith('sqlite'):
                         for k, v in entry.items():
                             if isinstance(v, six.string_types):
-                                try:
+                                match = re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d", v)
+                                if match:
+                                    entry[k] = datetime.datetime.strptime(v, '%Y-%m-%dT%H:%M:%S.%f')
+                                    continue
+                                match = re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", v)
+                                if match:
                                     entry[k] = datetime.datetime.strptime(v, '%Y-%m-%dT%H:%M:%S')
-                                except ValueError as e:
-                                    pass
-                    table.insert(entry)
+                                    continue
+                    for k, v in entry.items():
+                        if k == 'chal' or k == 'chalid':
+                            entry[k] += chals_base
+                        if k == 'team' or k == 'teamid':
+                            entry[k] += teams_base
+
+                    if item == 'teams':
+                        table.insert_ignore(entry, ['email'])
+                    else:
+                        table.insert(entry)
             else:
                 continue
 

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -897,6 +897,11 @@ def import_ctf(backup, segments=None, erase=False):
                 saved = json.loads(data)
                 for entry in saved['results']:
                     entry_id = entry.pop('id', None)
+                    if item == 'keys':
+                        key_type = entry.get('key_type', None)
+                        if key_type is not None:
+                            entry['type'] = key_type
+                            del entry['key_type']
                     # This is a hack to get SQlite to properly accept datetime values from dataset
                     # See Issue #246
                     if get_config('SQLALCHEMY_DATABASE_URI').startswith('sqlite'):

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -949,6 +949,6 @@ def import_ctf(backup, segments=None, erase=False):
             os.makedirs(dirname)
 
         source = backup.open(f)
-        target = file(full_path, "wb")
+        target = open(full_path, "wb")
         with source, target:
             shutil.copyfileobj(source, target)

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -871,6 +871,7 @@ def import_ctf(backup, segments=None, erase=False):
                 elif item == 'pages':
                     saved = json.loads(data)
                     for entry in saved['results']:
+                        # Support migration c12d2a1b0926_add_draft_and_title_to_pages
                         route = entry['route']
                         title = entry.get('title', route.title())
                         html = entry['html']
@@ -897,11 +898,6 @@ def import_ctf(backup, segments=None, erase=False):
                 saved = json.loads(data)
                 for entry in saved['results']:
                     entry_id = entry.pop('id', None)
-                    if item == 'keys':
-                        key_type = entry.get('key_type', None)
-                        if key_type is not None:
-                            entry['type'] = key_type
-                            del entry['key_type']
                     # This is a hack to get SQlite to properly accept datetime values from dataset
                     # See Issue #246
                     if get_config('SQLALCHEMY_DATABASE_URI').startswith('sqlite'):
@@ -923,6 +919,13 @@ def import_ctf(backup, segments=None, erase=False):
 
                     if item == 'teams':
                         table.insert_ignore(entry, ['email'])
+                    elif item == 'keys':
+                        # Support migration 2539d8b5082e_rename_key_type_to_type
+                        key_type = entry.get('key_type', None)
+                        if key_type is not None:
+                            entry['type'] = key_type
+                            del entry['key_type']
+                        table.insert(entry)
                     else:
                         table.insert(entry)
             else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -365,7 +365,8 @@ def test_import_ctf():
             base_user = 'user'
             for x in range(10):
                 user = base_user + str(x)
-                gen_team(app.db, name=user, email=user+"@ctfd.io")
+                user_email = user + "@ctfd.io"
+                gen_team(app.db, name=user, email=user_email)
 
             for x in range(10):
                 gen_challenge(app.db, name='chal_name{}'.format(x))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -381,8 +381,7 @@ def test_import_ctf():
 
         app = create_ctfd()
         with app.app_context():
-            with open('export.zip') as f:
-                import_ctf(f)
+            import_ctf('export.zip')
 
             app.db.session.commit()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -369,7 +369,8 @@ def test_import_ctf():
                 gen_team(app.db, name=user, email=user_email)
 
             for x in range(10):
-                gen_challenge(app.db, name='chal_name{}'.format(x))
+                chal = gen_challenge(app.db, name='chal_name{}'.format(x))
+                gen_flag(app.db, chal=chal.id, flag='flag')
 
             app.db.session.commit()
 
@@ -390,6 +391,7 @@ def test_import_ctf():
 
             assert Teams.query.count() == 11
             assert Challenges.query.count() == 10
+            assert Keys.query.count() == 10
     destroy_ctfd(app)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -386,8 +386,8 @@ def test_import_ctf():
 
             app.db.session.commit()
 
-            print Teams.query.count()
-            print Challenges.query.count()
+            print(Teams.query.count())
+            print(Challenges.query.count())
 
             assert Teams.query.count() == 11
             assert Challenges.query.count() == 10


### PR DESCRIPTION
Closes #498 by checking for multiple date formats
Resolves some import conflicts with IDs not matching up and conflicts with users having the same team name. 
All exports should include their alembic_version or else we're just guessing when the export came from. 
