### PR TITLE
Properly hide users/teams if they are set to banned/hidden

### DIFF
--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -80,7 +80,7 @@ class TeamPublic(Resource):
     def get(self, team_id):
         team = Teams.query.filter_by(id=team_id).first_or_404()
 
-        if team.banned or team.hidden and is_admin() is False:
+        if (team.banned or team.hidden) and is_admin() is False:
             abort(404)
 
         view = TeamSchema.views.get(session.get('type', 'user'))
@@ -199,7 +199,7 @@ class TeamSolves(Resource):
                 abort(404)
             team = Teams.query.filter_by(id=team_id).first_or_404()
 
-            if team.banned or team.hidden and is_admin() is False:
+            if (team.banned or team.hidden) and is_admin() is False:
                 abort(404)
 
         solves = team.get_solves(
@@ -236,7 +236,7 @@ class TeamFails(Resource):
                 abort(404)
             team = Teams.query.filter_by(id=team_id).first_or_404()
 
-            if team.banned or team.hidden and is_admin() is False:
+            if (team.banned or team.hidden) and is_admin() is False:
                 abort(404)
 
         fails = team.get_fails(
@@ -283,7 +283,7 @@ class TeamAwards(Resource):
                 abort(404)
             team = Teams.query.filter_by(id=team_id).first_or_404()
 
-            if team.banned or team.hidden and is_admin() is False:
+            if (team.banned or team.hidden) and is_admin() is False:
                 abort(404)
 
         awards = team.get_awards(

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -80,6 +80,9 @@ class TeamPublic(Resource):
     def get(self, team_id):
         team = Teams.query.filter_by(id=team_id).first_or_404()
 
+        if team.banned or team.hidden and is_admin() is False:
+            abort(404)
+
         view = TeamSchema.views.get(session.get('type', 'user'))
         schema = TeamSchema(view=view)
         response = schema.dump(team)
@@ -196,6 +199,9 @@ class TeamSolves(Resource):
                 abort(404)
             team = Teams.query.filter_by(id=team_id).first_or_404()
 
+            if team.banned or team.hidden and is_admin() is False:
+                abort(404)
+
         solves = team.get_solves(
             admin=is_admin()
         )
@@ -229,6 +235,9 @@ class TeamFails(Resource):
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
             team = Teams.query.filter_by(id=team_id).first_or_404()
+
+            if team.banned or team.hidden and is_admin() is False:
+                abort(404)
 
         fails = team.get_fails(
             admin=is_admin()
@@ -273,6 +282,9 @@ class TeamAwards(Resource):
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
             team = Teams.query.filter_by(id=team_id).first_or_404()
+
+            if team.banned or team.hidden and is_admin() is False:
+                abort(404)
 
         awards = team.get_awards(
             admin=is_admin()

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -78,7 +78,7 @@ class UserPublic(Resource):
     def get(self, user_id):
         user = Users.query.filter_by(id=user_id).first_or_404()
 
-        if user.banned or user.hidden and is_admin() is False:
+        if (user.banned or user.hidden) and is_admin() is False:
             abort(404)
 
         response = UserSchema(
@@ -195,7 +195,7 @@ class UserSolves(Resource):
                 abort(404)
             user = Users.query.filter_by(id=user_id).first_or_404()
 
-            if user.banned or user.hidden and is_admin() is False:
+            if (user.banned or user.hidden) and is_admin() is False:
                 abort(404)
 
         solves = user.get_solves(
@@ -232,7 +232,7 @@ class UserFails(Resource):
                 abort(404)
             user = Users.query.filter_by(id=user_id).first_or_404()
 
-            if user.banned or user.hidden and is_admin() is False:
+            if (user.banned or user.hidden) and is_admin() is False:
                 abort(404)
 
         fails = user.get_fails(
@@ -275,7 +275,7 @@ class UserAwards(Resource):
                 abort(404)
             user = Users.query.filter_by(id=user_id).first_or_404()
 
-            if user.banned or user.hidden and is_admin() is False:
+            if (user.banned or user.hidden) and is_admin() is False:
                 abort(404)
 
         awards = user.get_awards(

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -32,7 +32,7 @@ users_namespace = Namespace('users', description="Endpoint to retrieve Users")
 class UserList(Resource):
     @check_account_visibility
     def get(self):
-        users = Users.query.filter_by(banned=False)
+        users = Users.query.filter_by(banned=False, hidden=False)
         response = UserSchema(view='user', many=True).dump(users)
 
         if response.errors:
@@ -77,6 +77,9 @@ class UserPublic(Resource):
     @check_account_visibility
     def get(self, user_id):
         user = Users.query.filter_by(id=user_id).first_or_404()
+
+        if user.banned or user.hidden and is_admin() is False:
+            abort(404)
 
         response = UserSchema(
             view=session.get('type', 'user')
@@ -192,6 +195,9 @@ class UserSolves(Resource):
                 abort(404)
             user = Users.query.filter_by(id=user_id).first_or_404()
 
+            if user.banned or user.hidden and is_admin() is False:
+                abort(404)
+
         solves = user.get_solves(
             admin=is_admin()
         )
@@ -225,6 +231,9 @@ class UserFails(Resource):
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
             user = Users.query.filter_by(id=user_id).first_or_404()
+
+            if user.banned or user.hidden and is_admin() is False:
+                abort(404)
 
         fails = user.get_fails(
             admin=is_admin()
@@ -265,6 +274,9 @@ class UserAwards(Resource):
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
             user = Users.query.filter_by(id=user_id).first_or_404()
+
+            if user.banned or user.hidden and is_admin() is False:
+                abort(404)
 
         awards = user.get_awards(
             admin=is_admin()

--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -128,7 +128,7 @@ def private():
 @require_team_mode
 def public(team_id):
     errors = get_errors()
-    team = Teams.query.filter_by(id=team_id).first_or_404()
+    team = Teams.query.filter_by(id=team_id, banned=False, hidden=False).first_or_404()
     solves = team.get_solves()
     awards = team.get_awards()
 

--- a/CTFd/users.py
+++ b/CTFd/users.py
@@ -58,5 +58,5 @@ def private():
 @check_account_visibility
 @check_score_visibility
 def public(user_id):
-    user = Users.query.filter_by(id=user_id).first_or_404()
+    user = Users.query.filter_by(id=user_id, banned=False, hidden=False).first_or_404()
     return render_template('users/user.html', user=user)

--- a/tests/api/v1/test_teams.py
+++ b/tests/api/v1/test_teams.py
@@ -447,13 +447,13 @@ def test_api_accessing_hidden_banned_users():
         register_user(app, name="visible_user", email="visible_user@ctfd.io")
 
         user = Users.query.filter_by(id=2).first()
-        team = gen_team(app.db, name='hidden_team', hidden=True)
+        team = gen_team(app.db, name='hidden_team', email="hidden_team@ctfd.io", hidden=True)
         team.members.append(user)
         user.team_id = team.id
         app.db.session.commit()
 
         user = Users.query.filter_by(id=3).first()
-        team = gen_team(app.db, name='banned_team', hidden=True)
+        team = gen_team(app.db, name='banned_team', email="banned_team@ctfd.io", banned=True)
         team.members.append(user)
         user.team_id = team.id
         app.db.session.commit()

--- a/tests/api/v1/test_teams.py
+++ b/tests/api/v1/test_teams.py
@@ -436,3 +436,47 @@ def test_api_team_get_awards():
             print(r.get_json())
             assert r.status_code == 200
     destroy_ctfd(app)
+
+
+def test_api_accessing_hidden_banned_users():
+    """Hidden/Banned users should not be visible to normal users, only to admins"""
+    app = create_ctfd(user_mode="teams")
+    with app.app_context():
+        register_user(app)
+        register_user(app, name="user2", email="user2@ctfd.io")
+        register_user(app, name="visible_user", email="visible_user@ctfd.io")
+
+        user = Users.query.filter_by(id=2).first()
+        team = gen_team(app.db, name='hidden_team', hidden=True)
+        team.members.append(user)
+        user.team_id = team.id
+        app.db.session.commit()
+
+        user = Users.query.filter_by(id=3).first()
+        team = gen_team(app.db, name='banned_team', hidden=True)
+        team.members.append(user)
+        user.team_id = team.id
+        app.db.session.commit()
+
+        with login_as_user(app, name="visible_user") as client:
+            assert client.get('/api/v1/teams/1').status_code == 404
+            assert client.get('/api/v1/teams/1/solves').status_code == 404
+            assert client.get('/api/v1/teams/1/fails').status_code == 404
+            assert client.get('/api/v1/teams/1/awards').status_code == 404
+
+            assert client.get('/api/v1/teams/2').status_code == 404
+            assert client.get('/api/v1/teams/2/solves').status_code == 404
+            assert client.get('/api/v1/teams/2/fails').status_code == 404
+            assert client.get('/api/v1/teams/2/awards').status_code == 404
+
+        with login_as_user(app, name="admin") as client:
+            assert client.get('/api/v1/teams/1').status_code == 200
+            assert client.get('/api/v1/teams/1/solves').status_code == 200
+            assert client.get('/api/v1/teams/1/fails').status_code == 200
+            assert client.get('/api/v1/teams/1/awards').status_code == 200
+
+            assert client.get('/api/v1/teams/2').status_code == 200
+            assert client.get('/api/v1/teams/2/solves').status_code == 200
+            assert client.get('/api/v1/teams/2/fails').status_code == 200
+            assert client.get('/api/v1/teams/2/awards').status_code == 200
+    destroy_ctfd(app)

--- a/tests/users/test_submissions.py
+++ b/tests/users/test_submissions.py
@@ -29,9 +29,10 @@ def test_user_get_another_public_solves():
     """Can a registered user load public solves page of another user"""
     app = create_ctfd()
     with app.app_context():
-        register_user(app)
-        client = login_as_user(app)
-        r = client.get('/api/v1/users/1/solves')
+        register_user(app, name='user1', email='user1@ctfd.io')  # ID 2
+        register_user(app, name='user2', email='user2@ctfd.io')  # ID 3
+        client = login_as_user(app, name='user2')
+        r = client.get('/api/v1/users/2/solves')
         assert r.status_code == 200
     destroy_ctfd(app)
 
@@ -62,9 +63,10 @@ def test_user_get_another_public_fails():
     """Can a registered user load public fails page of another user"""
     app = create_ctfd()
     with app.app_context():
-        register_user(app)
-        client = login_as_user(app)
-        r = client.get('/api/v1/users/1/fails')
+        register_user(app, name='user1', email='user1@ctfd.io')  # ID 2
+        register_user(app, name='user2', email='user2@ctfd.io')  # ID 3
+        client = login_as_user(app, name="user2")
+        r = client.get('/api/v1/users/2/fails')
         assert r.status_code == 200
     destroy_ctfd(app)
 
@@ -84,9 +86,10 @@ def test_user_get_another_public_team_page():
     """Can a registered user load the public profile of another user (/users/1)"""
     app = create_ctfd()
     with app.app_context():
-        register_user(app)
-        client = login_as_user(app)
-        r = client.get('/users/1')
+        register_user(app, name='user1', email='user1@ctfd.io')  # ID 2
+        register_user(app, name='user2', email='user2@ctfd.io')  # ID 3
+        client = login_as_user(app, name='user2')
+        r = client.get('/users/2')
         assert r.status_code == 200
     destroy_ctfd(app)
 

--- a/tests/users/test_users.py
+++ b/tests/users/test_users.py
@@ -4,6 +4,35 @@
 from tests.helpers import *
 
 
+def test_accessing_hidden_users():
+    """Hidden users should not give any data from /users or /api/v1/users"""
+    app = create_ctfd()
+    with app.app_context():
+        register_user(app, name="visible_user", email="visible_user@ctfd.io")  # ID 2
+        register_user(app, name="hidden_user", email="hidden_user@ctfd.io")  # ID 3
+        register_user(app, name="banned_user", email="banned_user@ctfd.io")  # ID 4
+        user = Users.query.filter_by(name="hidden_user").first()
+        user.hidden = True
+        app.db.session.commit()
+        user = Users.query.filter_by(name="banned_user").first()
+        user.banned = True
+        app.db.session.commit()
+
+        with login_as_user(app, name="visible_user") as client:
+            assert client.get('/users/3').status_code == 404
+            assert client.get('/api/v1/users/3').status_code == 404
+            assert client.get('/api/v1/users/3/solves').status_code == 404
+            assert client.get('/api/v1/users/3/fails').status_code == 404
+            assert client.get('/api/v1/users/3/awards').status_code == 404
+
+            assert client.get('/users/4').status_code == 404
+            assert client.get('/api/v1/users/4').status_code == 404
+            assert client.get('/api/v1/users/4/solves').status_code == 404
+            assert client.get('/api/v1/users/4/fails').status_code == 404
+            assert client.get('/api/v1/users/4/awards').status_code == 404
+    destroy_ctfd(app)
+
+
 def test_hidden_user_visibility():
     """Hidden users should not show up on /users or /api/v1/users or /api/v1/scoreboard"""
     app = create_ctfd()


### PR DESCRIPTION
* Properly hide users/teams if they are set to hidden/banned
    * This should be in the API and in the main user panel. This should not affect admins. 
* Update tests to reflect this behavior. 