### PR TITLE
Remove Flask-SocketIO in favor of custom Server Side Events code (#852)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: pip
 services:
     - mysql
     - postgresql
+    - redis-server
 addons:
   apt:
     sources:

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -14,8 +14,13 @@ from CTFd import utils
 from CTFd.utils.migrations import migrations, create_database
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
-from CTFd.utils.initialization import init_request_processors, init_template_filters, init_template_globals, init_logs
-from CTFd.utils.events import socketio
+from CTFd.utils.initialization import (
+    init_request_processors,
+    init_template_filters,
+    init_template_globals,
+    init_logs,
+    init_events,
+)
 from CTFd.plugins import init_plugins
 
 # Hack to support Unicode in Python 2 properly
@@ -148,13 +153,6 @@ def create_app(config='CTFd.config.Config'):
         cache.init_app(app)
         app.cache = cache
 
-        # If you have multiple workers you must have a shared cache
-        socketio.init_app(
-            app,
-            async_mode=app.config.get('SOCKETIO_ASYNC_MODE'),
-            message_queue=app.config.get('CACHE_REDIS_URL')
-        )
-
         if app.config.get('REVERSE_PROXY'):
             app.wsgi_app = ProxyFix(app.wsgi_app)
 
@@ -208,6 +206,7 @@ def create_app(config='CTFd.config.Config'):
         app.register_error_handler(502, gateway_error)
 
         init_logs(app)
+        init_events(app)
         init_plugins(app)
 
         return app

--- a/CTFd/api/v1/notifications.py
+++ b/CTFd/api/v1/notifications.py
@@ -1,8 +1,7 @@
-from flask import request
+from flask import current_app, request
 from flask_restplus import Namespace, Resource
 from CTFd.models import db, Notifications
 from CTFd.schemas.notifications import NotificationSchema
-from CTFd.utils.events import socketio
 
 from CTFd.utils.decorators import (
     admins_only
@@ -44,7 +43,9 @@ class NotificantionList(Resource):
         db.session.commit()
 
         response = schema.dump(result.data)
-        socketio.emit('notification', response.data, broadcast=True)
+        current_app.events_manager.publish(
+            data=response.data, type='notification'
+        )
 
         return {
             'success': True,

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -207,19 +207,12 @@ class Config(object):
     APPLICATION_ROOT:
         Specifies what path CTFd is mounted under. It can be used to run CTFd in a subdirectory.
         Example: /ctfd
-
-    SOCKETIO_ASYNC_MODE:
-        Specifies what async mode SocketIO should use. The simplest but least performant option is 'threading'.
-        Switching to a different async mode is not recommended without the appropriate load balancing mechanisms
-        in place and proper understanding of how websockets are supported by Flask.
-        https://flask-socketio.readthedocs.io/en/latest/#deployment
     '''
     REVERSE_PROXY = os.getenv("REVERSE_PROXY") or False
     TEMPLATES_AUTO_RELOAD = (not os.getenv("TEMPLATES_AUTO_RELOAD"))  # Defaults True
     SQLALCHEMY_TRACK_MODIFICATIONS = (not os.getenv("SQLALCHEMY_TRACK_MODIFICATIONS"))  # Defaults True
     UPDATE_CHECK = (not os.getenv("UPDATE_CHECK"))  # Defaults True
     APPLICATION_ROOT = os.getenv('APPLICATION_ROOT') or '/'
-    SOCKETIO_ASYNC_MODE = os.getenv('SOCKETIO_ASYNC_MODE') or 'threading'
 
     '''
     === OAUTH ===

--- a/CTFd/events/__init__.py
+++ b/CTFd/events/__init__.py
@@ -1,3 +1,13 @@
-from flask import Blueprint
+from flask import current_app, Blueprint, Response, stream_with_context
 
 events = Blueprint('events', __name__)
+
+
+@events.route("/events")
+def subscribe():
+    @stream_with_context
+    def gen():
+        for event in current_app.events_manager.subscribe():
+            yield str(event)
+
+    return Response(gen(), mimetype="text/event-stream")

--- a/CTFd/themes/core/static/js/events.js
+++ b/CTFd/themes/core/static/js/events.js
@@ -1,14 +1,10 @@
-var socket = io.connect(
-    window.location.protocol + '//' + document.domain + ':' + location.port,
-    {
-        path: script_root + '/socket.io'
-    }
-);
+var source = new EventSource(script_root + "/events");
 
-socket.on('notification', function (data) {
+source.addEventListener('notification', function (event) {
+    var data = JSON.parse(event.data);
     ezal({
         title: data.title,
         body: data.content,
         button: "Got it!"
     });
-});
+}, false);

--- a/CTFd/utils/events/__init__.py
+++ b/CTFd/utils/events/__init__.py
@@ -1,5 +1,74 @@
-from flask_socketio import SocketIO
+from collections import defaultdict
+from CTFd.cache import cache
+from six.moves.queue import Queue
+import json
+import six
 
-# The choice to use threading is intentional to simplify deployment.
-# At the moment it is not recommended to build full-duplex systems inside CTFd.
-socketio = SocketIO()
+
+@six.python_2_unicode_compatible
+class ServerSentEvent(object):
+    def __init__(self, data, type=None, id=None):
+        self.data = data
+        self.type = type
+        self.id = id
+
+    def __str__(self):
+        if isinstance(self.data, six.string_types):
+            data = self.data
+        else:
+            data = json.dumps(self.data)
+        lines = ["data:{value}".format(value=line) for line in data.splitlines()]
+        if self.type:
+            lines.insert(0, "event:{value}".format(value=self.type))
+        if self.id:
+            lines.append("id:{value}".format(value=self.id))
+        return "\n".join(lines) + "\n\n"
+
+    def to_dict(self):
+        d = {"data": self.data}
+        if self.type:
+            d["type"] = self.type
+        if self.id:
+            d["id"] = self.id
+        return d
+
+
+class EventManager(object):
+    def __init__(self):
+        self.clients = []
+
+    def publish(self, data, type=None, channel='ctf'):
+        event = ServerSentEvent(data, type=type)
+        message = event.to_dict()
+        for client in self.clients:
+            client[channel].put(message)
+        return len(self.clients)
+
+    def subscribe(self, channel='ctf'):
+        q = defaultdict(Queue)
+        self.clients.append(q)
+        try:
+            while True:
+                message = q[channel].get()
+                yield ServerSentEvent(**message)
+        except GeneratorExit:
+            self.clients.remove(q)
+
+
+class RedisEventManager(EventManager):
+    def __init__(self):
+        super(EventManager, self).__init__()
+        self.client = cache.cache._client
+
+    def publish(self, data, type=None, channel='ctf'):
+        event = ServerSentEvent(data, type=type)
+        message = json.dumps(event.to_dict())
+        return self.client.publish(message=message, channel=channel)
+
+    def subscribe(self, channel='ctf'):
+        pubsub = self.client.pubsub()
+        pubsub.subscribe(channel)
+        for message in pubsub.listen():
+            if message['type'] == 'message':
+                event = json.loads(message['data'])
+                yield ServerSentEvent(**event)

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -8,7 +8,7 @@ from CTFd.utils.dates import unix_time_millis, unix_time, isoformat
 from CTFd.utils import config
 from CTFd.utils.config import can_send_mail, ctf_logo, ctf_name, ctf_theme
 from CTFd.utils.config.pages import get_pages
-
+from CTFd.utils.events import EventManager, RedisEventManager
 from CTFd.utils.plugins import (
     get_registered_stylesheets,
     get_registered_scripts,
@@ -106,6 +106,13 @@ def init_logs(app):
     logger_submissions.propagate = 0
     logger_logins.propagate = 0
     logger_registrations.propagate = 0
+
+
+def init_events(app):
+    if app.config.get('CACHE_TYPE') == 'redis':
+        app.events_manager = RedisEventManager()
+    elif app.config.get('CACHE_TYPE') == 'filesystem':
+        app.events_manager = EventManager()
 
 
 def init_request_processors(app):

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -113,6 +113,8 @@ def init_events(app):
         app.events_manager = RedisEventManager()
     elif app.config.get('CACHE_TYPE') == 'filesystem':
         app.events_manager = EventManager()
+    else:
+        app.events_manager = EventManager()
 
 
 def init_request_processors(app):

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,4 @@ flask-restplus==0.12.1
 pathlib2==2.3.2
 flask-marshmallow==0.9.0
 marshmallow-sqlalchemy==0.15.0
-Flask-SocketIO==3.0.2
 boto3==1.9.39

--- a/serve.py
+++ b/serve.py
@@ -1,6 +1,4 @@
-from CTFd import create_app, socketio
+from CTFd import create_app
 
 app = create_app()
-# app.run(debug=True, threaded=True, host="127.0.0.1", port=4000)
-
-socketio.run(app, debug=True, host="127.0.0.1", port=4000)
+app.run(debug=True, threaded=True, host="127.0.0.1", port=4000)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,15 +51,23 @@ class CTFdTestClient(FlaskClient):
         return super(CTFdTestClient, self).open(*args, **kwargs)
 
 
-def create_ctfd(ctf_name="CTFd", name="admin", email="admin@ctfd.io", password="password", user_mode="users", setup=True, enable_plugins=False, application_root='/'):
+def create_ctfd(ctf_name="CTFd",
+                name="admin",
+                email="admin@ctfd.io",
+                password="password",
+                user_mode="users",
+                setup=True,
+                enable_plugins=False,
+                application_root='/',
+                config=TestingConfig):
     if enable_plugins:
-        TestingConfig.SAFE_MODE = False
+        config.SAFE_MODE = False
     else:
-        TestingConfig.SAFE_MODE = True
+        config.SAFE_MODE = True
 
-    TestingConfig.APPLICATION_ROOT = application_root
+    config.APPLICATION_ROOT = application_root
 
-    app = create_app(TestingConfig)
+    app = create_app(config)
     app.test_client_class = CTFdTestClient
 
     if setup:

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -155,8 +155,7 @@ def test_redis_event_manager_publish():
             }
 
             event_manager = RedisEventManager()
-            count = event_manager.publish(data=saved_data, type='notification', channel='ctf')
-            assert count == 1
+            event_manager.publish(data=saved_data, type='notification', channel='ctf')
         destroy_ctfd(app)
     except ConnectionError:
         print("Failed to connect to redis. Skipping test.")

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -1,13 +1,8 @@
 from tests.helpers import create_ctfd, destroy_ctfd
-from CTFd.utils import get_config, set_config
 from CTFd.utils.events import ServerSentEvent, EventManager
-from freezegun import freeze_time
-from mock import patch, Mock
+from mock import patch
 from six.moves.queue import Queue
 from collections import defaultdict
-from email.mime.text import MIMEText
-import requests
-import json
 
 
 def test_event_manager_installed():

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -1,0 +1,80 @@
+from tests.helpers import create_ctfd, destroy_ctfd
+from CTFd.utils import get_config, set_config
+from CTFd.utils.events import ServerSentEvent, EventManager
+from freezegun import freeze_time
+from mock import patch, Mock
+from six.moves.queue import Queue
+from collections import defaultdict
+from email.mime.text import MIMEText
+import requests
+import json
+
+
+def test_event_manager_installed():
+    """Test that EventManager is installed on the Flask app"""
+    app = create_ctfd()
+    assert type(app.events_manager) == EventManager
+    destroy_ctfd(app)
+
+
+def test_event_manager_subscription():
+    """Test that EventManager subscribing works"""
+    with patch.object(Queue, 'get') as fake_queue:
+        saved_data = {
+            'user_id': None,
+            'title': 'asdf',
+            'content': 'asdf',
+            'team_id': None,
+            'user': None,
+            'team': None,
+            'date': '2019-01-28T01:20:46.017649+00:00',
+            'id': 10
+        }
+        saved_event = {
+            'type': 'notification',
+            'data': saved_data
+        }
+
+        saved_event_string = 'event:notification\n'\
+                             'data:{"content": "asdf", "team_id": null, "user_id": null, "user": null, "title": "asdf", "date": "2019-01-28T01:20:46.017649+00:00", "team": null, "id": 10}\n\n'
+
+        fake_queue.return_value = saved_event
+        event_manager = EventManager()
+        for message in event_manager.subscribe():
+            assert message.to_dict() == saved_event
+            assert str(message) == saved_event_string
+            assert len(event_manager.clients) == 1
+            break
+
+
+def test_event_manager_publish():
+    """Test that EventManager publishing to clients works"""
+    saved_data = {
+        'user_id': None,
+        'title': 'asdf',
+        'content': 'asdf',
+        'team_id': None,
+        'user': None,
+        'team': None,
+        'date': '2019-01-28T01:20:46.017649+00:00',
+        'id': 10
+    }
+
+    event_manager = EventManager()
+    event_manager.clients.append(
+        defaultdict(Queue)
+    )
+    event_manager.publish(data=saved_data, type='notification', channel='ctf')
+
+    event = event_manager.clients[0]['ctf'].get()
+    event = ServerSentEvent(**event)
+    assert event.data == saved_data
+
+
+def test_event_endpoint_is_event_stream():
+    """Test that the /events endpoint is text/event-stream"""
+    app = create_ctfd()
+    with app.app_context(), app.test_client() as client:
+        r = client.get('/events')
+        assert "text/event-stream" in r.headers['Content-Type']
+    destroy_ctfd(app)

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -1,6 +1,5 @@
 from tests.helpers import create_ctfd, destroy_ctfd
 from CTFd.utils.events import ServerSentEvent, EventManager
-from CTFd.utils import text_type
 from mock import patch
 from six.moves.queue import Queue
 from collections import defaultdict

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -1,8 +1,12 @@
 from tests.helpers import create_ctfd, destroy_ctfd
-from CTFd.utils.events import ServerSentEvent, EventManager
+from CTFd.utils.events import ServerSentEvent, EventManager, RedisEventManager
+from CTFd.config import TestingConfig
 from mock import patch
 from six.moves.queue import Queue
 from collections import defaultdict
+from redis.exceptions import ConnectionError
+import json
+import redis
 
 
 def test_event_manager_installed():
@@ -70,3 +74,89 @@ def test_event_endpoint_is_event_stream():
         r = client.get('/events')
         assert "text/event-stream" in r.headers['Content-Type']
     destroy_ctfd(app)
+
+
+def test_redis_event_manager_installed():
+    """Test that RedisEventManager is installed on the Flask app"""
+    # TODO: This test is flaky.
+    class RedisConfig(TestingConfig):
+        REDIS_URL = 'redis://localhost:6379'
+        CACHE_REDIS_URL = 'redis://localhost:6379'
+        CACHE_TYPE = 'redis'
+
+    try:
+        app = create_ctfd(config=RedisConfig)
+        with app.app_context():
+            assert isinstance(app.events_manager, RedisEventManager)
+        destroy_ctfd(app)
+    except ConnectionError:
+        print("Failed to connect to redis. Skipping test.")
+
+
+def test_redis_event_manager_subscription():
+    """Test that RedisEventManager subscribing works."""
+    # TODO: This test is flaky.
+    class RedisConfig(TestingConfig):
+        REDIS_URL = 'redis://localhost:6379'
+        CACHE_REDIS_URL = 'redis://localhost:6379'
+        CACHE_TYPE = 'redis'
+
+    try:
+        app = create_ctfd(config=RedisConfig)
+        with app.app_context():
+            saved_data = {u'data': {u'content': u'asdf',
+                                    u'date': u'2019-01-28T05:02:19.830906+00:00',
+                                    u'id': 13,
+                                    u'team': None,
+                                    u'team_id': None,
+                                    u'title': u'asdf',
+                                    u'user': None,
+                                    u'user_id': None},
+                          u'type': u'notification'}
+
+            saved_event = {
+                'pattern': None,
+                'type': 'message',
+                'channel': 'ctf',
+                'data': json.dumps(saved_data)
+            }
+            with patch.object(redis.client.PubSub, 'listen') as fake_pubsub_listen:
+                fake_pubsub_listen.return_value = [saved_event]
+                event_manager = RedisEventManager()
+                for message in event_manager.subscribe():
+                    assert isinstance(message, ServerSentEvent)
+                    assert message.to_dict() == saved_data
+                    assert message.__str__().startswith('event:notification\ndata:')
+                    break
+        destroy_ctfd(app)
+    except ConnectionError:
+        print("Failed to connect to redis. Skipping test.")
+
+
+def test_redis_event_manager_publish():
+    """Test that RedisEventManager publishing to clients works."""
+    # TODO: This test is flaky.
+    class RedisConfig(TestingConfig):
+        REDIS_URL = 'redis://localhost:6379'
+        CACHE_REDIS_URL = 'redis://localhost:6379'
+        CACHE_TYPE = 'redis'
+    try:
+        app = create_ctfd(config=RedisConfig)
+        with app.app_context():
+            saved_data = {
+                'user_id': None,
+                'title': 'asdf',
+                'content': 'asdf',
+                'team_id': None,
+                'user': None,
+                'team': None,
+                'date': '2019-01-28T01:20:46.017649+00:00',
+                'id': 10
+            }
+
+            event_manager = RedisEventManager()
+            count = event_manager.publish(data=saved_data, type='notification', channel='ctf')
+            assert count == 1
+        destroy_ctfd(app)
+    except ConnectionError:
+        print("Failed to connect to redis. Skipping test.")

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -1,5 +1,6 @@
 from tests.helpers import create_ctfd, destroy_ctfd
 from CTFd.utils.events import ServerSentEvent, EventManager
+from CTFd.utils import text_type
 from mock import patch
 from six.moves.queue import Queue
 from collections import defaultdict
@@ -30,14 +31,11 @@ def test_event_manager_subscription():
             'data': saved_data
         }
 
-        saved_event_string = 'event:notification\n'\
-                             'data:{"content": "asdf", "team_id": null, "user_id": null, "user": null, "title": "asdf", "date": "2019-01-28T01:20:46.017649+00:00", "team": null, "id": 10}\n\n'
-
         fake_queue.return_value = saved_event
         event_manager = EventManager()
         for message in event_manager.subscribe():
             assert message.to_dict() == saved_event
-            assert str(message) == saved_event_string
+            assert message.__str__().startswith('event:notification\ndata:')
             assert len(event_manager.clients) == 1
             break
 


### PR DESCRIPTION
* Remove Flask-SocketIO in favor of custom Server Side Events code (#852)
* Remove `SOCKETIO_ASYNC_MODE` config
* Allow `create_ctfd()` test helper to take app configuration as an argument