### PR TITLE
Mark 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+1.1.1 / 2018-01-08
+==================
+
+**General**
+
+* Fixed regression where users could not be promoted to admins or verified.
+* Fixed two icons in the Media Library which were not updated to Font Awesome 5.
+* Challenge previews now include tags, hints, and files. 
+
+**Themes**
+
+* Upgraded to Bootstrap 4 Beta v3. No major changes needed by themes. 
+* Fixed issue where the frozen message was not centered in the team page.
+* The JavaScript update() function now has a callback instead of being hardcoded.
+
+
 1.1.0 / 2017-12-22
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,8 @@
 
 * Upgraded to Bootstrap 4 Beta v3. No major changes needed by themes. 
 * Fixed issue where the frozen message was not centered in the team page.
-* The JavaScript update() function now has a callback instead of being hardcoded.
+* The JavaScript `update()` function now has a callback instead of being hardcoded.
 * `chalboard.js` now passes `script_root` into the Nunjucks templates so that file downloads work properly under subdirectories.
-
 
 
 1.1.0 / 2017-12-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 * Fixed regression where users could not be promoted to admins or verified.
 * Fixed two icons in the Media Library which were not updated to Font Awesome 5.
 * Challenge previews now include tags, hints, and files. 
+* Fixed an issue where a page could not be published immediately after being saved.
 
 **Themes**
 
 * Upgraded to Bootstrap 4 Beta v3. No major changes needed by themes. 
 * Fixed issue where the frozen message was not centered in the team page.
 * The JavaScript update() function now has a callback instead of being hardcoded.
+* `chalboard.js` now passes `script_root` into the Nunjucks templates so that file downloads work properly under subdirectories.
+
 
 
 1.1.0 / 2017-12-22

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -17,7 +17,7 @@ if sys.version_info[0] < 3:
     reload(sys)
     sys.setdefaultencoding("utf-8")
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 
 class CTFdFlask(Flask):


### PR DESCRIPTION
Marks the 1.1.1 release which fixes a few issues in 1.1.0. 

**General**

* Fixed regression where users could not be promoted to admins or verified.
* Fixed two icons in the Media Library which were not updated to Font Awesome 5.
* Challenge previews now include tags, hints, and files. 
* Fixed an issue where a page could not be published immediately after being saved.

**Themes**

* Upgraded to Bootstrap 4 Beta v3. No major changes needed by themes. 
* Fixed issue where the frozen message was not centered in the team page.
* The JavaScript `update()` function now has a callback instead of being hardcoded.
* `chalboard.js` now passes `script_root` into the Nunjucks templates so that file downloads work properly under subdirectories.
