### PR TITLE
Fix divison-by-zero when adding requirement to dynamic challenge

### DIFF
--- a/CTFd/plugins/dynamic_challenges/__init__.py
+++ b/CTFd/plugins/dynamic_challenges/__init__.py
@@ -89,6 +89,9 @@ class DynamicValueChallenge(BaseChallenge):
         data = request.form or request.get_json()
 
         for attr, value in data.items():
+            # We need to set these to floats so that the next operations don't operate on strings
+            if attr in ('initial', 'minimum', 'decay'):
+                value = float(value)
             setattr(challenge, attr, value)
 
         Model = get_model()

--- a/CTFd/plugins/dynamic_challenges/__init__.py
+++ b/CTFd/plugins/dynamic_challenges/__init__.py
@@ -88,10 +88,10 @@ class DynamicValueChallenge(BaseChallenge):
         """
         data = request.form or request.get_json()
         for attr, value in data.items():
-                setattr(challenge, attr, value)
+            setattr(challenge, attr, value)
         if challenge.requirements is not None:
-                db.session.commit()
-                return challenge
+            db.session.commit()
+            return challenge
         challenge.initial = float(data.get('initial', 0))
         challenge.minimum = float(data.get('minimum', 0))
         challenge.decay = float(data.get('decay', 0))

--- a/CTFd/plugins/dynamic_challenges/__init__.py
+++ b/CTFd/plugins/dynamic_challenges/__init__.py
@@ -87,14 +87,9 @@ class DynamicValueChallenge(BaseChallenge):
         :return:
         """
         data = request.form or request.get_json()
+
         for attr, value in data.items():
             setattr(challenge, attr, value)
-        if challenge.requirements is not None:
-            db.session.commit()
-            return challenge
-        challenge.initial = float(data.get('initial', 0))
-        challenge.minimum = float(data.get('minimum', 0))
-        challenge.decay = float(data.get('decay', 0))
 
         Model = get_model()
 
@@ -231,9 +226,9 @@ class DynamicValueChallenge(BaseChallenge):
 class DynamicChallenge(Challenges):
     __mapper_args__ = {'polymorphic_identity': 'dynamic'}
     id = db.Column(None, db.ForeignKey('challenges.id'), primary_key=True)
-    initial = db.Column(db.Integer)
-    minimum = db.Column(db.Integer)
-    decay = db.Column(db.Integer)
+    initial = db.Column(db.Integer, default=0)
+    minimum = db.Column(db.Integer, default=0)
+    decay = db.Column(db.Integer, default=0)
 
     def __init__(self, *args, **kwargs):
         super(DynamicChallenge, self).__init__(**kwargs)

--- a/CTFd/plugins/dynamic_challenges/__init__.py
+++ b/CTFd/plugins/dynamic_challenges/__init__.py
@@ -87,11 +87,14 @@ class DynamicValueChallenge(BaseChallenge):
         :return:
         """
         data = request.form or request.get_json()
-        data['initial'] = float(data.get('initial', 0))
-        data['minimum'] = float(data.get('minimum', 0))
-        data['decay'] = float(data.get('decay', 0))
         for attr, value in data.items():
-            setattr(challenge, attr, value)
+                setattr(challenge, attr, value)
+        if challenge.requirements is not None:
+                db.session.commit()
+                return challenge
+        challenge.initial = float(data.get('initial', 0))
+        challenge.minimum = float(data.get('minimum', 0))
+        challenge.decay = float(data.get('decay', 0))
 
         Model = get_model()
 

--- a/tests/challenges/test_dynamic.py
+++ b/tests/challenges/test_dynamic.py
@@ -83,9 +83,9 @@ def test_can_update_dynamic_challenge():
         assert challenge.state == "visible"
 
     destroy_ctfd(app)
-    
+
 def test_can_add_requirement_dynamic_challenge():
-    """Test that dynamic challenges can be deleted"""
+    """Test that requirements can be added to dynamic challenges"""
     app = create_ctfd(enable_plugins=True)
     with app.app_context():
         challenge_data = {
@@ -119,7 +119,7 @@ def test_can_add_requirement_dynamic_challenge():
         }
 
         req = FakeRequest(form=challenge_data)
-        challenge = DynamicValueChallenge.create(challenge, req)
+        challenge = DynamicValueChallenge.create(req)
 
         assert challenge.name == 'second_name'
         assert challenge.description == "new_description"

--- a/tests/challenges/test_dynamic.py
+++ b/tests/challenges/test_dynamic.py
@@ -83,6 +83,62 @@ def test_can_update_dynamic_challenge():
         assert challenge.state == "visible"
 
     destroy_ctfd(app)
+    
+def test_can_add_requirement_dynamic_challenge():
+    """Test that dynamic challenges can be deleted"""
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge_data = {
+            "name": "name",
+            "category": "category",
+            "description": "description",
+            "value": 100,
+            "decay": 20,
+            "minimum": 1,
+            "state": "hidden",
+            "type": "dynamic"
+        }
+        req = FakeRequest(form=challenge_data)
+        challenge = DynamicValueChallenge.create(req)
+
+        assert challenge.value == 100
+        assert challenge.initial == 100
+        assert challenge.decay == 20
+        assert challenge.minimum == 1
+
+        challenge_data = {
+            "name": "second_name",
+            "category": "category",
+            "description": "new_description",
+            "value": "200",
+            "initial": "200",
+            "decay": "40",
+            "minimum": "5",
+            "max_attempts": "0",
+            "state": "visible"
+        }
+
+        req = FakeRequest(form=challenge_data)
+        challenge = DynamicValueChallenge.create(challenge, req)
+
+        assert challenge.name == 'second_name'
+        assert challenge.description == "new_description"
+        assert challenge.value == 200
+        assert challenge.initial == 200
+        assert challenge.decay == 40
+        assert challenge.minimum == 5
+        assert challenge.state == "visible"
+
+        challenge_data = {
+            "requirements": [1]
+        }
+
+        req = FakeRequest(form=challenge_data)
+        challenge = DynamicValueChallenge.update(challenge, req)
+
+        assert challenge.requirements == [1]
+
+    destroy_ctfd(app)
 
 
 def test_can_delete_dynamic_challenge():

--- a/tests/challenges/test_dynamic.py
+++ b/tests/challenges/test_dynamic.py
@@ -84,6 +84,7 @@ def test_can_update_dynamic_challenge():
 
     destroy_ctfd(app)
 
+
 def test_can_add_requirement_dynamic_challenge():
     """Test that requirements can be added to dynamic challenges"""
     app = create_ctfd(enable_plugins=True)


### PR DESCRIPTION
I noticed that when I wanted to add a pre-requisite challenge to a dynamic challenge, I received a divison-by-zero error.

During a requirement addition, only the new required challenge id is sent. Because the initial, minimum and decay values are not set, the update path in the __init.py set them to a default 0. 
Later on, when a calculation takes place with these values, a divison-by-zero happens before anything gets committed to the database.

I've added a simple check before other calculations to check if data received from client includes a requirements (is not None). If there is data there, it means the request is a requirement addition so we can just commit those changes and return. At the same time, updating values and other data will not include a requirement field so everything else will work as it does currently.