### PR TITLE
setting APPLICATION_ROOT from env var

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -197,6 +197,14 @@ class Config(object):
     OAUTH_CLIENT_ID = None
     OAUTH_CLIENT_SECRET = None
 
+    '''
+    APPLICATION_ROOT informs the application what path it is mounted under by
+    the application / web server.
+
+    Set it to whatever you like if you need to host CTFd under a subfolder
+    '''
+    APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT', '/')
+
 
 class TestingConfig(Config):
     SECRET_KEY = 'AAAAAAAAAAAAAAAAAAAA'

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -198,12 +198,10 @@ class Config(object):
     OAUTH_CLIENT_SECRET = None
 
     '''
-    APPLICATION_ROOT informs the application what path it is mounted under by
-    the application / web server.
-
-    Set it to whatever you like if you need to host CTFd under a subfolder
+    APPLICATION_ROOT specifies what path CTFd is mounted under. It can be used to run CTFd in a subdirectory.
+    Example: /ctfd
     '''
-    APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT', '/')
+    APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT') or '/'
 
 
 class TestingConfig(Config):

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,11 +37,6 @@ else
     ERROR_LOG=-
 fi
 
-# Set application root
-if [ -z "$APPLICATION_ROOT" ]; then
-    APPLICATION_ROOT='/'
-fi
-
 # Initialize database
 python manage.py db upgrade
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,6 +37,11 @@ else
     ERROR_LOG=-
 fi
 
+# Set application root
+if [ -z "$APPLICATION_ROOT" ]; then
+    APPLICATION_ROOT='/'
+fi
+
 # Initialize database
 python manage.py db upgrade
 


### PR DESCRIPTION
This allows to set `APPLICATION_ROOT` externally by setting an env variable, making hosting under a subfolder easier. The `dockerfile-entrypoint.sh` has been adapted accordingly, so the `APPLICATION_ROOT` env var can be passed when calling `docker` or set in the `docker-compose.yml` file.