### PR TITLE
Fix email confirmation log line

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -48,7 +48,7 @@ def confirm(data=None):
 
         user = Users.query.filter_by(email=user_email).first_or_404()
         user.verified = True
-        log('registrations', format="[{date}] {ip} -  successful password reset for {name}")
+        log('registrations', format="[{date}] {ip} - successful confirmation for {name}", name=user.name)
         db.session.commit()
         db.session.close()
         if current_user.authed():


### PR DESCRIPTION
It looks like this log output was copied and pasted from the reset password route. Also, the `{name}` format specifier resolves to `None` in cases where the user is not logged in (`session.get('name')` is None), but confirms the CTFd email.

Before:
```
[03/16/2019 18:59:30] x.x.x.x -  successful password reset for None
```
After:
```
[03/16/2019 19:10:39] x.x.x.x - successful confirmation for Test Team
```
