### PR TITLE
Only clear jinja_env cache on config changes

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -177,6 +177,7 @@ def admin_config():
         db.session.close()
         with app.app_context():
             cache.clear()
+            app.jinja_env.cache = {}
         return redirect(url_for('admin.admin_config'))
 
     # Clear the cache so that we don't get stale values

--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -204,10 +204,6 @@ def init_utils(app):
             if session['nonce'] != request.form.get('nonce'):
                 abort(403)
 
-    @app.before_request
-    def disable_jinja_cache():
-        app.jinja_env.cache = {}
-
 
 @cache.memoize()
 def ctf_name():


### PR DESCRIPTION
This simplifies jinja cache clearing so that we only clear when we update config (i.e. switch themes). This should increase page load speeds because templates will now be cached. 