### PR TITLE
Prevent scrollbar showing on pages that are smaller than the screen size

### DIFF
--- a/CTFd/themes/core/static/css/sticky-footer.css
+++ b/CTFd/themes/core/static/css/sticky-footer.css
@@ -11,7 +11,7 @@ body {
 
 .footer {
     position: absolute;
-    bottom: 0;
+    bottom: 1px;
     width: 100%;
     height: 60px; /* Set the fixed height of the footer here */
     line-height: 60px; /* Vertically center the text there */


### PR DESCRIPTION
With the footer having distance 0 from the bottom, a scrollbar is shown on each page, even when it's not completely filled (Tested on Firefox/Ubuntu and Chrome/Windows10). Setting the distance to 1px solves this problem.