### PR TITLE
Wrong URL in email verification response email

### DIFF
--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -667,7 +667,7 @@ def sendmail(addr, text):
 def verify_email(addr):
     s = TimedSerializer(app.config['SECRET_KEY'])
     token = s.dumps(addr)
-    text = """Please click the following link to confirm your email address for {ctf_name}: {url}/{token}""".format(
+    text = """Please click the following link to confirm your email address for {ctf_name}: {url}/confirm/{token}""".format(
         ctf_name=get_config('ctf_name'),
         url=url_for('auth.confirm_user', _external=True),
         token=base64encode(token)


### PR DESCRIPTION
URL path is given in verification mail ends up invalid because of following reason,
The current format is http://localhost:8000/ASDJdshifad32.... if user click on this verification links he/she ends up getting error 404 since token is added directly to the path and there will be no route defined for it and according to auth.py verification tokens are handled by /confirm route so correct format will be http://localhost:8000/confirm/ASDJdshifad32... hence {url}/confirm/{token}