### PR TITLE
Fix smtp sendmail 

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -121,6 +121,7 @@ class Config(object):
     MAILFROM_ADDR = os.getenv("MAILFROM_ADDR") or "noreply@ctfd.io"
     MAIL_SERVER = os.getenv("MAIL_SERVER") or None
     MAIL_PORT = os.getenv("MAIL_PORT")
+    MAIL_USEAUTH = os.getenv("MAIL_USEAUTH")
     MAIL_USERNAME = os.getenv("MAIL_USERNAME")
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
     MAIL_TLS = os.getenv("MAIL_TLS") or False

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -117,6 +117,27 @@ class Config(object):
 
     MAIL_PORT:
         The mail port that emails are sent from if not overriden in the configuration panel.
+
+    MAIL_USEAUTH
+        Whether or not to use username and password to authenticate to the SMTP server
+
+    MAIL_USERNAME
+        The username used to authenticate to the SMTP server if MAIL_USEAUTH is defined
+
+    MAIL_PASSWORD
+        The password used to authenticate to the SMTP server if MAIL_USEAUTH is defined
+
+    MAIL_TLS
+        Whether to connect to the SMTP server over TLS
+
+    MAIL_SSL
+        Whether to connect to the SMTP server over SSL
+
+    MAILGUN_API_KEY
+        Mailgun API key to send email over Mailgun
+
+    MAILGUN_BASE_URL
+        Mailgun base url to send email over Mailgun
     '''
     MAILFROM_ADDR = os.getenv("MAILFROM_ADDR") or "noreply@ctfd.io"
     MAIL_SERVER = os.getenv("MAIL_SERVER") or None

--- a/CTFd/themes/admin/static/js/configs/configs.js
+++ b/CTFd/themes/admin/static/js/configs/configs.js
@@ -83,6 +83,18 @@ function update_configs(obj){
 
     var params = {};
 
+    if (obj.mail_useauth === false) {
+        obj.mail_username = null;
+        obj.mail_password = null;
+    } else {
+        if (obj.mail_username === "") {
+            delete obj.mail_username;
+        }
+        if (obj.mail_password === "") {
+            delete obj.mail_password;
+        }
+    }
+
     Object.keys(obj).forEach(function (x) {
         if (obj[x] === "true") {
             params[x] = true;

--- a/CTFd/themes/admin/templates/configs/email.html
+++ b/CTFd/themes/admin/templates/configs/email.html
@@ -44,17 +44,17 @@
 					<div class="form-group">
 						<label>Username:</label>
 						{% if mail_username is defined and mail_username != None %}
-							<label for="mail_u"><sup>A mail server username is currently set</sup></label>
+							<label for="mail_username"><sup>A mail server username is currently set</sup></label>
 						{% endif %}
-						<input class="form-control" id='mail_u' name='mail_u' autocomplete='off' type='text'
+						<input class="form-control" id='mail_username' name='mail_username' autocomplete='off' type='text'
 							   placeholder="Username">
 					</div>
 					<div class="form-group">
-						<label for="mail_p">Password:</label>
+						<label for="mail_password">Password:</label>
 						{% if mail_password is defined and mail_password != None %}
 							<label for="mail_p"><sup>An mail server password is currently set</sup></label>
 						{% endif %}
-						<input class="form-control" id='mail_p' name='mail_p' autocomplete='off' type='password'
+						<input class="form-control" id='mail_password' name='mail_password' autocomplete='off' type='password'
 							   placeholder="Password">
 					</div>
 					<sup>Uncheck setting and update to remove username and password</sup>

--- a/CTFd/utils/email/smtp.py
+++ b/CTFd/utils/email/smtp.py
@@ -29,8 +29,7 @@ def sendmail(addr, text):
     password = get_config('mail_password') or get_app_config('MAIL_PASSWORD')
     TLS = get_config('mail_tls') or get_app_config('MAIL_TLS')
     SSL = get_config('mail_ssl') or get_app_config('MAIL_SSL')
-    if username:
-        auth = True
+    auth = get_config('mail_useauth') or get_app_config('MAIL_USEAUTH')
 
     if username:
         data['username'] = username

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -179,6 +179,7 @@ def test_expired_reset_password_link():
     with app.app_context():
         set_config('mail_server', 'localhost')
         set_config('mail_port', 25)
+        set_config('mail_useauth', True)
         set_config('mail_username', 'username')
         set_config('mail_password', 'password')
 
@@ -199,6 +200,7 @@ def test_invalid_reset_password_link():
     with app.app_context():
         set_config('mail_server', 'localhost')
         set_config('mail_port', 25)
+        set_config('mail_useauth', True)
         set_config('mail_username', 'username')
         set_config('mail_password', 'password')
 
@@ -237,6 +239,7 @@ def test_user_can_confirm_email(mock_smtp):
         set_config('verify_emails', True)
         set_config('mail_server', 'localhost')
         set_config('mail_port', 25)
+        set_config('mail_useauth', True)
         set_config('mail_username', 'username')
         set_config('mail_password', 'password')
 
@@ -279,6 +282,7 @@ def test_user_can_reset_password(mock_smtp):
         # Set CTFd to send emails
         set_config('mail_server', 'localhost')
         set_config('mail_port', 25)
+        set_config('mail_useauth', True)
         set_config('mail_username', 'username')
         set_config('mail_password', 'password')
 

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -34,6 +34,7 @@ def test_sendmail_with_smtp(mock_smtp):
     with app.app_context():
         set_config('mail_server', 'localhost')
         set_config('mail_port', 25)
+        set_config('mail_useauth', True)
         set_config('mail_username', 'username')
         set_config('mail_password', 'password')
 
@@ -143,6 +144,7 @@ def test_verify_email(mock_smtp):
     with app.app_context():
         set_config('mail_server', 'localhost')
         set_config('mail_port', 25)
+        set_config('mail_useauth', True)
         set_config('mail_username', 'username')
         set_config('mail_password', 'password')
         set_config('verify_emails', True)


### PR DESCRIPTION
* Closes #779
* This brings back MAIL_USEAUTH and allows you to set it from `config.py`
* Prevent saving configs from overwriting saved SMTP username and password 