### PR TITLE
Extension that allows to restrict the allowed users to configured domains or emails

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -158,28 +158,29 @@ def admin_config():
         utils.set_config("ctf_theme", request.form.get('ctf_theme', None))
         utils.set_config('css', request.form.get('css', None))
 
-        allowed_users = request.form.get('allowed_users', None)
+        white_listed_users = request.form.get('white_listed_users', None)
 
-        if allowed_users is None:
-            allowed_users = []
+        if white_listed_users is None:
+            white_listed_users = []
         else:
-            allowed_users = allowed_users.split('\n')
-        allowed_domains = []
-        allowed_mails = []
+            white_listed_users = white_listed_users.split('\n')
+        white_listed_domains = []
+        white_listed_addresses = []
         errors = []
 
-        for item in allowed_users:
-            if utils.check_domain_format(item.strip()):
-                allowed_domains.append(item.strip())
-            elif utils.check_email_format(item.strip()):
-                allowed_mails.append(item.strip())
+        for it in white_listed_users:
+            item = it.strip()
+            if utils.check_domain_format(item):
+                white_listed_domains.append(item)
+            elif utils.check_email_format(item):
+                white_listed_addresses.append(item)
             else:
-                errors.append(item.strip())
-        allowed_domains.sort()
-        allowed_mails.sort()
+                errors.append(item)
+        white_listed_domains.sort()
+        white_listed_addresses.sort()
 
-        utils.set_config('allowed_domains', json.dumps(allowed_domains))
-        utils.set_config('allowed_mails', json.dumps(allowed_mails))
+        utils.set_config('white_listed_domains', json.dumps(white_listed_domains))
+        utils.set_config('white_listed_addresses', json.dumps(white_listed_addresses))
 
         utils.set_config("mailfrom_addr", request.form.get('mailfrom_addr', None))
         utils.set_config("mg_base_url", request.form.get('mg_base_url', None))
@@ -234,9 +235,9 @@ def admin_config():
     prevent_registration = utils.get_config('prevent_registration')
     prevent_name_change = utils.get_config('prevent_name_change')
     verify_emails = utils.get_config('verify_emails')
-    allowed_domains = json.loads(utils.get_config('allowed_domains'))
-    allowed_mails = json.loads(utils.get_config('allowed_mails'))
-    allowed_users = "\n".join(allowed_domains + allowed_mails)
+    white_listed_domains = json.loads(utils.get_config('white_listed_domains'))
+    white_listed_addresses = json.loads(utils.get_config('white_listed_addresses'))
+    white_listed_users = "\n".join(white_listed_domains + white_listed_addresses)
 
     workshop_mode = utils.get_config('workshop_mode')
     paused = utils.get_config('paused')
@@ -264,7 +265,7 @@ def admin_config():
         mail_password=mail_password,
         mail_tls=mail_tls,
         mail_ssl=mail_ssl,
-        allowed_users=allowed_users,
+        white_listed_users=white_listed_users,
         view_challenges_unregistered=view_challenges_unregistered,
         view_scoreboard_if_authed=view_scoreboard_if_authed,
         prevent_registration=prevent_registration,

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -158,10 +158,12 @@ def admin_config():
         utils.set_config("ctf_theme", request.form.get('ctf_theme', None))
         utils.set_config('css', request.form.get('css', None))
 
+        allowed_users = request.form.get('allowed_users', None)
+
         if allowed_users == None:
             allowed_users = []
         else:
-            allowed_users = request.form.get('allowed_users', None).split('\n')
+            allowed_users = allowed_users.split('\n')
         allowed_domains = []
         allowed_mails = []
         errors = []

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -158,7 +158,10 @@ def admin_config():
         utils.set_config("ctf_theme", request.form.get('ctf_theme', None))
         utils.set_config('css', request.form.get('css', None))
 
-        allowed_users = request.form.get('allowed_users', None).split('\n')
+        if allowed_users == None:
+            allowed_users = []
+        else:
+            allowed_users = request.form.get('allowed_users', None).split('\n')
         allowed_domains = []
         allowed_mails = []
         errors = []
@@ -175,7 +178,7 @@ def admin_config():
 
         utils.set_config('allowed_domains', json.dumps(allowed_domains))
         utils.set_config('allowed_mails', json.dumps(allowed_mails))
-        
+
         utils.set_config("mailfrom_addr", request.form.get('mailfrom_addr', None))
         utils.set_config("mg_base_url", request.form.get('mg_base_url', None))
         utils.set_config("mg_api_key", request.form.get('mg_api_key', None))

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -160,7 +160,7 @@ def admin_config():
 
         allowed_users = request.form.get('allowed_users', None)
 
-        if allowed_users == None:
+        if allowed_users is None:
             allowed_users = []
         else:
             allowed_users = allowed_users.split('\n')

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -158,6 +158,24 @@ def admin_config():
         utils.set_config("ctf_theme", request.form.get('ctf_theme', None))
         utils.set_config('css', request.form.get('css', None))
 
+        allowed_users = request.form.get('allowed_users', None).split('\n')
+        allowed_domains = []
+        allowed_mails = []
+        errors = []
+
+        for item in allowed_users:
+            if utils.check_domain_format(item.strip()):
+                allowed_domains.append(item.strip())
+            elif utils.check_email_format(item.strip()):
+                allowed_mails.append(item.strip())
+            else:
+                errors.append(item.strip())
+        allowed_domains.sort()
+        allowed_mails.sort()
+
+        utils.set_config('allowed_domains', json.dumps(allowed_domains))
+        utils.set_config('allowed_mails', json.dumps(allowed_mails))
+        
         utils.set_config("mailfrom_addr", request.form.get('mailfrom_addr', None))
         utils.set_config("mg_base_url", request.form.get('mg_base_url', None))
         utils.set_config("mg_api_key", request.form.get('mg_api_key', None))
@@ -211,6 +229,9 @@ def admin_config():
     prevent_registration = utils.get_config('prevent_registration')
     prevent_name_change = utils.get_config('prevent_name_change')
     verify_emails = utils.get_config('verify_emails')
+    allowed_domains = json.loads(utils.get_config('allowed_domains'))
+    allowed_mails = json.loads(utils.get_config('allowed_mails'))
+    allowed_users = "\n".join(allowed_domains + allowed_mails)
 
     workshop_mode = utils.get_config('workshop_mode')
     paused = utils.get_config('paused')
@@ -238,6 +259,7 @@ def admin_config():
         mail_password=mail_password,
         mail_tls=mail_tls,
         mail_ssl=mail_ssl,
+        allowed_users=allowed_users,
         view_challenges_unregistered=view_challenges_unregistered,
         view_scoreboard_if_authed=view_scoreboard_if_authed,
         prevent_registration=prevent_registration,

--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -60,6 +60,7 @@ def admin_create_team():
     admin_user = True if request.form.get('admin', None) == 'on' else False
     verified = True if request.form.get('verified', None) == 'on' else False
     hidden = True if request.form.get('hidden', None) == 'on' else False
+    white_listed_user = utils.is_white_listed(email)
 
     errors = []
 
@@ -80,6 +81,9 @@ def admin_create_team():
         valid_email = utils.check_email_format(email)
         if not valid_email:
             errors.append("That email address is invalid")
+
+    if not white_listed_user:
+            errors.append("User e-mail address should belongsto the whitelisted domains or to the whitelisted users' list")
 
     if not password:
         errors.append('The team requires a password')
@@ -137,6 +141,7 @@ def admin_team(teamid):
         admin_user = True if request.form.get('admin', None) == 'on' else False
         verified = True if request.form.get('verified', None) == 'on' else False
         hidden = True if request.form.get('hidden', None) == 'on' else False
+        white_listed_user = utils.is_white_listed(email)
 
         errors = []
 
@@ -144,6 +149,9 @@ def admin_team(teamid):
             valid_email = utils.check_email_format(email)
             if not valid_email:
                 errors.append("That email address is invalid")
+
+        if not white_listed_user:
+            errors.append("User e-mail address should belongsto the whitelisted domains or to the whitelisted users' list")
 
         name_used = Teams.query.filter(Teams.name == name).first()
         if name_used and int(name_used.id) != int(teamid):

--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -83,7 +83,7 @@ def admin_create_team():
             errors.append("That email address is invalid")
 
     if not white_listed_user:
-            errors.append("User e-mail address should belongsto the whitelisted domains or to the whitelisted users' list")
+            errors.append("User e-mail address should belong to the whitelisted domains or to the whitelisted users' list")
 
     if not password:
         errors.append('The team requires a password')
@@ -151,7 +151,7 @@ def admin_team(teamid):
                 errors.append("That email address is invalid")
 
         if not white_listed_user:
-            errors.append("User e-mail address should belongsto the whitelisted domains or to the whitelisted users' list")
+            errors.append("User e-mail address should belong to the whitelisted domains or to the whitelisted users' list")
 
         name_used = Teams.query.filter(Teams.name == name).first()
         if name_used and int(name_used.id) != int(teamid):

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -153,14 +153,12 @@ def register():
         pass_long = len(password) > 128
         valid_email = utils.check_email_format(request.form['email'])
         team_name_email_check = utils.check_email_format(name)
-        allowed_user = (json.loads(utils.get_config('allowed_domains')) + json.loads(utils.get_config('allowed_mails'))) == []
-        allowed_user = allowed_user or email.split('@')[-1] in json.loads(utils.get_config('allowed_domains'))
-        allowed_user = allowed_user or (email in json.loads(utils.get_config('allowed_mails')))
+        white_listed_user = utils.is_white_listed(email)
 
         if not valid_email:
             errors.append("Please enter a valid email address")
-        if not allowed_user:
-            errors.append("Please enter an e-mail address that belongs to the allowed domains or to the allowed users' list")
+        if not white_listed_user:
+            errors.append("Please enter a whitelisted e-mail address that belongs to the whitelisted domains or to the whitelisted users' list")
         if names:
             errors.append('That team name is already taken')
         if team_name_email_check is True:

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import time
+import json
 
 from flask import current_app as app, render_template, request, redirect, url_for, session, Blueprint
 from itsdangerous import TimedSerializer, BadTimeSignature, Signer, BadSignature
@@ -152,9 +153,14 @@ def register():
         pass_long = len(password) > 128
         valid_email = utils.check_email_format(request.form['email'])
         team_name_email_check = utils.check_email_format(name)
+        allowed_user = (json.loads(utils.get_config('allowed_domains')) + json.loads(utils.get_config('allowed_mails'))) == []
+        allowed_user = allowed_user or email.split('@')[-1] in json.loads(utils.get_config('allowed_domains'))
+        allowed_user = allowed_user or (email in json.loads(utils.get_config('allowed_mails')))
 
         if not valid_email:
             errors.append("Please enter a valid email address")
+        if not allowed_user:
+            errors.append("Please enter an e-mail address that belongs to the allowed domains or to the allowed users' list")
         if names:
             errors.append('That team name is already taken')
         if team_name_email_check is True:

--- a/CTFd/themes/admin/templates/config.html
+++ b/CTFd/themes/admin/templates/config.html
@@ -120,6 +120,13 @@
 							Only allow users with verified emails
 						</label>
 					</div>
+					<div class="form-group">
+						<label>Restrict users to those below <i class="far fa-question-circle text-muted cursor-help" data-toggle="tooltip"
+							data-placement="right"
+							title="Restrict users to the list of e-mails or domains defined below. One per line."></i>
+						</label>
+						<textarea class="form-control" id="allowed_users" name="allowed_users" rows="7">{{ allowed_users |default('', True) }}</textarea>
+					</div>
 
 					<div class="form-check">
 						<label>

--- a/CTFd/themes/admin/templates/config.html
+++ b/CTFd/themes/admin/templates/config.html
@@ -121,11 +121,11 @@
 						</label>
 					</div>
 					<div class="form-group">
-						<label>Restrict users to those below <i class="far fa-question-circle text-muted cursor-help" data-toggle="tooltip"
+						<label>Whitelist users to those below <i class="far fa-question-circle text-muted cursor-help" data-toggle="tooltip"
 							data-placement="right"
 							title="Restrict users to the list of e-mails or domains defined below. One per line."></i>
 						</label>
-						<textarea class="form-control" id="allowed_users" name="allowed_users" rows="7">{{ allowed_users |default('', True) }}</textarea>
+						<textarea class="form-control" id="white_listed_users" name="white_listed_users" rows="7">{{ white_listed_users |default('', True) }}</textarea>
 					</div>
 
 					<div class="form-check">

--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -270,8 +270,8 @@ def is_verified():
 
 
 def is_white_listed(email):
-    white_listed_domains = json.loads(utils.get_config('white_listed_domains'))
-    white_listed_addresses = json.loads(utils.get_config('white_listed_addresses'))
+    white_listed_domains = json.loads(get_config('white_listed_domains'))
+    white_listed_addresses = json.loads(get_config('white_listed_addresses'))
     if (white_listed_domains + white_listed_addresses == []) or (email.split('@')[-1] in white_listed_domains) or (email in white_listed_addresses):
         return True
     else:

--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -269,6 +269,15 @@ def is_verified():
         return True
 
 
+def is_allowed_to_register(user):
+    for domain in get_config('allowed_domains'):
+        if user.split('@')[-1] == domain:
+            return True
+    if user in get_config('allowed_mails'):
+        return True
+    return False
+
+
 @cache.memoize()
 def is_setup():
     setup = Config.query.filter_by(key='setup').first()
@@ -703,6 +712,10 @@ def validate_url(url):
 
 def check_email_format(email):
     return bool(re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email))
+
+
+def check_domain_format(email):
+    return bool(re.match(r"(^[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email))
 
 
 def sha512(string):

--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -269,13 +269,13 @@ def is_verified():
         return True
 
 
-def is_allowed_to_register(user):
-    for domain in get_config('allowed_domains'):
-        if user.split('@')[-1] == domain:
-            return True
-    if user in get_config('allowed_mails'):
+def is_white_listed(email):
+    white_listed_domains = json.loads(utils.get_config('white_listed_domains'))
+    white_listed_addresses = json.loads(utils.get_config('white_listed_addresses'))
+    if (white_listed_domains + white_listed_addresses == []) or (email.split('@')[-1] in white_listed_domains) or (email in white_listed_addresses):
         return True
-    return False
+    else:
+        return False
 
 
 @cache.memoize()

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -74,8 +74,8 @@ def setup():
 
             # Verify emails
             verify_emails = utils.set_config('verify_emails', None)
-            allowed_domains = utils.set_config('allowed_domains', None)
-            allowed_mails = utils.set_config('allowed_mails', None)
+            allowed_domains = utils.set_config('allowed_domains', json.dumps([]))
+            allowed_mails = utils.set_config('allowed_mails', json.dumps([]))
 
             mail_server = utils.set_config('mail_server', None)
             mail_port = utils.set_config('mail_port', None)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -74,8 +74,8 @@ def setup():
 
             # Verify emails
             verify_emails = utils.set_config('verify_emails', None)
-            allowed_domains = utils.set_config('allowed_domains', None)            
-            allowed_mails = utils.set_config('allowed_mails', None)            
+            allowed_domains = utils.set_config('allowed_domains', None)
+            allowed_mails = utils.set_config('allowed_mails', None)
 
             mail_server = utils.set_config('mail_server', None)
             mail_port = utils.set_config('mail_port', None)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -74,8 +74,8 @@ def setup():
 
             # Verify emails
             verify_emails = utils.set_config('verify_emails', None)
-            allowed_domains = utils.set_config('allowed_domains', json.dumps([]))
-            allowed_mails = utils.set_config('allowed_mails', json.dumps([]))
+            white_listed_domains = utils.set_config('white_listed_domains', json.dumps([]))
+            white_listed_addresses = utils.set_config('white_listed_addresses', json.dumps([]))
 
             mail_server = utils.set_config('mail_server', None)
             mail_port = utils.set_config('mail_port', None)
@@ -236,9 +236,7 @@ def profile():
             emails = Teams.query.filter_by(email=email).first()
             valid_email = utils.check_email_format(email)
 
-            allowed_user = (json.loads(utils.get_config('allowed_domains')) + json.loads(utils.get_config('allowed_mails'))) == []
-            allowed_user = allowed_user or email.split('@')[-1] in json.loads(utils.get_config('allowed_domains'))
-            allowed_user = allowed_user or (email in json.loads(utils.get_config('allowed_mails')))
+            white_listed_user = utils.is_white_listed(email)
 
             if utils.check_email_format(name) is True:
                 errors.append('Team name cannot be an email address')
@@ -248,8 +246,8 @@ def profile():
                 errors.append("Your old password doesn't match what we have.")
             if not valid_email:
                 errors.append("That email doesn't look right")
-            if not allowed_user:
-                errors.append("Please enter an e-mail address that belongs to the allowed domains or to the allowed users' list")
+            if not white_listed_user:
+                errors.append("Please enter a whitelisted e-mail address that belongs to the whitelisted domains or to the whitelisted users' list")
             if not utils.get_config('prevent_name_change') and names and name != session['username']:
                 errors.append('That team name is already taken')
             if emails and emails.id != session['id']:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -496,23 +496,23 @@ def test_check_email_format():
 
 def test_check_domain_format():
     """Test that the check_domain_format() works properly"""
-    assert check_email_format('user@ctfd.io') is False
-    assert check_email_format('user+plus@gmail.com') is False
-    assert check_email_format('user.period1234@gmail.com') is False
-    assert check_email_format('user.period1234@b.c') is False
-    assert check_email_format('user.period1234@b') is False
-    assert check_email_format('no.ampersand') is True
-    assert check_email_format('yes.no.ampersand') is True
-    assert check_email_format('no.yes.no.ampersand') is True
-    assert check_email_format('ampersand') is False
-    assert check_email_format('user@') is False
-    assert check_email_format('@ctfd.io') is False
-    assert check_email_format('user.io@ctfd') is False
-    assert check_email_format('user\@ctfd') is False
+    assert check_domain_format('user@ctfd.io') is False
+    assert check_domain_format('user+plus@gmail.com') is False
+    assert check_domain_format('user.period1234@gmail.com') is False
+    assert check_domain_format('user.period1234@b.c') is False
+    assert check_domain_format('user.period1234@b') is False
+    assert check_domain_format('no.ampersand') is True
+    assert check_domain_format('yes.no.ampersand') is True
+    assert check_domain_format('no.yes.no.ampersand') is True
+    assert check_domain_format('ampersand') is False
+    assert check_domain_format('user@') is False
+    assert check_domain_format('@ctfd.io') is False
+    assert check_domain_format('user.io@ctfd') is False
+    assert check_domain_format('user\@ctfd') is False
 
     for invalid_domain in ['user.@ctfd.io', '.user@ctfd.io', 'user@ctfd..io']:
         try:
-            assert check_email_format(invalid_domain) is False
+            assert check_domain_format(invalid_domain) is False
         except AssertionError:
             print(invalid_domain, 'did not pass validation')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from CTFd.models import ip2long, long2ip
 from CTFd.utils import get_config, set_config, override_template, sendmail, verify_email, ctf_started, ctf_ended, export_ctf, import_ctf
 from CTFd.utils import register_plugin_script, register_plugin_stylesheet
 from CTFd.utils import base64encode, base64decode
-from CTFd.utils import check_email_format
+from CTFd.utils import check_email_format, check_domain_format
 from CTFd.utils import update_check
 from email.mime.text import MIMEText
 from freezegun import freeze_time

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -494,6 +494,29 @@ def test_check_email_format():
             print(invalid_email, 'did not pass validation')
 
 
+def test_check_domain_format():
+    """Test that the check_domain_format() works properly"""
+    assert check_email_format('user@ctfd.io') is False
+    assert check_email_format('user+plus@gmail.com') is False
+    assert check_email_format('user.period1234@gmail.com') is False
+    assert check_email_format('user.period1234@b.c') is False
+    assert check_email_format('user.period1234@b') is False
+    assert check_email_format('no.ampersand') is True
+    assert check_email_format('yes.no.ampersand') is True
+    assert check_email_format('no.yes.no.ampersand') is True
+    assert check_email_format('ampersand') is False
+    assert check_email_format('user@') is False
+    assert check_email_format('@ctfd.io') is False
+    assert check_email_format('user.io@ctfd') is False
+    assert check_email_format('user\@ctfd') is False
+
+    for invalid_domain in ['user.@ctfd.io', '.user@ctfd.io', 'user@ctfd..io']:
+        try:
+            assert check_email_format(invalid_domain) is False
+        except AssertionError:
+            print(invalid_domain, 'did not pass validation')
+
+
 def test_update_check_is_called():
     """Update checks happen on start"""
     app = create_ctfd()

--- a/tests/user/test_user_facing.py
+++ b/tests/user/test_user_facing.py
@@ -140,8 +140,8 @@ def test_register_invalid_email():
         team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
         assert team_count == 1  # There's only the admin user
     destroy_ctfd(app)
-    
-    
+
+
 def test_user_bad_login():
     """A user should not be able to login with an incorrect password"""
     app = create_ctfd()
@@ -408,16 +408,11 @@ def test_user_set_profile_invalid_team_name():
 
         user = Teams.query.filter_by(id=2).first()
         assert user.name == 'user1'
-        assert user.email == 'user1@ctfd.io'
-        assert user.password == 'password'
-        assert user.affiliation is None
-        assert user.website is None
-        assert user.country is None
     destroy_ctfd(app)
 
 
 def test_user_set_profile_invalid_password():
-    """Fail to change a profile when old password is wrong"""
+    """Fail to change a team password when old password is wrong"""
     app = create_ctfd()
     with app.app_context():
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
@@ -428,7 +423,7 @@ def test_user_set_profile_invalid_password():
                 'name': 'user',
                 'email': 'user@ctfd.io',
                 'confirm': 'wrong_password',
-                'password': '',
+                'password': 'new_password',
                 'affiliation': 'affiliation_test',
                 'website': 'https://ctfd.io',
                 'country': 'United States of America',
@@ -439,17 +434,12 @@ def test_user_set_profile_invalid_password():
         assert r.status_code == 302
 
         user = Teams.query.filter_by(id=2).first()
-        assert user.name == 'user1'
-        assert user.email == 'user1@ctfd.io'
         assert user.password == 'password'
-        assert user.affiliation is None
-        assert user.website is None
-        assert user.country is None
     destroy_ctfd(app)
 
 
 def test_user_set_profile_invalid_email():
-    """Fail to change a profile when the email fails utils.check_email_format"""
+    """Fail to change a team email when utils.check_email_format fails"""
     app = create_ctfd()
     with app.app_context():
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
@@ -471,12 +461,7 @@ def test_user_set_profile_invalid_email():
         assert r.status_code == 302
 
         user = Teams.query.filter_by(id=2).first()
-        assert user.name == 'user1'
         assert user.email == 'user1@ctfd.io'
-        assert user.password == 'password'
-        assert user.affiliation is None
-        assert user.website is None
-        assert user.country is None
     destroy_ctfd(app)
 
 

--- a/tests/user/test_user_facing.py
+++ b/tests/user/test_user_facing.py
@@ -432,7 +432,7 @@ def test_user_set_profile_invalid_password():
         r = client.post('/profile', data=data)
 
         user = Teams.query.filter_by(id=2).first()
-        assert user.password == 'password'
+        assert bcrypt_sha256.verify('password', user.password):
     destroy_ctfd(app)
 
 

--- a/tests/user/test_user_facing.py
+++ b/tests/user/test_user_facing.py
@@ -404,7 +404,6 @@ def test_user_set_profile_invalid_team_name():
             }
 
         r = client.post('/profile', data=data)
-        assert r.status_code == 302
 
         user = Teams.query.filter_by(id=2).first()
         assert user.name == 'user1'
@@ -431,7 +430,6 @@ def test_user_set_profile_invalid_password():
             }
 
         r = client.post('/profile', data=data)
-        assert r.status_code == 302
 
         user = Teams.query.filter_by(id=2).first()
         assert user.password == 'password'
@@ -458,7 +456,6 @@ def test_user_set_profile_invalid_email():
             }
 
         r = client.post('/profile', data=data)
-        assert r.status_code == 302
 
         user = Teams.query.filter_by(id=2).first()
         assert user.email == 'user1@ctfd.io'

--- a/tests/user/test_user_facing.py
+++ b/tests/user/test_user_facing.py
@@ -432,7 +432,7 @@ def test_user_set_profile_invalid_password():
         r = client.post('/profile', data=data)
 
         user = Teams.query.filter_by(id=2).first()
-        assert bcrypt_sha256.verify('password', user.password):
+        assert bcrypt_sha256.verify('password', user.password)
     destroy_ctfd(app)
 
 

--- a/tests/user/test_white_listing_mails.py
+++ b/tests/user/test_white_listing_mails.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from CTFd.models import Teams, Solves, WrongKeys
+from CTFd.utils import get_config, set_config
+from CTFd import utils
+from tests.helpers import *
+from freezegun import freeze_time
+from mock import patch
+import json
+
+
+# Any user can register if there is allowed domain and allowed mail is undefined is the default registration. No need for new test.
+
+
+def test_user_can_register_allowed_mail_domain():
+    """User can register a mail from a white-listed domain"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_domains = ['ctfd.io']
+        set_config('allowed_domains', json.dumps(allowed_domains))
+        register_user(app, name="user1", email="user1@ctfd.io", password="password")
+        team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
+        assert team_count == 2  # There's the admin user and the created user
+    destroy_ctfd(app)
+
+
+def test_user_cannot_register_disallowed_mail_domain():
+    """User cannot register a mail that is not in a white-listed domain"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_domains = ['ctfd.io']
+        set_config('allowed_domains', json.dumps(allowed_domains))
+        register_user(app, name="user1", email="user1@ctfd2.io", password="password")
+        team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
+        assert team_count == 1  # There's only the admin user
+    destroy_ctfd(app)
+
+
+def test_user_can_register_allowed_mail():
+    """User can register a white-listed mail"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_mails = ['user1@ctfd.io']
+        set_config('allowed_mails', json.dumps(allowed_mails))
+        register_user(app, name="user1", email="user1@ctfd.io", password="password")
+        team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
+        assert team_count == 2  # There's the admin user and the created user
+    destroy_ctfd(app)
+
+
+def test_user_cannot_register_disallowed_mail():
+    """User cannot register a mail that is not white-listed"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_mails = ['user1@ctfd.io']
+        set_config('allowed_mails', json.dumps(allowed_mails))
+        register_user(app, name="user1", email="user2@ctfd.io", password="password")
+        team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
+        assert team_count == 1  # There's only the admin user
+    destroy_ctfd(app)
+
+
+def test_user_can_change_to_allowed_mail_domain():
+    """User can change to a mail from a white-listed domain"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_domains = ['ctfd.io', 'ctfd2.io']
+        set_config('allowed_domains', json.dumps(allowed_domains))
+        register_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        r = client.get('/profile')
+        with client.session_transaction() as sess:
+            data = {
+                'name': 'user1',
+                'email': 'user1@ctfd2.io',
+                'confirm': '',
+                'password': '',
+                'affiliation': 'affiliation_test',
+                'website': 'https://ctfd.io',
+                'country': 'United States of America',
+                'nonce': sess.get('nonce')
+            }
+
+        r = client.post('/profile', data=data)
+        #assert r.status_code == 302
+
+        user = Teams.query.filter_by(name='user1').first()
+        assert user.email == 'user1@ctfd2.io'
+        assert user.affiliation == 'affiliation_test'
+        assert user.website == 'https://ctfd.io'
+        assert user.country == 'United States of America'
+    destroy_ctfd(app)
+
+
+def test_user_cannot_change_to_disallowed_mail_domain():
+    """User cannot change to a mail that is not in a white-listed domain"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_domains = ['ctfd.io', 'ctfd2.io']
+        set_config('allowed_domains', json.dumps(allowed_domains))
+        register_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        r = client.get('/profile')
+        with client.session_transaction() as sess:
+            data = {
+                'name': 'user1',
+                'email': 'user1@ctfd3.io',
+                'confirm': '',
+                'password': '',
+                'affiliation': 'affiliation_test',
+                'website': 'https://ctfd.io',
+                'country': 'United States of America',
+                'nonce': sess.get('nonce')
+            }
+
+        r = client.post('/profile', data=data)
+        #assert r.status_code == 302
+
+        user = Teams.query.filter_by(name='user1').first()
+        assert user.email == 'user1@ctfd.io'
+        assert user.affiliation == 'affiliation_test'
+        assert user.website == 'https://ctfd.io'
+        assert user.country == 'United States of America'
+    destroy_ctfd(app)
+
+
+def test_user_can_change_to_allowed_mail():
+    """User can change to a mail that is white-listed"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_mails = ['user1@ctfd.io', 'user1@ctfd2.io']
+        set_config('allowed_mails', json.dumps(allowed_mails))
+        register_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        r = client.get('/profile')
+        with client.session_transaction() as sess:
+            data = {
+                'name': 'user1',
+                'email': 'user1@ctfd2.io',
+                'confirm': '',
+                'password': '',
+                'affiliation': 'affiliation_test',
+                'website': 'https://ctfd.io',
+                'country': 'United States of America',
+                'nonce': sess.get('nonce')
+            }
+
+        r = client.post('/profile', data=data)
+        #assert r.status_code == 302
+
+        user = Teams.query.filter_by(name='user1').first()
+        assert user.email == 'user1@ctfd2.io'
+        assert user.affiliation == 'affiliation_test'
+        assert user.website == 'https://ctfd.io'
+        assert user.country == 'United States of America'
+    destroy_ctfd(app)
+
+
+def test_user_cannot_change_to_disallowed_mail():
+    """User cannot change to a mail that is not white-listed"""
+    app = create_ctfd()
+    with app.app_context():
+        allowed_mails = ['user1@ctfd.io', 'user1@ctfd2.io']
+        set_config('allowed_mails', json.dumps(allowed_mails))
+        register_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        r = client.get('/profile')
+        with client.session_transaction() as sess:
+            data = {
+                'name': 'user1',
+                'email': 'user2@ctfd.io',
+                'confirm': '',
+                'password': '',
+                'affiliation': 'affiliation_test',
+                'website': 'https://ctfd.io',
+                'country': 'United States of America',
+                'nonce': sess.get('nonce')
+            }
+
+        r = client.post('/profile', data=data)
+        #assert r.status_code == 302
+
+        user = Teams.query.filter_by(name='user1').first()
+        assert user.email == 'user1@ctfd.io'
+        assert user.affiliation == 'affiliation_test'
+        assert user.website == 'https://ctfd.io'
+        assert user.country == 'United States of America'
+    destroy_ctfd(app)

--- a/tests/user/test_white_listing_mails.py
+++ b/tests/user/test_white_listing_mails.py
@@ -13,60 +13,60 @@ import json
 # Any user can register if there is allowed domain and allowed mail is undefined is the default registration. No need for new test.
 
 
-def test_user_can_register_allowed_mail_domain():
+def test_user_can_register_mail_from_whitelisted_domain():
     """User can register a mail from a white-listed domain"""
     app = create_ctfd()
     with app.app_context():
-        allowed_domains = ['ctfd.io']
-        set_config('allowed_domains', json.dumps(allowed_domains))
+        white_listed_domains = ['ctfd.io']
+        set_config('white_listed_domains', json.dumps(white_listed_domains))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
         team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
         assert team_count == 2  # There's the admin user and the created user
     destroy_ctfd(app)
 
 
-def test_user_cannot_register_disallowed_mail_domain():
+def test_user_cannot_register_mail_not_in_whitelisted_domain():
     """User cannot register a mail that is not in a white-listed domain"""
     app = create_ctfd()
     with app.app_context():
-        allowed_domains = ['ctfd.io']
-        set_config('allowed_domains', json.dumps(allowed_domains))
+        white_listed_domains = ['ctfd.io']
+        set_config('white_listed_domains', json.dumps(white_listed_domains))
         register_user(app, name="user1", email="user1@ctfd2.io", password="password")
         team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
         assert team_count == 1  # There's only the admin user
     destroy_ctfd(app)
 
 
-def test_user_can_register_allowed_mail():
+def test_user_can_register_mail_from_whitelisted_addresses():
     """User can register a white-listed mail"""
     app = create_ctfd()
     with app.app_context():
-        allowed_mails = ['user1@ctfd.io']
-        set_config('allowed_mails', json.dumps(allowed_mails))
+        white_listed_addresses = ['user1@ctfd.io']
+        set_config('white_listed_addresses', json.dumps(white_listed_addresses))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
         team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
         assert team_count == 2  # There's the admin user and the created user
     destroy_ctfd(app)
 
 
-def test_user_cannot_register_disallowed_mail():
+def test_user_cannot_register_mail_not_in_whitelisted_addresses():
     """User cannot register a mail that is not white-listed"""
     app = create_ctfd()
     with app.app_context():
-        allowed_mails = ['user1@ctfd.io']
-        set_config('allowed_mails', json.dumps(allowed_mails))
+        white_listed_addresses = ['user1@ctfd.io']
+        set_config('white_listed_addresses', json.dumps(white_listed_addresses))
         register_user(app, name="user1", email="user2@ctfd.io", password="password")
         team_count = app.db.session.query(app.db.func.count(Teams.id)).first()[0]
         assert team_count == 1  # There's only the admin user
     destroy_ctfd(app)
 
 
-def test_user_can_change_to_allowed_mail_domain():
-    """User can change to a mail from a white-listed domain"""
+def test_user_can_change_mail_to_whitelisted_domain():
+    """User can change to a mail in a white-listed domain"""
     app = create_ctfd()
     with app.app_context():
-        allowed_domains = ['ctfd.io', 'ctfd2.io']
-        set_config('allowed_domains', json.dumps(allowed_domains))
+        white_listed_domains = ['ctfd.io', 'ctfd2.io']
+        set_config('white_listed_domains', json.dumps(white_listed_domains))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
         client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
@@ -86,18 +86,15 @@ def test_user_can_change_to_allowed_mail_domain():
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd2.io'
-        assert user.affiliation == 'affiliation_test'
-        assert user.website == 'https://ctfd.io'
-        assert user.country == 'United States of America'
     destroy_ctfd(app)
 
 
-def test_user_cannot_change_to_disallowed_mail_domain():
+def test_user_cannot_change_mail_not_in_whitelisted_domain():
     """User cannot change to a mail that is not in a white-listed domain"""
     app = create_ctfd()
     with app.app_context():
-        allowed_domains = ['ctfd.io', 'ctfd2.io']
-        set_config('allowed_domains', json.dumps(allowed_domains))
+        white_listed_domains = ['ctfd.io', 'ctfd2.io']
+        set_config('white_listed_domains', json.dumps(white_listed_domains))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
         client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
@@ -117,18 +114,15 @@ def test_user_cannot_change_to_disallowed_mail_domain():
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd.io'
-        assert user.affiliation is None
-        assert user.website is None
-        assert user.country is None
     destroy_ctfd(app)
 
 
-def test_user_can_change_to_allowed_mail():
+def test_user_can_change_mail_to_whitelisted_addresses():
     """User can change to a mail that is white-listed"""
     app = create_ctfd()
     with app.app_context():
-        allowed_mails = ['user1@ctfd.io', 'user1@ctfd2.io']
-        set_config('allowed_mails', json.dumps(allowed_mails))
+        white_listed_addresses = ['user1@ctfd.io', 'user1@ctfd2.io']
+        set_config('white_listed_addresses', json.dumps(white_listed_addresses))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
         client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
@@ -148,18 +142,15 @@ def test_user_can_change_to_allowed_mail():
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd2.io'
-        assert user.affiliation == 'affiliation_test'
-        assert user.website == 'https://ctfd.io'
-        assert user.country == 'United States of America'
     destroy_ctfd(app)
 
 
-def test_user_cannot_change_to_disallowed_mail():
+def test_user_cannot_change_mail_not_in_whitelisted_addresses():
     """User cannot change to a mail that is not white-listed"""
     app = create_ctfd()
     with app.app_context():
-        allowed_mails = ['user1@ctfd.io', 'user1@ctfd2.io']
-        set_config('allowed_mails', json.dumps(allowed_mails))
+        white_listed_addresses = ['user1@ctfd.io', 'user1@ctfd2.io']
+        set_config('white_listed_addresses', json.dumps(white_listed_addresses))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
         client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
@@ -179,7 +170,4 @@ def test_user_cannot_change_to_disallowed_mail():
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd.io'
-        assert user.affiliation is None
-        assert user.website is None
-        assert user.country is None
     destroy_ctfd(app)

--- a/tests/user/test_white_listing_mails.py
+++ b/tests/user/test_white_listing_mails.py
@@ -68,7 +68,7 @@ def test_user_can_change_to_allowed_mail_domain():
         allowed_domains = ['ctfd.io', 'ctfd2.io']
         set_config('allowed_domains', json.dumps(allowed_domains))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
-        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
         with client.session_transaction() as sess:
             data = {
@@ -100,7 +100,7 @@ def test_user_cannot_change_to_disallowed_mail_domain():
         allowed_domains = ['ctfd.io', 'ctfd2.io']
         set_config('allowed_domains', json.dumps(allowed_domains))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
-        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
         with client.session_transaction() as sess:
             data = {
@@ -132,7 +132,7 @@ def test_user_can_change_to_allowed_mail():
         allowed_mails = ['user1@ctfd.io', 'user1@ctfd2.io']
         set_config('allowed_mails', json.dumps(allowed_mails))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
-        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
         with client.session_transaction() as sess:
             data = {
@@ -164,7 +164,7 @@ def test_user_cannot_change_to_disallowed_mail():
         allowed_mails = ['user1@ctfd.io', 'user1@ctfd2.io']
         set_config('allowed_mails', json.dumps(allowed_mails))
         register_user(app, name="user1", email="user1@ctfd.io", password="password")
-        client = login_as_user(app, name="user1", email="user1@ctfd.io", password="password")
+        client = login_as_user(app, name="user1", password="password")
         r = client.get('/profile')
         with client.session_transaction() as sess:
             data = {

--- a/tests/user/test_white_listing_mails.py
+++ b/tests/user/test_white_listing_mails.py
@@ -185,8 +185,7 @@ def test_admin_can_create_team_with_mail_in_whitelisted_domain():
             data = {
                 'name': 'user1',
                 'email': 'user1@ctfd.io',
-                'confirm': '',
-                'password': '',
+                'password': 'password',
                 'affiliation': 'affiliation_test',
                 'website': 'https://ctfd.io',
                 'country': 'United States of America',
@@ -212,8 +211,7 @@ def test_admin_cannot_create_team_with_mail_not_in_whitelisted_domain():
             data = {
                 'name': 'user1',
                 'email': 'user1@ctfd2.io',
-                'confirm': '',
-                'password': '',
+                'password': 'password',
                 'affiliation': 'affiliation_test',
                 'website': 'https://ctfd.io',
                 'country': 'United States of America',
@@ -241,8 +239,7 @@ def test_admin_can_create_team_with_mail_in_whitelisted_address():
             data = {
                 'name': 'user1',
                 'email': 'user1@ctfd.io',
-                'confirm': '',
-                'password': '',
+                'password': 'password',
                 'affiliation': 'affiliation_test',
                 'website': 'https://ctfd.io',
                 'country': 'United States of America',
@@ -268,8 +265,7 @@ def test_admin_cannot_create_team_with_mail_not_in_whitelisted_adress():
             data = {
                 'name': 'user1',
                 'email': 'user2@ctfd.io',
-                'confirm': '',
-                'password': '',
+                'password': 'password',
                 'affiliation': 'affiliation_test',
                 'website': 'https://ctfd.io',
                 'country': 'United States of America',
@@ -283,24 +279,6 @@ def test_admin_cannot_create_team_with_mail_not_in_whitelisted_adress():
         assert len(response['data']) == 1
         assert "User e-mail address should belong to the whitelisted domains or to the whitelisted users' list" in response['data']
     destroy_ctfd(app)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 def test_admin_can_change_team_with_mail_in_whitelisted_domain():

--- a/tests/user/test_white_listing_mails.py
+++ b/tests/user/test_white_listing_mails.py
@@ -83,7 +83,6 @@ def test_user_can_change_to_allowed_mail_domain():
             }
 
         r = client.post('/profile', data=data)
-        #assert r.status_code == 302
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd2.io'
@@ -115,13 +114,12 @@ def test_user_cannot_change_to_disallowed_mail_domain():
             }
 
         r = client.post('/profile', data=data)
-        #assert r.status_code == 302
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd.io'
-        assert user.affiliation == 'affiliation_test'
-        assert user.website == 'https://ctfd.io'
-        assert user.country == 'United States of America'
+        assert user.affiliation == ''
+        assert user.website == ''
+        assert user.country == ''
     destroy_ctfd(app)
 
 
@@ -147,7 +145,6 @@ def test_user_can_change_to_allowed_mail():
             }
 
         r = client.post('/profile', data=data)
-        #assert r.status_code == 302
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd2.io'
@@ -179,11 +176,10 @@ def test_user_cannot_change_to_disallowed_mail():
             }
 
         r = client.post('/profile', data=data)
-        #assert r.status_code == 302
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd.io'
-        assert user.affiliation == 'affiliation_test'
-        assert user.website == 'https://ctfd.io'
-        assert user.country == 'United States of America'
+        assert user.affiliation == ''
+        assert user.website == ''
+        assert user.country == ''
     destroy_ctfd(app)

--- a/tests/user/test_white_listing_mails.py
+++ b/tests/user/test_white_listing_mails.py
@@ -117,9 +117,9 @@ def test_user_cannot_change_to_disallowed_mail_domain():
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd.io'
-        assert user.affiliation == ''
-        assert user.website == ''
-        assert user.country == ''
+        assert user.affiliation is None
+        assert user.website is None
+        assert user.country is None
     destroy_ctfd(app)
 
 
@@ -179,7 +179,7 @@ def test_user_cannot_change_to_disallowed_mail():
 
         user = Teams.query.filter_by(name='user1').first()
         assert user.email == 'user1@ctfd.io'
-        assert user.affiliation == ''
-        assert user.website == ''
-        assert user.country == ''
+        assert user.affiliation is None
+        assert user.website is None
+        assert user.country is None
     destroy_ctfd(app)


### PR DESCRIPTION
This extension allows the admin to configure a set of domains and usernames such that only users from these domains (or those addresses explicitly specified) can register.
Invalid e-mails and domains are silently discarded.