### PR TITLE
Mark 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 **General**
 * Users/Teams set to hidden or banned are no longer visible by other users
-    * This affects the API and the main user interface. This does not affect admins.
-* Users without Teams can no longer view challenges when the CTF is in Team Mode
+    * This affects the API and the main user interface. This does not affect admins
+* Users without a Team can no longer view challenges when the CTF is in Team Mode
 
 2.0.5 / 2019-03-23
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2.0.6 / 2019-04-08
+==================
+
+**Security**
+* Fixes an issue where user email addresses could be disclosed to non-admins
+
+**General**
+* Users/Teams set to hidden or banned are no longer visible by other users
+* Users without Teams can no longer view challenges when the CTF is in Team Mode
+
 2.0.5 / 2019-03-23
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **General**
 * Users/Teams set to hidden or banned are no longer visible by other users
+    * This affects the API and the main user interface. This does not affect admins.
 * Users without Teams can no longer view challenges when the CTF is in Team Mode
 
 2.0.5 / 2019-03-23

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -22,7 +22,7 @@ if sys.version_info[0] < 3:
     reload(sys)
     sys.setdefaultencoding("utf-8")
 
-__version__ = '2.0.5'
+__version__ = '2.0.6'
 
 
 class CTFdRequest(Request):


### PR DESCRIPTION
2.0.6 / 2019-04-08
==================

**Security**
* Fixes an issue where user email addresses could be disclosed to non-admins

**General**
* Users/Teams set to hidden or banned are no longer visible by other users
    * This affects the API and the main user interface. This does not affect admins.
* Users without Teams can no longer view challenges when the CTF is in Team Mode