### PR TITLE
Bypass csrf plugins

### DIFF
--- a/CTFd/plugins/__init__.py
+++ b/CTFd/plugins/__init__.py
@@ -129,6 +129,8 @@ def bypass_csrf_protection(f):
     """
     Decorator that allows a route to bypass the need for a CSRF nonce on POST requests.
 
+    This should be considered beta and may change in future versions. 
+
     :param f: A function that needs to bypass CSRF protection
     :return: Returns a function with the _bypass_csrf attribute set which tells CTFd to not require CSRF protection.
     """

--- a/CTFd/plugins/__init__.py
+++ b/CTFd/plugins/__init__.py
@@ -129,7 +129,7 @@ def bypass_csrf_protection(f):
     """
     Decorator that allows a route to bypass the need for a CSRF nonce on POST requests.
 
-    This should be considered beta and may change in future versions. 
+    This should be considered beta and may change in future versions.
 
     :param f: A function that needs to bypass CSRF protection
     :return: Returns a function with the _bypass_csrf attribute set which tells CTFd to not require CSRF protection.

--- a/CTFd/plugins/__init__.py
+++ b/CTFd/plugins/__init__.py
@@ -125,6 +125,17 @@ def get_user_page_menu_bar():
     return db_pages() + USER_PAGE_MENU_BAR
 
 
+def bypass_csrf_protection(f):
+    """
+    Decorator that allows a route to bypass the need for a CSRF nonce on POST requests.
+
+    :param f: A function that needs to bypass CSRF protection
+    :return: Returns a function with the _bypass_csrf attribute set which tells CTFd to not require CSRF protection.
+    """
+    f._bypass_csrf = True
+    return f
+
+
 def init_plugins(app):
     """
     Searches for the load function in modules in the CTFd/plugins folder. This function is called with the current CTFd

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -190,6 +190,9 @@ def init_utils(app):
 
     @app.before_request
     def csrf():
+        func = app.view_functions[request.endpoint]
+        if hasattr(func, '_bypass_csrf'):
+            return
         if not session.get('nonce'):
             session['nonce'] = sha512(os.urandom(10))
         if request.method == "POST":


### PR DESCRIPTION
Add a bypass_csrf_protection decorator to allow routes to forego CSRF nonce protection on POST requests. 