### PR TITLE
Disable jinja cache properly by setting cache_size to 0 (#662)

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -28,7 +28,6 @@ class CTFdFlask(Flask):
     def __init__(self, *args, **kwargs):
         """Overriden Jinja constructor setting a custom jinja_environment"""
         self.jinja_environment = SandboxedBaseEnvironment
-        self.jinja_environment.cache = None
         self.session_interface = CachingSessionInterface(key_prefix='session')
         Flask.__init__(self, *args, **kwargs)
 
@@ -42,7 +41,9 @@ class SandboxedBaseEnvironment(SandboxedEnvironment):
     def __init__(self, app, **options):
         if 'loader' not in options:
             options['loader'] = app.create_global_jinja_loader()
-        SandboxedEnvironment.__init__(self, **options)
+        # Disable cache entirely so that themes can be switched (#662)
+        # If the cache is enabled, switching themes will cause odd rendering errors
+        SandboxedEnvironment.__init__(self, cache_size=0, **options)
         self.app = app
 
 


### PR DESCRIPTION
* Disable jinja cache properly by setting cache_size to 0 (#662)
* Without disabling the cache you get some difficult to debug rendering errors. Regression from 1.2.0.
