### PR TITLE
Fix admin cannot modify verified status in Edit User

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        # Fail the status if coverage drops by >= 1%
+        threshold: 1
+    patch:
+      default:
+        threshold: 1

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -152,7 +152,8 @@ class UserSchema(ma.ModelSchema):
             'id',
             'oauth_id',
             'password',
-            'type'
+            'type',
+            'verified'
         ]
     }
 

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -168,10 +168,13 @@ def test_api_user_patch_admin():
                 "name": "user",
                 "email": "user@ctfd.io",
                 "password": "password",
-                "country": "US"
+                "country": "US",
+                "verified": True
             })
             assert r.status_code == 200
-            assert r.get_json()['data'][0]['country'] == 'US'
+            user_data = r.get_json()['data'][0]
+            assert user_data['country'] == 'US'
+            assert user_data['verified'] is True
     destroy_ctfd(app)
 
 

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -92,6 +92,32 @@ def test_api_users_post_admin():
     destroy_ctfd(app)
 
 
+def test_api_users_post_admin_with_attributes():
+    """Can a user post /api/v1/users with user settings"""
+    app = create_ctfd()
+    with app.app_context():
+        with login_as_user(app, 'admin') as client:
+            # Create user
+            r = client.post('/api/v1/users', json={
+                "name": "user",
+                "email": "user@user.com",
+                "password": "password",
+                "banned": True,
+                "hidden": True,
+                "verified": True
+            })
+            assert r.status_code == 200
+
+            # Make sure password was hashed properly
+            user = Users.query.filter_by(email='user@user.com').first()
+            assert user
+            assert verify_password('password', user.password)
+            assert user.banned
+            assert user.hidden
+            assert user.verified
+    destroy_ctfd(app)
+
+
 def test_api_team_get_public():
     """Can a user get /api/v1/team/<user_id> if users are public"""
     app = create_ctfd()


### PR DESCRIPTION
The Edit User page has a form field to modify the user's Verified, Hidden and Banned status. Both the Hidden and Banned status can be modified by an admin, however the Verified status cannot be modified. This appears to be a bug.

![Edit User](https://user-images.githubusercontent.com/31173491/49369815-e8b72480-f724-11e8-8367-6a3c3119ebd8.png)
  
There are two potential solutions for this bug:
- Remove the Verified field from the form
- Allow admin to modify `verified` field in `UserSchema`

In this pull request I propose that admins should be allowed access to modify the `verified` field in `UserSchema`. 

This change has two advantages:
- It makes the existing Edit User form work as intended. 
- It allows admins to manually verify users, which enables contests to employ user verification without setting up a mail server.


