### PR TITLE
Add SAFE_MODE concept to let tests run without plugins

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -189,6 +189,7 @@ def create_app(config='CTFd.config.Config'):
         app.register_error_handler(500, general_error)
         app.register_error_handler(502, gateway_error)
 
-        init_plugins(app)
+        if app.config.get('SAFE_MODE', False):
+            init_plugins(app)
 
         return app

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -210,3 +210,4 @@ class TestingConfig(Config):
     UPDATE_CHECK = False
     REDIS_URL = None
     CACHE_TYPE = 'simple'
+    SAFE_MODE = True


### PR DESCRIPTION
Adds a `SAFE_MODE` config to disable the loading of plugins. 