### PR TITLE
Consider account configs when user patches their own account

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -140,18 +140,13 @@ def register():
         valid_email = validators.validate_email(request.form['email'])
         team_name_email_check = validators.validate_email(name)
 
-        local_id, _, domain = email_address.partition('@')
-
-        domain_whitelist = get_config('domain_whitelist')
-
         if not valid_email:
             errors.append("Please enter a valid email address")
-        if domain_whitelist:
-            domain_whitelist = [d.strip() for d in domain_whitelist.split(',')]
-            if domain not in domain_whitelist:
+        if email.check_email_is_whitelisted(email_address) is False:
                 errors.append(
                     "Only email addresses under {domains} may register".format(
-                        domains=', '.join(domain_whitelist))
+                        domains=get_config('domain_whitelist')
+                    )
                 )
         if names:
             errors.append('That team name is already taken')

--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -4,8 +4,8 @@ cache = Cache()
 
 
 def clear_config():
-    from CTFd.utils import get_config, get_app_config
-    cache.delete_memoized(get_config)
+    from CTFd.utils import _get_config, get_app_config
+    cache.delete_memoized(_get_config)
     cache.delete_memoized(get_app_config)
 
 

--- a/CTFd/schemas/teams.py
+++ b/CTFd/schemas/teams.py
@@ -4,6 +4,7 @@ from marshmallow import validate, ValidationError, pre_load
 from marshmallow_sqlalchemy import field_for
 from CTFd.models import ma, Teams
 from CTFd.utils.validators import validate_country_code
+from CTFd.utils import get_config
 from CTFd.utils.user import is_admin, get_current_team
 from CTFd.utils.countries import lookup_country_code
 from CTFd.utils.user import is_admin, get_current_team
@@ -69,6 +70,10 @@ class TeamSchema(ma.ModelSchema):
             if data['name'] == current_team.name:
                 return data
             else:
+                name_changes = get_config('name_changes', default=True)
+                if bool(name_changes) is False:
+                    raise ValidationError('Name changes are disabled', field_names=['name'])
+
                 if existing_team:
                     raise ValidationError('Team name has already been taken', field_names=['name'])
 

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -5,6 +5,7 @@ from marshmallow import validate, ValidationError, pre_load
 from marshmallow.decorators import validates_schema
 from marshmallow_sqlalchemy import field_for
 from CTFd.models import ma, Users
+from CTFd.utils import get_config
 from CTFd.utils.validators import unique_email, validate_country_code
 from CTFd.utils.user import is_admin, get_current_user
 from CTFd.utils.countries import lookup_country_code
@@ -23,7 +24,7 @@ class UserSchema(ma.ModelSchema):
         'name',
         required=True,
         validate=[
-            validate.Length(min=1, max=128, error='Team names must not be empty')
+            validate.Length(min=1, max=128, error='User names must not be empty')
         ]
     )
     email = field_for(
@@ -74,6 +75,9 @@ class UserSchema(ma.ModelSchema):
             if name == current_user.name:
                 return data
             else:
+                name_changes = get_config('name_changes', default=True)
+                if bool(name_changes) is False:
+                    raise ValidationError('Name changes are disabled', field_names=['name'])
                 if existing_user:
                     raise ValidationError('User name has already been taken', field_names=['name'])
 
@@ -96,6 +100,8 @@ class UserSchema(ma.ModelSchema):
             else:
                 if existing_user:
                     raise ValidationError('Email address has already been used', field_names=['email'])
+                if get_config('verify_emails'):
+                    current_user.verified = False
 
     @pre_load
     def validate_password_confirmation(self, data):

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -10,6 +10,7 @@ from CTFd.utils.validators import unique_email, validate_country_code
 from CTFd.utils.user import is_admin, get_current_user
 from CTFd.utils.countries import lookup_country_code
 from CTFd.utils.crypto import verify_password, hash_password
+from CTFd.utils.email import check_email_is_whitelisted
 
 
 class UserSchema(ma.ModelSchema):
@@ -100,6 +101,13 @@ class UserSchema(ma.ModelSchema):
             else:
                 if existing_user:
                     raise ValidationError('Email address has already been used', field_names=['email'])
+                if check_email_is_whitelisted(email) is False:
+                    raise ValidationError(
+                        "Only email addresses under {domains} may register".format(
+                            domains=get_config('domain_whitelist')
+                        ),
+                        field_names=['email']
+                    )
                 if get_config('verify_emails'):
                     current_user.verified = False
 

--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -30,14 +30,13 @@ else:
 markdown = mistune.Markdown()
 
 
-@cache.memoize()
-def get_app_config(key):
-    value = app.config.get(key)
+def get_app_config(key, default=None):
+    value = app.config.get(key, default)
     return value
 
 
 @cache.memoize()
-def get_config(key):
+def _get_config(key):
     config = Configs.query.filter_by(key=key).first()
     if config and config.value:
         value = config.value
@@ -52,6 +51,14 @@ def get_config(key):
                 return value
 
 
+def get_config(key, default=None):
+    value = _get_config(key)
+    if value is None:
+        return default
+    else:
+        return value
+
+
 def set_config(key, value):
     config = Configs.query.filter_by(key=key).first()
     if config:
@@ -60,5 +67,5 @@ def set_config(key, value):
         config = Configs(key=key, value=value)
         db.session.add(config)
     db.session.commit()
-    cache.delete_memoized(get_config, key)
+    cache.delete_memoized(_get_config, key)
     return config

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -41,3 +41,13 @@ def verify_email_address(addr):
 
 def check_email_format(email):
     return bool(re.match(EMAIL_REGEX, email))
+
+
+def check_email_is_whitelisted(email_address):
+    local_id, _, domain = email_address.partition('@')
+    domain_whitelist = get_config('domain_whitelist')
+    if domain_whitelist:
+        domain_whitelist = [d.strip() for d in domain_whitelist.split(',')]
+        if domain not in domain_whitelist:
+            return False
+    return True

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -363,7 +363,7 @@ def test_api_user_change_email_under_whitelist():
             )
             assert r.status_code == 400
             resp = r.get_json()
-            assert "Only email addresses under" in resp['errors']['email']
+            assert resp['errors']['email']
             assert resp['success'] is False
 
             r = client.patch(


### PR DESCRIPTION
* Block user name changes if name changes are disabled (Closes #835 )
* Block team name changes  if name changes are disabled
* Set accounts to unconfirmed if email is changed while `verify_emails` is enabled
* Only allow users to change their email to emails with domains in the whitelist. 
* Add `email.check_email_is_whitelisted()` to verify that a user's email is whitelisted.
* Create a get_config wrapper around the internal _get_config to let us set a default config value (Closes #659)
* Remove `utils.get_app_config()` from memoization and also give it a `default` parameter