### PR TITLE
Read smtp server configuration from config.py

### DIFF
--- a/CTFd/utils/email/smtp.py
+++ b/CTFd/utils/email/smtp.py
@@ -22,8 +22,8 @@ def sendmail(addr, text):
     ctf_name = get_config('ctf_name')
     mailfrom_addr = get_config('mailfrom_addr') or get_app_config('MAILFROM_ADDR')
     data = {
-        'host': get_config('mail_server'),
-        'port': int(get_config('mail_port'))
+        'host': get_config('mail_server') or get_app_config('MAIL_SERVER'),
+        'port': int(get_config('mail_port') or get_app_config('MAIL_PORT'))
     }
     username = get_config('mail_username') or get_app_config('MAIL_USERNAME')
     password = get_config('mail_password') or get_app_config('MAIL_PASSWORD')


### PR DESCRIPTION
The CTFd/utils/email/smtp.py file has a provision to read SMTP
configuration for all fields from either the UI or CTFd/config.py file.
Two fields, `MAIL_SERVER` and `MAIL_PORT`, were not being read from the
config.py file. This commit fixes this issue.