### PR TITLE
Return getsolves() promise

### DIFF
--- a/CTFd/themes/core/static/js/chalboard.js
+++ b/CTFd/themes/core/static/js/chalboard.js
@@ -222,7 +222,7 @@ function updatesolves(cb){
 }
 
 function getsolves(id){
-  $.get(script_root + '/chal/'+id+'/solves', function (data) {
+  return $.get(script_root + '/chal/'+id+'/solves', function (data) {
     var teams = data['teams'];
     $('.chal-solves').text((parseInt(teams.length) + " Solves"));
     var box = $('#chal-solves-names');


### PR DESCRIPTION
Hi,

For a plugin I'm writing, I need to act on the result of the `getsolves()` call, but its promise isn't returned.

This patch makes `getsolves()` pass the promise returned by jQuery to the caller. Similar patches for other functions may be desired, but this solves my problem and see no benefit in investigating further; I prefer to let these be evaluated on a case-by-case basis.