### PR TITLE
Disable native asynchronous IO for MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     networks:
         internal:
     # This command is required to set important mariadb defaults
-    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0]
+    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0, --innodb_use_native_aio=0]
 
   cache:
     image: redis:4


### PR DESCRIPTION
Running on windows hosts with docker, the database fails to initialize
as the native asynchronous IO is not supported on the host.

See https://dev.mysql.com/doc/refman/5.5/en/innodb-parameters.html#sysvar_innodb_use_native_aio