### PR TITLE
Add Flask-Profiler to development requirements. Add a --profile optio…

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -11,3 +11,4 @@ psycopg2-binary==2.7.5
 codecov==2.0.15
 moto==1.3.7
 bandit==1.5.1
+flask_profiler==1.8.1

--- a/serve.py
+++ b/serve.py
@@ -1,4 +1,24 @@
 from CTFd import create_app
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--profile", help="Enable flask_profiler profiling", action="store_true")
+args = parser.parse_args()
 
 app = create_app()
+
+if args.profile:
+    import flask_profiler
+    app.config["flask_profiler"] = {
+        "enabled": app.config["DEBUG"],
+        "storage": {
+            "engine": "sqlite"
+        },
+        "basicAuth": {
+            "enabled": False,
+        },
+    }
+    flask_profiler.init_app(app)
+    print(" * Flask profiling running at http://127.0.0.1:4000/flask-profiler/")
+
 app.run(debug=True, threaded=True, host="127.0.0.1", port=4000)


### PR DESCRIPTION
* Adds `Flask-Profiler` to development requirements
* Adds `--profile` option to `serve.py` to enable the profile page running at `http://127.0.0.1:4000/flask-profiler/`