### PR TITLE
Only prompt for upgrades if there's a TTY & mark 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * SMTP email connections take priority over mailgun settings now. The opposite used to be true.
 * The JavaScript `submitkey()` function now takes an optional callback.
 * `utils.get_config()` no longer looks at `app.config` values. Instead use `utils.get_app_config()`.
+* Only prompt about upgrades when running with a TTY.
 
 
 1.0.5 / 2017-10-25

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -17,7 +17,7 @@ if sys.version_info[0] < 3:
     reload(sys)
     sys.setdefaultencoding("utf-8")
 
-__version__ = '1.1.0a1'
+__version__ = '1.1.0'
 
 
 class CTFdFlask(Flask):
@@ -64,14 +64,17 @@ class ThemeLoader(FileSystemLoader):
 
 
 def confirm_upgrade():
-    print("/*\\ CTFd has updated and must update the database! /*\\")
-    print("/*\\ Please backup your database before proceeding! /*\\")
-    print("/*\\ CTFd maintainers are not responsible for any data loss! /*\\")
-    if input('Run database migrations (Y/N)').lower().strip() == 'y':
-        return True
+    if sys.stdin.isatty():
+        print("/*\\ CTFd has updated and must update the database! /*\\")
+        print("/*\\ Please backup your database before proceeding! /*\\")
+        print("/*\\ CTFd maintainers are not responsible for any data loss! /*\\")
+        if input('Run database migrations (Y/N)').lower().strip() == 'y':
+            return True
+        else:
+            print('/*\\ Ignored database migrations... /*\\')
+            return False
     else:
-        print('/*\\ Ignored database migrations... /*\\')
-        return False
+        return True
 
 
 def run_upgrade():


### PR DESCRIPTION
Some people were annoyed last time there was an upgrade with the upgrade confirmation requiring using debug mode. 

I think I share that annoyance so it only applies if there's a TTY to use now. 

Also marking 1.1.0 in __version___