### PR TITLE
Fix subdirectory deployments in a generic manner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_install:
     - sudo mysql_upgrade -u root -ppassword
     - sudo service mysql restart
     - sudo rm -f /etc/boto.cfg
-    - export AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
-    - export AWS_ACCESS_KEY_ID=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    - export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+    - export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 install:
     - pip install -r development.txt
 before_script:

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -27,8 +27,15 @@ __version__ = '2.0.1'
 
 class CTFdRequest(Request):
     @cached_property
-    def script_path(self):
-        return self.script_root + self.path
+    def path(self):
+        """
+        Hijack the original Flask request path because it does not account for subdirectory deployments in an intuitive
+        manner. We append script_root so that the path always points to the full path as seen in the browser.
+        e.g. /subdirectory/path/route vs /path/route
+
+        :return: string
+        """
+        return self.script_root + super(CTFdRequest, self).path
 
 
 class CTFdFlask(Flask):

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -2,10 +2,9 @@ import sys
 import os
 
 from distutils.version import StrictVersion
-from flask import Flask, Request, redirect, request
+from flask import Flask, Request
 from werkzeug.utils import cached_property
 from werkzeug.contrib.fixers import ProxyFix
-from werkzeug.wsgi import DispatcherMiddleware
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from six.moves import input
@@ -201,19 +200,5 @@ def create_app(config='CTFd.config.Config'):
         app.register_error_handler(502, gateway_error)
 
         init_plugins(app)
-
-        application_root = app.config.get('APPLICATION_ROOT')
-        if application_root != '/':
-            dispatcher = Flask('dispatcher')
-
-            @dispatcher.route('/', defaults={'path': ''})
-            @dispatcher.route('/<path:path>')
-            def dispatcher_redirect(path):
-                return redirect(application_root + request.script_root + request.path)
-
-            dispatcher.wsgi_app = DispatcherMiddleware(dispatcher.wsgi_app, {
-                application_root: app,
-            })
-            return dispatcher
 
         return app

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -39,7 +39,7 @@ def require_authentication_if_config(config_key):
         def __require_authentication_if_config(*args, **kwargs):
             value = get_config(config_key)
             if value and current_user.authed():
-                return redirect(url_for('auth.login', next=request.path))
+                return redirect(url_for('auth.login', next=request.script_path))
             else:
                 return f(*args, **kwargs)
         return __require_authentication_if_config
@@ -82,7 +82,7 @@ def authed_only(f):
             if request.content_type == 'application/json':
                 abort(403)
             else:
-                return redirect(url_for('auth.login', next=request.path))
+                return redirect(url_for('auth.login', next=request.script_path))
 
     return authed_only_wrapper
 
@@ -102,7 +102,7 @@ def admins_only(f):
             if request.content_type == 'application/json':
                 abort(403)
             else:
-                return redirect(url_for('auth.login', next=request.path))
+                return redirect(url_for('auth.login', next=request.script_path))
 
     return admins_only_wrapper
 
@@ -113,7 +113,7 @@ def require_team(f):
         if get_config('user_mode') == TEAMS_MODE:
             team = get_current_team()
             if team is None:
-                return redirect(url_for('teams.private', next=request.path))
+                return redirect(url_for('teams.private', next=request.script_path))
         return f(*args, **kwargs)
 
     return require_team_wrapper

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -39,7 +39,7 @@ def require_authentication_if_config(config_key):
         def __require_authentication_if_config(*args, **kwargs):
             value = get_config(config_key)
             if value and current_user.authed():
-                return redirect(url_for('auth.login', next=request.script_path))
+                return redirect(url_for('auth.login', next=request.full_path))
             else:
                 return f(*args, **kwargs)
         return __require_authentication_if_config
@@ -82,7 +82,7 @@ def authed_only(f):
             if request.content_type == 'application/json':
                 abort(403)
             else:
-                return redirect(url_for('auth.login', next=request.script_path))
+                return redirect(url_for('auth.login', next=request.full_path))
 
     return authed_only_wrapper
 
@@ -102,7 +102,7 @@ def admins_only(f):
             if request.content_type == 'application/json':
                 abort(403)
             else:
-                return redirect(url_for('auth.login', next=request.script_path))
+                return redirect(url_for('auth.login', next=request.full_path))
 
     return admins_only_wrapper
 
@@ -113,7 +113,7 @@ def require_team(f):
         if get_config('user_mode') == TEAMS_MODE:
             team = get_current_team()
             if team is None:
-                return redirect(url_for('teams.private', next=request.script_path))
+                return redirect(url_for('teams.private', next=request.full_path))
         return f(*args, **kwargs)
 
     return require_team_wrapper

--- a/CTFd/utils/decorators/visibility.py
+++ b/CTFd/utils/decorators/visibility.py
@@ -18,7 +18,7 @@ def check_score_visibility(f):
                 if request.content_type == 'application/json':
                     abort(403)
                 else:
-                    return redirect(url_for('auth.login', next=request.script_path))
+                    return redirect(url_for('auth.login', next=request.full_path))
 
         elif v == 'hidden':
             return render_template('errors/403.html', error='Scores are currently hidden'), 403
@@ -45,7 +45,7 @@ def check_challenge_visibility(f):
                 if request.content_type == 'application/json':
                     abort(403)
                 else:
-                    return redirect(url_for('auth.login', next=request.script_path))
+                    return redirect(url_for('auth.login', next=request.full_path))
     return _check_challenge_visibility
 
 
@@ -63,7 +63,7 @@ def check_account_visibility(f):
                 if request.content_type == 'application/json':
                     abort(403)
                 else:
-                    return redirect(url_for('auth.login', next=request.script_path))
+                    return redirect(url_for('auth.login', next=request.full_path))
 
         elif v == 'admins':
             if is_admin():

--- a/CTFd/utils/decorators/visibility.py
+++ b/CTFd/utils/decorators/visibility.py
@@ -18,7 +18,7 @@ def check_score_visibility(f):
                 if request.content_type == 'application/json':
                     abort(403)
                 else:
-                    return redirect(url_for('auth.login', next=request.path))
+                    return redirect(url_for('auth.login', next=request.script_path))
 
         elif v == 'hidden':
             return render_template('errors/403.html', error='Scores are currently hidden'), 403
@@ -45,7 +45,7 @@ def check_challenge_visibility(f):
                 if request.content_type == 'application/json':
                     abort(403)
                 else:
-                    return redirect(url_for('auth.login', next=request.path))
+                    return redirect(url_for('auth.login', next=request.script_path))
     return _check_challenge_visibility
 
 
@@ -63,7 +63,7 @@ def check_account_visibility(f):
                 if request.content_type == 'application/json':
                     abort(403)
                 else:
-                    return redirect(url_for('auth.login', next=request.path))
+                    return redirect(url_for('auth.login', next=request.script_path))
 
         elif v == 'admins':
             if is_admin():

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -73,7 +73,7 @@ def init_request_processors(app):
 
     @app.before_request
     def needs_setup():
-        if request.script_path == url_for('views.setup') or request.path.startswith('/themes'):
+        if request.path == url_for('views.setup') or request.path.startswith('/themes'):
             return
         if not is_setup():
             return redirect(url_for('views.setup'))
@@ -128,7 +128,7 @@ def init_request_processors(app):
     if application_root != '/':
         @app.before_request
         def force_subdirectory_redirect():
-            if request.script_path.startswith(application_root) is False:
+            if request.path.startswith(application_root) is False:
                 return redirect(application_root + request.script_root + request.full_path)
 
         app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask, current_app as app, request, session, redirect, url_for, abort, render_template
+from werkzeug.wsgi import DispatcherMiddleware
 from CTFd.models import db, Tracking
 
 from CTFd.utils import markdown, get_config
@@ -114,3 +115,14 @@ def init_request_processors(app):
             if request.content_type != 'application/json':
                 if session['nonce'] != request.form.get('nonce'):
                     abort(403)
+
+    application_root = app.config.get('APPLICATION_ROOT')
+    if application_root != '/':
+        @app.before_request
+        def force_subdirectory_redirect():
+            if request.script_path.startswith(application_root) is False:
+                return redirect(application_root + request.script_root + request.full_path)
+
+        app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
+            application_root: app,
+        })

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -1,4 +1,4 @@
-from flask import current_app as app, request, session, redirect, url_for, abort, render_template
+from flask import Flask, current_app as app, request, session, redirect, url_for, abort, render_template
 from CTFd.models import db, Tracking
 
 from CTFd.utils import markdown, get_config
@@ -64,7 +64,7 @@ def init_request_processors(app):
 
     @app.before_request
     def needs_setup():
-        if request.path == '/setup' or request.path.startswith('/themes'):
+        if request.script_path == url_for('views.setup') or request.path.startswith('/themes'):
             return
         if not is_setup():
             return redirect(url_for('views.setup'))

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -174,7 +174,7 @@ def static_html(route):
         abort(404)
     else:
         if page.auth_required and authed() is False:
-            return redirect(url_for('auth.login', next=request.path))
+            return redirect(url_for('auth.login', next=request.script_path))
 
         return render_template('page.html', content=markdown(page.content))
 

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -174,7 +174,7 @@ def static_html(route):
         abort(404)
     else:
         if page.auth_required and authed() is False:
-            return redirect(url_for('auth.login', next=request.script_path))
+            return redirect(url_for('auth.login', next=request.full_path))
 
         return render_template('page.html', content=markdown(page.content))
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,11 +20,13 @@ else:
 FakeRequest = namedtuple('FakeRequest', ['form'])
 
 
-def create_ctfd(ctf_name="CTFd", name="admin", email="admin@ctfd.io", password="password", user_mode="users", setup=True, enable_plugins=False, application_root=None):
+def create_ctfd(ctf_name="CTFd", name="admin", email="admin@ctfd.io", password="password", user_mode="users", setup=True, enable_plugins=False, application_root='/'):
     if enable_plugins:
         TestingConfig.SAFE_MODE = False
-    if application_root:
-        TestingConfig.APPLICATION_ROOT = application_root
+    else:
+        TestingConfig.SAFE_MODE = True
+
+    TestingConfig.APPLICATION_ROOT = application_root
 
     app = create_app(TestingConfig)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,9 +20,11 @@ else:
 FakeRequest = namedtuple('FakeRequest', ['form'])
 
 
-def create_ctfd(ctf_name="CTFd", name="admin", email="admin@ctfd.io", password="password", user_mode="users", setup=True, enable_plugins=False):
+def create_ctfd(ctf_name="CTFd", name="admin", email="admin@ctfd.io", password="password", user_mode="users", setup=True, enable_plugins=False, application_root=None):
     if enable_plugins:
         TestingConfig.SAFE_MODE = False
+    if application_root:
+        TestingConfig.APPLICATION_ROOT = application_root
 
     app = create_app(TestingConfig)
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -66,9 +66,9 @@ def test_custom_css():
 
 def test_that_ctfd_can_be_deployed_in_subdir():
     """Test that CTFd can be deployed in a subdirectory"""
+    # This test is quite complicated. I do not suggest modifying it haphazardly.
     app = create_ctfd(setup=False, application_root='/ctf')
     true_app = app.wsgi_app.mounts['/ctf']
-    # app.session_interface = true_app.session_interface
     with app.app_context():
         with app.test_client() as client, true_app.test_client() as true_client:
             r = client.get('/setup')

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -116,7 +116,7 @@ def test_user_get_logout():
         client = login_as_user(app)
         client.get('/logout', follow_redirects=True)
         r = client.get('/challenges')
-        assert r.location == "http://localhost/login?next=%2Fchallenges"
+        assert r.location == "http://localhost/login?next=%2Fchallenges%3F"
         assert r.status_code == 302
     destroy_ctfd(app)
 

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -56,7 +56,7 @@ def test_page_requiring_auth():
         with app.test_client() as client:
             r = client.get('/this-is-a-route')
             assert r.status_code == 302
-            assert r.location == 'http://localhost/login?next=%2Fthis-is-a-route'
+            assert r.location == 'http://localhost/login?next=%2Fthis-is-a-route%3F'
 
         register_user(app)
         client = login_as_user(app)


### PR DESCRIPTION
* Fix subdirectory deployments in a generic manner by modifying`request.path` to combine both `request.script_root` and `request.path` and also creating a request preprocessor to redirect users into the true CTFd app. Without this sessions will be invalid because sessions will be set to a subdirectory. 
* Add a test for testing subdirectory deployments and the customized CTFdRequest object.
* Fix `TestingConfig.SAFE_MODE` getting stuck in between tests. 
* Order AWS keys properly in travis.yml
* Redirect to `request.full_path` instead of just `request.path`