### PR TITLE
Fix for overflowing content preventing edit and deletion in admin panel

### DIFF
--- a/CTFd/themes/admin/static/css/base.css
+++ b/CTFd/themes/admin/static/css/base.css
@@ -182,3 +182,10 @@ pre {
     -moz-border-radius: 0 !important;
     border-radius: 0 !important;
 }
+
+.text-break {
+    /* TODO: This is .text-break cloned from Bootstrap 4.3 with a fix for browsers not supporting break-word. Remove later. */
+    word-break: break-all !important;
+    word-break: break-word !important;
+    overflow-wrap: break-word !important;
+}

--- a/CTFd/themes/admin/templates/modals/challenges/flags.html
+++ b/CTFd/themes/admin/templates/modals/challenges/flags.html
@@ -10,7 +10,7 @@
 	{% for flag in flags %}
 		<tr name="{{ flag.id }}">
 			<td class="text-center">{{ flag.type }}</td>
-			<td>
+			<td class="text-break">
 				<pre class="flag-content">{{ flag.content }}</pre>
 			</td>
 			<td class="text-center">

--- a/CTFd/themes/admin/templates/modals/challenges/hints.html
+++ b/CTFd/themes/admin/templates/modals/challenges/hints.html
@@ -11,7 +11,7 @@
 	{% for hint in challenge.hints %}
 		<tr>
 			<td class="text-center">{{ hint.type }}</td>
-			<td class=""><pre>{{ hint.content }}</pre></td>
+			<td class="text-break"><pre>{{ hint.content }}</pre></td>
 			<td class="text-center">{{ hint.cost }}</td>
 			<td class="text-center">
 				<i role='button' class='btn-fa fas fa-edit edit-hint' hint-id="{{ hint.id }}"></i>


### PR DESCRIPTION
* Closes #876
* Fixes overflowing admin panel content by adding the `.text-break` CSS class.
    * This is .text-break cloned from Bootstrap 4.3 with a fix for browsers not supporting break-word. It will be removed from the main CTFd classes when Bootstrap is upgraded internally. 