### PR TITLE
Revert 762 log envvar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "8000:8000"
     environment:
       - UPLOAD_FOLDER=/var/uploads
+      - LOG_FOLDER=/var/log/CTFd
       - DATABASE_URL=mysql+pymysql://root:ctfd@db/ctfd
       - REDIS_URL=redis://cache:6379
       - WORKERS=4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,12 @@ services:
       - "8000:8000"
     environment:
       - UPLOAD_FOLDER=/var/uploads
-      - LOG_FOLDER=/var/log/CTFd
       - DATABASE_URL=mysql+pymysql://root:ctfd@db/ctfd
       - REDIS_URL=redis://cache:6379
       - WORKERS=4
+      - LOG_FOLDER=/var/log/CTFd
+      - ACCESS_LOG=-
+      - ERROR_LOG=-
     volumes:
       - .data/CTFd/logs:/var/log/CTFd
       - .data/CTFd/uploads:/var/uploads

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 set -eo pipefail
 
 WORKERS=${WORKERS:-1}
+ACCESS_LOG=${ACCESS_LOG:--}
+ERROR_LOG=${ERROR_LOG:--}
 
 # Check that a .ctfd_secret_key file or SECRET_KEY envvar is set
 if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
@@ -26,15 +28,6 @@ if [ -n "$DATABASE_URL" ]
     echo "$database is ready"
     # Give it another second.
     sleep 1;
-fi
-
-# Log to stdout/stderr by default
-if [ -n "$LOG_FOLDER" ]; then
-    ACCESS_LOG=${LOG_FOLDER}/access.log
-    ERROR_LOG=${LOG_FOLDER}/error.log
-else
-    ACCESS_LOG=-
-    ERROR_LOG=-
 fi
 
 # Initialize database


### PR DESCRIPTION
* Stop gunicorn from logging to `LOG_FOLDER` in docker without explicit opt-in
* Re-add the `LOG_FOLDER` envvar to docker-compose so we don't try to write to the read-only host
* Add `ACCESS_LOG` and `ERROR_LOG` envvars to docker to specify where gunicorn will log to