### PR TITLE
Disable user mode switching on client side (Closes #799)

### DIFF
--- a/CTFd/themes/admin/templates/configs/appearance.html
+++ b/CTFd/themes/admin/templates/configs/appearance.html
@@ -51,18 +51,19 @@
 			<label for="user_mode">
 				User Mode
 				<small class="form-text text-muted">User mode allows users to register as themselves
-					or choose to form teams
+					or choose to form teams.
 				</small>
 			</label>
-			<select class="form-control" id="user_mode" name="user_mode">
-				<option value="teams" {% if user_mode == 'teams' %}selected{% endif %}>
-					Teams
-				</option>
-				<option value="users" {% if user_mode == 'users' %}selected{% endif %}>
-					Users
-				</option>
-			</select>
-
+			<div data-toggle="tooltip" data-placement="bottom" title="In order to change User Mode you must reset your CTF">
+				<select class="form-control" id="user_mode" name="user_mode" disabled="true" style="z-index: -1;">
+					<option value="teams" {% if user_mode == 'teams' %}selected{% endif %}>
+						Teams
+					</option>
+					<option value="users" {% if user_mode == 'users' %}selected{% endif %}>
+						Users
+					</option>
+				</select>
+			</div>
 		</div>
 
 		<div class="form-group">


### PR DESCRIPTION
* Disable user mode switching on client side (Closes #799)
It's ill advised to switch user modes after a CTF is setup. The simplest thing to do here is to require CTF resetting in order to switch modes. If it makes sense this can be re-enabled and re-evaluated. 