### PR TITLE
Move Fontawesome script load to after body

### DIFF
--- a/CTFd/themes/admin/templates/base.html
+++ b/CTFd/themes/admin/templates/base.html
@@ -16,7 +16,6 @@
 	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/moment.min.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/moment-timezone-with-data.min.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/nunjucks.min.js"></script>
-	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/fontawesome-all.min.js"></script>
 	<script type="text/javascript">
 			var script_root = "{{ request.script_root }}";
 	</script>
@@ -115,6 +114,7 @@
 	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/jquery.min.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/marked.min.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/bootstrap.bundle.min.js"></script>
+	<script src="{{ request.script_root }}/themes/admin/static/js/vendor/fontawesome-all.min.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/main.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/utils.js"></script>
 	<script src="{{ request.script_root }}/themes/admin/static/js/ezq.js"></script>

--- a/CTFd/themes/core/templates/base.html
+++ b/CTFd/themes/core/templates/base.html
@@ -25,7 +25,6 @@
 		{% endfor %}
 		<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/moment.min.js"></script>
 		<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/nunjucks.min.js"></script>
-		<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/fontawesome-all.min.js"></script>
 		<script type="text/javascript">
 				var script_root = "{{ request.script_root }}";
 		</script>
@@ -124,6 +123,7 @@
 	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/jquery.min.js"></script>
 	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/marked.min.js"></script>
 	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/bootstrap.bundle.min.js"></script>
+	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/vendor/fontawesome-all.min.js"></script>
 	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/style.js"></script>
 	<script src="{{ request.script_root }}/themes/{{ ctf_theme() }}/static/js/ezq.js"></script>
 	{% block scripts %}


### PR DESCRIPTION
Closes #556 

For some reason Safari specifically is having trouble with the document.ready call. Either they're not being called under certain situations or they're being called out of order or something to that extent. 

This moves the font awesome script to after the body so that we don't "iconify" before we try to add handlers. 