### PR TITLE
Allow custom MySQL ports in docker entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - UPLOAD_FOLDER=/var/uploads
       - DATABASE_URL=mysql+pymysql://root:ctfd@db/ctfd
       - REDIS_URL=redis://cache:6379
-      - WORKERS=4
+      - WORKERS=1
       - LOG_FOLDER=/var/log/CTFd
       - ACCESS_LOG=-
       - ERROR_LOG=-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,9 +18,11 @@ fi
 # Check that the database is available
 if [ -n "$DATABASE_URL" ]
     then
-    database=`echo $DATABASE_URL | awk -F[@//] '{print $4}'`
-    echo "Waiting for $database to be ready"
-    while ! mysqladmin ping -h $database --silent; do
+    url=`echo $DATABASE_URL | awk -F[@//] '{print $4}'`
+    database=`echo $url | awk -F[:] '{print $1}'`
+    port=`echo $url | awk -F[:] '{print $2}'`
+    echo "Waiting for $database:$port to be ready"
+    while ! mysqladmin ping -h "$database" -P "$port" --silent; do
         # Show some progress
         echo -n '.';
         sleep 1;


### PR DESCRIPTION
* Closes #846 
* Allow DATABASE_URL to contain custom MySQL ports for docker-entrypoint.sh
* Drop WORKERS count to 1 to avoid dealing with Flask-SocketIO sticky sessions'