### PR TITLE
fix admin_export bugs

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -88,7 +88,7 @@ def admin_export_ctf():
         backup = export_ctf()
     ctf_name = utils.ctf_name()
     day = datetime.datetime.now().strftime("%Y-%m-%d")
-    full_name = "{}.{}.zip".format(ctf_name, day)
+    full_name = u"{}.{}.zip".format(ctf_name, day)
     return send_file(backup, as_attachment=True, attachment_filename=full_name)
 
 

--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -133,6 +133,8 @@ def chal_view(chal_id):
     teamid = session.get('id')
 
     chal = Challenges.query.filter_by(id=chal_id).first_or_404()
+    if chal.hidden:
+        abort(404)
     chal_class = get_chal_class(chal.type)
 
     tags = [tag.tag for tag in Tags.query.add_columns('tag').filter_by(chal=chal.id).all()]


### PR DESCRIPTION
python 2.7  flask send_file function need attachment_filename type is unicode, not str