### PR TITLE
import.py: Proper check for second argument

### DIFF
--- a/import.py
+++ b/import.py
@@ -8,7 +8,7 @@ import sys
 
 app = create_app()
 with app.app_context():
-    if sys.argv[2]:
+    if len(sys.argv) == 2:
         segments = sys.argv[2].split(',')
     else:
         segments = None


### PR DESCRIPTION
The check for the second argument is mistaken and causes an exception instead of the intended behavior. This PR fixes that.

```
python import.py backup.zip 
 * Loaded module, <module 'CTFd.plugins.challenges' from '/opt/CTFd/CTFd/plugins/challenges/__init__.pyc'>
 * Loaded module, <module 'CTFd.plugins.keys' from '/opt/CTFd/CTFd/plugins/keys/__init__.pyc'>
Traceback (most recent call last):
  File "import.py", line 11, in <module>
    if sys.argv[2]:
IndexError: list index out of range
```