### PR TITLE
Hosting under a subfolder

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -146,6 +146,13 @@ class Config(object):
     '''
     UPDATE_CHECK = True
 
+    '''
+    APPLICATION_ROOT inform the application what path it is mounted under by the application / web server.
+
+    Set it to whatever you like if you need to host CTFd under a subfolder
+    '''
+    APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT', '/')
+
 
 class TestingConfig(Config):
     SECRET_KEY = 'AAAAAAAAAAAAAAAAAAAA'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,6 +32,11 @@ if [ -z "$WORKERS" ]; then
     WORKERS=1
 fi
 
+# Set application root
+if [ -z "$APPLICATION_ROOT" ]; then
+    APPLICATION_ROOT='/'
+fi
+
 # Start CTFd
 echo "Starting CTFd"
 gunicorn 'CTFd:create_app()' \


### PR DESCRIPTION
This allows to set `APPLICATION_ROOT` externally by setting an env variable, making hosting under a subfolder easier. The `dockerfile-entrypoint.sh` has been adapted accordingly, so the `APPLICATION_ROOT` env var can be passed when calling `docker` or set in the `docker-compose.yml` file.