### PR TITLE
Add ability to specify packages to be installed with apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ COPY . /opt/CTFd
 
 VOLUME ["/opt/CTFd"]
 
+RUN apk update
+RUN for d in CTFd/plugins/*; do \
+      if [ -f "$d/apk-requirements.txt" ]; then \
+        cat "$d/apk-requirements.txt" | xargs -n1 apk add; \
+      fi; \
+    done;
+
 RUN for d in CTFd/plugins/*; do \
       if [ -f "$d/requirements.txt" ]; then \
         pip install -r $d/requirements.txt; \


### PR DESCRIPTION
This addresses issue with using Google Captcha plugin in CTFd.  To successfully add this in Docker, packages need to be added with apk before adding packages with pip.

This allows plugin creators to add an "apk-requirements.txt" file to their plugins and have them installed at the build phase.

Will require modification to plugin guidelines.