### PR TITLE
Fix hint loading for admins with /api/v1/hints/<id>?preview=true

### DIFF
--- a/CTFd/api/v1/hints.py
+++ b/CTFd/api/v1/hints.py
@@ -3,7 +3,7 @@ from flask_restplus import Namespace, Resource
 from CTFd.models import db, Hints, HintUnlocks
 from CTFd.plugins.challenges import get_chal_class
 from CTFd.utils.dates import ctf_ended
-from CTFd.utils.user import get_current_user
+from CTFd.utils.user import get_current_user, is_admin
 from CTFd.schemas.hints import HintSchema
 from CTFd.utils.decorators import (
     during_ctf_time_only,
@@ -74,6 +74,10 @@ class Hint(Resource):
             ).first()
             if unlocked:
                 view = 'unlocked'
+
+        if is_admin():
+            if request.args.get('preview', False):
+                view = 'admin'
 
         response = HintSchema(view=view).dump(hint)
 

--- a/CTFd/themes/admin/static/js/challenges/hints.js
+++ b/CTFd/themes/admin/static/js/challenges/hints.js
@@ -1,6 +1,55 @@
+function hint(id) {
+    return fetch(script_root + '/api/v1/hints/' + id + '?preview=true', {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+    }).then(function (response) {
+        return response.json();
+    });
+}
+
+function loadhint(hintid) {
+    var md = window.markdownit({
+        html: true,
+    });
+
+    hint(hintid).then(function (response) {
+        if (response.data.content) {
+            ezal({
+                title: "Hint",
+                body: md.render(response.data.content),
+                button: "Got it!"
+            });
+        } else {
+            ezal({
+                title: "Error",
+                body: "Error loading hint!",
+                button: "OK"
+            });
+        }
+    });
+}
+
 $(document).ready(function () {
     $('#hint-add-button').click(function (e) {
         $('#hint-edit-modal form').find("input, textarea").val("");
+
+        // Markdown Preview
+        $('#new-hint-edit').on('shown.bs.tab', function (event) {
+            console.log(event.target.hash);
+            if (event.target.hash == '#hint-preview') {
+                console.log(event.target.hash);
+                var renderer = window.markdownit({
+                    html: true,
+                });
+                var editor_value = $('#hint-write textarea').val();
+                $(event.target.hash).html(renderer.render(editor_value));
+            }
+        });
+
         $('#hint-edit-modal').modal();
     });
 
@@ -26,7 +75,7 @@ $(document).ready(function () {
         e.preventDefault();
         var hint_id = $(this).attr('hint-id');
 
-        fetch(script_root + '/api/v1/hints/' + hint_id, {
+        fetch(script_root + '/api/v1/hints/' + hint_id + '?preview=true', {
             method: 'GET',
             credentials: 'same-origin',
             headers: {
@@ -40,6 +89,19 @@ $(document).ready(function () {
                 $('#hint-edit-form input[name=content],textarea[name=content]').val(response.data.content);
                 $('#hint-edit-form input[name=cost]').val(response.data.cost);
                 $('#hint-edit-form input[name=id]').val(response.data.id);
+
+                // Markdown Preview
+                $('#new-hint-edit').on('shown.bs.tab', function (event) {
+                    console.log(event.target.hash);
+                    if (event.target.hash == '#hint-preview') {
+                        console.log(event.target.hash);
+                        var renderer = new markdownit({
+                            html: true,
+                        });
+                        var editor_value = $('#hint-write textarea').val();
+                        $(event.target.hash).html(renderer.render(editor_value));
+                    }
+                });
 
                 $('#hint-edit-modal').modal();
             }

--- a/CTFd/themes/admin/templates/challenges/challenge.html
+++ b/CTFd/themes/admin/templates/challenges/challenge.html
@@ -114,10 +114,12 @@
         var CHALLENGE_ID = {{ challenge.id }};
         var CHALLENGE_NAME = {{ challenge.name | tojson }};
 	</script>
+	<script src="{{ url_for('views.themes', theme='admin', path='js/vendor/markdown-it.min.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/vendor/moment.min.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/vendor/plotly.min.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/multi-modal.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/challenges/challenge.js') }}"></script>
+	<script src="{{ url_for('views.themes', theme='core', path='js/hints.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/challenges/hints.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/challenges/flags.js') }}"></script>
 	<script src="{{ url_for('views.themes', theme='admin', path='js/challenges/tags.js') }}"></script>


### PR DESCRIPTION
* Fix hint loading for admins by adding /api/v1/hints/<id>?preview=true for use by admins
* Add tests for admin Hint preview
* This also starts integrating the core and admin themes meaning that the core theme cannot be removed from CTFd and is available for usage by other themes