### PR TITLE
Remove @during_ctf_time_only from /challenges

### DIFF
--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -74,7 +74,6 @@ def hints_view(hintid):
 
 
 @challenges.route('/challenges', methods=['GET'])
-@during_ctf_time_only
 @require_verified_emails
 @viewable_without_authentication()
 def challenges_view():


### PR DESCRIPTION
Method already gracefully handles being requested before the CTF starts.

By removing @during_ctf_time_only, we get a nicer error message ("<ctf
name> has not started yet" vs a 403).