### PR TITLE
Make sure update.read() is not str then decode

### DIFF
--- a/CTFd/admin/challenges.py
+++ b/CTFd/admin/challenges.py
@@ -23,8 +23,11 @@ def challenges_detail(challenge_id):
     challenge_class = get_chal_class(challenge.type)
 
     with open(os.path.join(app.root_path, challenge_class.templates['update'].lstrip('/'))) as update:
+        read = update.read()
+        if type(read) != str:
+            read = read.decode('utf-8')
         update_j2 = render_template_string(
-            update.read().decode('utf-8'),
+            read,
             challenge=challenge
         )
 


### PR DESCRIPTION
In my environment 500 error came when admin tried to make a challenge.
The errors that occurred were as follows.
`AttributeError: 'str' object has no attribute 'decode'`
For this reason, make sure `update.read()` is not `str` then `decode('utf-8')` .