### PR TITLE
Update the challenge name field to required

### DIFF
--- a/CTFd/plugins/challenges/assets/create.html
+++ b/CTFd/plugins/challenges/assets/create.html
@@ -6,7 +6,7 @@
 				The name of your challenge
 			</small>
 		</label>
-		<input type="text" class="form-control" name="name" placeholder="Enter challenge name">
+		<input type="text" class="form-control" name="name" placeholder="Enter challenge name" required>
 	</div>
 
 	<div class="form-group">

--- a/CTFd/plugins/dynamic_challenges/assets/create.html
+++ b/CTFd/plugins/dynamic_challenges/assets/create.html
@@ -13,7 +13,7 @@
 				The name of your challenge
 			</small>
 		</label>
-		<input type="text" class="form-control" name="name" placeholder="Enter challenge name">
+		<input type="text" class="form-control" name="name" placeholder="Enter challenge name" required>
 	</div>
 	<div class="form-group">
 		<label for="category">Category<br>


### PR DESCRIPTION
In the `admin/challenges` page, if a challenge was created without a
name, then the only way to open the challenge is by using its ID in the
URL as `admin/challenges/<ID>` since the "Name" column contains the
link to the challenge and "Name" of a challenge is not a required
field.