### PR TITLE
reorganized Dockerfile to improve layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,17 @@ FROM python:2.7-alpine
 RUN apk update && \
     apk add python python-dev libffi-dev gcc make musl-dev py-pip mysql-client
 
-RUN mkdir -p /opt/CTFd
-COPY . /opt/CTFd
 WORKDIR /opt/CTFd
-VOLUME ["/opt/CTFd"]
+RUN mkdir -p /opt/CTFd
+
+COPY requirements.txt .
 
 RUN pip install -r requirements.txt
+
+COPY . .
+
+VOLUME ["/opt/CTFd"]
+
 RUN for d in CTFd/plugins/*; do \
       if [ -f "$d/requirements.txt" ]; then \
         pip install -r $d/requirements.txt; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7-alpine
 RUN apk update && \
-    apk add python python-dev libffi-dev gcc make musl-dev py-pip mysql-client
+    apk add python python-dev libffi-dev gcc make musl-dev py-pip mysql-client git openssl-dev
 
 WORKDIR /opt/CTFd
 RUN mkdir -p /opt/CTFd
@@ -9,7 +9,7 @@ COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
-COPY . .
+COPY . /opt/CTFd
 
 VOLUME ["/opt/CTFd"]
 


### PR DESCRIPTION
Separately add `requirements.txt`, then run `pip install`, then add remaining files so as to not cause re-installation of python packages whenever any code files change. Should help make for faster docker-based dev cycle.