### PR TITLE
Fix wrong user mode in challenge_solves_box

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -29,11 +29,11 @@ from CTFd.cache import cache, clear_standings
 from CTFd.utils.scores import get_standings
 from CTFd.utils.config.visibility import scores_visible, accounts_visible, challenges_visible
 from CTFd.utils.user import get_current_user, is_admin, authed
-from CTFd.utils.modes import get_model
+from CTFd.utils.modes import get_model,USERS_MODE,TEAMS_MODE
 from CTFd.schemas.tags import TagSchema
 from CTFd.schemas.hints import HintSchema
 from CTFd.schemas.flags import FlagSchema
-from CTFd.utils import config
+from CTFd.utils import config,get_config
 from CTFd.utils import user as current_user
 from CTFd.utils.user import get_current_team
 from CTFd.utils.user import get_current_user
@@ -477,6 +477,7 @@ class ChallengeSolves(Resource):
     @require_verified_emails
     def get(self, challenge_id):
         response = []
+        user_mode = ''
         challenge = Challenges.query.filter_by(id=challenge_id).first_or_404()
 
         # TODO: Need a generic challenge visibility call.
@@ -490,11 +491,17 @@ class ChallengeSolves(Resource):
             .filter(Solves.challenge_id == challenge_id, Model.banned == False, Model.hidden == False)\
             .order_by(Solves.date.asc())
 
+        if get_config('user_mode') == TEAMS_MODE:
+            user_mode = 'teams'
+        elif get_config('user_mode') == USERS_MODE:
+            user_mode = 'users'
+
         for solve in solves:
             response.append({
                 'account_id': solve.account_id,
                 'name': solve.account.name,
-                'date': isoformat(solve.date)
+                'date': isoformat(solve.date),
+                'user_mode': user_mode
             })
 
         return {

--- a/CTFd/themes/core/static/js/challenges.js
+++ b/CTFd/themes/core/static/js/challenges.js
@@ -220,7 +220,8 @@ function getsolves(id) {
             var id = data[i].account_id;
             var name = data[i].name;
             var date = moment(data[i].date).local().fromNow();
-            box.append('<tr><td><a href="teams/{0}">{1}</td><td>{2}</td></tr>'.format(id, htmlentities(name), date));
+            var user_mode = data[i].user_mode
+            box.append('<tr><td><a href="{0}/{1}">{2}</td><td>{3}</td></tr>'.format(user_mode, id, htmlentities(name), date));
         }
     });
 }


### PR DESCRIPTION
I found that even when using `Users` mode, the url of the person who solved the problem is still in `/teams/id` format, not `/users/id`. So I added the result of the current user mode to the `data[]` returned by `/api/v1/challenges/id/solves` to generate the correct url.
Although this would insert a lot of redundant `user_mod` to `data[]`, but this is the solution I can think of with the least change to the code : )