### PR TITLE
Block new user registration if registering via MLC

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -319,8 +319,9 @@ def oauth_redirect():
             user_email = api_data['email']
 
             user = Users.query.filter_by(email=user_email).first()
-            if registration_visible():
-                if user is None:
+            if user is None:
+                # Check if we are allowing registration before creating users
+                if registration_visible():
                     user = Users(
                         name=user_name,
                         email=user_email,
@@ -329,29 +330,34 @@ def oauth_redirect():
                     )
                     db.session.add(user)
                     db.session.commit()
+                else:
+                    log('logins', "[{date}] {ip} - Public registration via MLC blocked")
+                    error_for(
+                        endpoint='auth.login',
+                        message='Public registration is disabled. Please try again later.'
+                    )
+                    return redirect(url_for('auth.login'))
 
-                if get_config('user_mode') == TEAMS_MODE:
-                    team_id = api_data['team']['id']
-                    team_name = api_data['team']['name']
+            if get_config('user_mode') == TEAMS_MODE:
+                team_id = api_data['team']['id']
+                team_name = api_data['team']['name']
 
-                    team = Teams.query.filter_by(oauth_id=team_id).first()
-                    if team is None:
-                        team = Teams(
-                            name=team_name,
-                            oauth_id=team_id
-                        )
-                        db.session.add(team)
-                        db.session.commit()
-
-                    team.members.append(user)
+                team = Teams.query.filter_by(oauth_id=team_id).first()
+                if team is None:
+                    team = Teams(
+                        name=team_name,
+                        oauth_id=team_id
+                    )
+                    db.session.add(team)
                     db.session.commit()
-            else:
-                log('logins', "[{date}] {ip} - Public registration via MLC blocked")
-                error_for(
-                    endpoint='auth.login',
-                    message='Public registration is disabled. Please try again later.'
-                )
-                return redirect(url_for('auth.login'))
+
+                team.members.append(user)
+                db.session.commit()
+
+            if user.oauth_id is None:
+                user.oauth_id = user_id
+                user.verified = True
+                db.session.commit()
 
             login_user(user)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,9 +7,11 @@ from CTFd.cache import cache
 from sqlalchemy_utils import database_exists, create_database, drop_database
 from sqlalchemy.engine.url import make_url
 from collections import namedtuple
+from mock import Mock, patch
 import datetime
 import six
 import gc
+import requests
 
 if six.PY2:
     text_type = unicode
@@ -128,6 +130,59 @@ def login_as_user(app, name="user", password="password", raise_for_error=True):
                     assert sess['email']
                     assert sess['nonce']
             return client
+
+
+def login_with_mlc(app, name='user', scope='profile%20team', email='user@ctfd.io', oauth_id=1337, team_name='TestTeam', team_oauth_id=1234, raise_for_error=True):
+    with app.test_client() as client, \
+            patch.object(requests, 'get') as fake_get_request, \
+            patch.object(requests, 'post') as fake_post_request:
+        client.get('/login')
+        with client.session_transaction() as sess:
+            nonce = sess['nonce']
+
+            redirect_url = "{endpoint}?response_type=code&client_id={client_id}&scope={scope}&state={state}".format(
+                endpoint=app.config['OAUTH_AUTHORIZATION_ENDPOINT'],
+                client_id=app.config['OAUTH_CLIENT_ID'],
+                scope=scope,
+                state=nonce
+            )
+
+        r = client.get('/oauth', follow_redirects=False)
+        assert r.location == redirect_url
+
+        fake_post_response = Mock()
+        fake_post_request.return_value = fake_post_response
+        fake_post_response.status_code = 200
+        fake_post_response.json = lambda: {
+            'access_token': 'fake_mlc_access_token'
+        }
+
+        fake_get_response = Mock()
+        fake_get_request.return_value = fake_get_response
+        fake_get_response.status_code = 200
+        fake_get_response.json = lambda: {
+            'id': oauth_id,
+            'name': name,
+            'email': email,
+            'team': {
+                'id': team_oauth_id,
+                'name': team_name
+            }
+        }
+
+        client.get('/redirect?code={code}&state={state}'.format(
+            code='mlc_test_code',
+            state=nonce
+        ), follow_redirects=False)
+
+        if raise_for_error:
+            with client.session_transaction() as sess:
+                assert sess['id']
+                assert sess['name']
+                assert sess['type']
+                assert sess['email']
+                assert sess['nonce']
+        return client
 
 
 def get_scores(user):

--- a/tests/oauth/test_redirect.py
+++ b/tests/oauth/test_redirect.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from tests.helpers import *
-from mock import Mock, patch
 from CTFd.utils import set_config
-import requests
 
 
 def test_oauth_not_configured():
@@ -21,6 +19,7 @@ def test_oauth_not_configured():
 
 
 def test_oauth_configured_flow():
+    """Test that MLC integration works properly but does not allow registration (account creation) if disabled"""
     app = create_ctfd(user_mode="teams")
     app.config.update({
         'OAUTH_CLIENT_ID': 'ctfd_testing_client_id',
@@ -71,6 +70,7 @@ def test_oauth_configured_flow():
 
 
 def test_oauth_login_upgrade():
+    """Test that users who use MLC after having registered will be associated with their MLC account"""
     app = create_ctfd(user_mode="teams")
     app.config.update({
         'OAUTH_CLIENT_ID': 'ctfd_testing_client_id',

--- a/tests/oauth/test_redirect.py
+++ b/tests/oauth/test_redirect.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from tests.helpers import *
+from mock import Mock, patch
+from CTFd.utils import set_config
+import requests
+
+
+def test_oauth_not_configured():
+    """Test that OAuth redirection fails if OAuth settings aren't configured"""
+    app = create_ctfd()
+    with app.app_context():
+        with app.test_client() as client:
+            r = client.get('/oauth', follow_redirects=False)
+            assert r.location == 'http://localhost/login'
+            r = client.get(r.location)
+            resp = r.get_data(as_text=True)
+            assert "OAuth Settings not configured" in resp
+    destroy_ctfd(app)
+
+
+@patch.object(requests, 'get')
+@patch.object(requests, 'post')
+def test_oauth_configured_flow(fake_post_request, fake_get_request):
+    app = create_ctfd()
+    app.config.update({
+        'OAUTH_CLIENT_ID': 'ctfd_testing_client_id',
+        'OAUTH_CLIENT_SECRET': 'ctfd_testing_client_secret',
+        'OAUTH_AUTHORIZATION_ENDPOINT': 'http://auth.localhost/oauth/authorize',
+        'OAUTH_TOKEN_ENDPOINT': 'http://auth.localhost/oauth/token',
+        'OAUTH_API_ENDPOINT': 'http://api.localhost/user',
+    })
+    with app.app_context():
+        set_config('registration_visibility', 'private')
+        assert Users.query.count() == 1
+        with app.test_client() as client:
+            client.get('/login')
+            with client.session_transaction() as sess:
+                nonce = sess['nonce']
+
+                redirect_url = "{endpoint}?response_type=code&client_id={client_id}&scope={scope}&state={state}".format(
+                    endpoint=app.config['OAUTH_AUTHORIZATION_ENDPOINT'],
+                    client_id=app.config['OAUTH_CLIENT_ID'],
+                    scope='profile',
+                    state=nonce
+                )
+
+            r = client.get('/oauth', follow_redirects=False)
+            assert r.location == redirect_url
+
+            fake_post_response = Mock()
+            fake_post_request.return_value = fake_post_response
+            fake_post_response.status_code = 200
+            fake_post_response.json = lambda: {
+                'access_token': 'fake_mlc_access_token'
+            }
+
+            fake_get_response = Mock()
+            fake_get_request.return_value = fake_get_response
+            fake_post_response.status_code = 200
+            fake_get_response.json = lambda: {
+                'id': 1337,
+                'name': 'user',
+                'email': 'user@ctfd.io',
+                'team': {
+                    'id': 1234,
+                    'name': 'TestTeamTen'
+                }
+            }
+
+            r = client.get('/redirect?code={code}&state={state}'.format(
+                code='mlc_test_code',
+                state=nonce
+            ))
+
+            assert Users.query.count() == 1
+            assert r.location == 'http://localhost/login'
+
+            resp = client.get(r.location).get_data(as_text=True)
+            assert 'Public registration is disabled' in resp
+
+            set_config('registration_visibility', 'public')
+
+            r = client.get('/redirect?code={code}&state={state}'.format(
+                code='mlc_test_code',
+                state=nonce
+            ))
+
+            assert Users.query.count() == 2
+            user = Users.query.filter_by(email='user@ctfd.io').first()
+            assert user.oauth_id == 1337
+    destroy_ctfd(app)

--- a/tests/oauth/test_redirect.py
+++ b/tests/oauth/test_redirect.py
@@ -101,3 +101,4 @@ def test_oauth_login_upgrade():
         assert user.oauth_id
         assert user.verified
         assert user.team_id
+    destroy_ctfd(app)


### PR DESCRIPTION
* Block the creation of users/teams from MLC if `registration_visibility` is private
* Add OAuth flow tests
