### PR TITLE
Optional nginx support

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,0 +1,13 @@
+version: '2'
+
+services:
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - .data/nginx/logs:/var/log/nginx
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    restart: unless-stopped
+    depends_on:
+      - ctfd

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,50 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  proxy_cache_path /tmp/cache levels=1:2 keys_zone=cache:32m max_size=1G;
+#  error_log /dev/stdout info;
+#  access_log /dev/stdout;
+
+  upstream app {
+    server ctfd:8000;
+  }
+
+  server {
+    listen 80;
+
+    if ($http_x_forwarded_proto = "http") {
+        return 301 https://$host$request_uri;
+    }
+
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/css text/javascript text/xml text/plain application/javascript application/x-javascript application/json;
+
+    location / {
+      proxy_pass http://app;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+
+      location ~ ^/themes/(core|admin)/static {
+        proxy_pass  http://app;
+        proxy_cache cache;
+        proxy_ignore_headers Set-Cookie;
+
+        proxy_cache_valid 30m; # 30m timeout for static files
+        expires 30m;
+      }
+
+      location ~ ^/static {
+        proxy_pass  http://app;
+        proxy_cache cache;
+        proxy_ignore_headers Set-Cookie;
+
+        proxy_cache_valid 1m; # 1m timeout for user.css
+        expires 1m;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Optional nginx docker-compose configuration to allow for improved performance:
* Caches static file responses from flask/gunicorn in nginx and in browser for 4h (1m for `user.css`) and responds with `304 Not Modified` status as appropriate
* Gzips text content (html, css, js, etc) if supported by client
* Buffers slow clients to prevent DoS impacts (http://docs.gunicorn.org/en/stable/deploy.html: *"we strongly advise that you use Nginx"*)

Run as follows:
```
docker-compose -f docker-compose.yml -f docker-compose.nginx.yml up
```