### PR TITLE
Return 404 error when viewing hidden/banned users

### DIFF
--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -32,7 +32,7 @@ users_namespace = Namespace('users', description="Endpoint to retrieve Users")
 class UserList(Resource):
     @check_account_visibility
     def get(self):
-        users = Users.query.filter_by(banned=False)
+        users = Users.query.filter_by(banned=False, hidden=False)
         response = UserSchema(view='user', many=True).dump(users)
 
         if response.errors:
@@ -76,7 +76,7 @@ class UserList(Resource):
 class UserPublic(Resource):
     @check_account_visibility
     def get(self, user_id):
-        user = Users.query.filter_by(id=user_id).first_or_404()
+        user = Users.query.filter_by(id=user_id, hidden=False, banned=False).first_or_404()
 
         response = UserSchema(
             view=session.get('type', 'user')
@@ -190,7 +190,7 @@ class UserSolves(Resource):
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
-            user = Users.query.filter_by(id=user_id).first_or_404()
+            user = Users.query.filter_by(id=user_id, banned=False, hidden=False).first_or_404()
 
         solves = user.get_solves(
             admin=is_admin()
@@ -224,7 +224,7 @@ class UserFails(Resource):
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
-            user = Users.query.filter_by(id=user_id).first_or_404()
+            user = Users.query.filter_by(id=user_id, banned=False, hidden=False).first_or_404()
 
         fails = user.get_fails(
             admin=is_admin()
@@ -264,7 +264,7 @@ class UserAwards(Resource):
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
-            user = Users.query.filter_by(id=user_id).first_or_404()
+            user = Users.query.filter_by(id=user_id, banned=False, hidden=False).first_or_404()
 
         awards = user.get_awards(
             admin=is_admin()

--- a/CTFd/users.py
+++ b/CTFd/users.py
@@ -58,5 +58,5 @@ def private():
 @check_account_visibility
 @check_score_visibility
 def public(user_id):
-    user = Users.query.filter_by(id=user_id).first_or_404()
+    user = Users.query.filter_by(id=user_id, banned=False, hidden=False).first_or_404()
     return render_template('users/user.html', user=user)


### PR DESCRIPTION
Users marked as hidden (such as admins when testing challenges) are not fully hidden. It is still possible to view their user profile and even see challenges that this user has solved before the competition has started. This PR fixes this by returning a 404 Not Found error upon trying to view anything about hidden users, even via the API.