### PR TITLE
Add cache.make_key_prefix to allow us to cache and invalidate API responses

### DIFF
--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -1,6 +1,7 @@
 from flask_restplus import Namespace, Resource
 
 from CTFd.models import Solves, Awards, Teams
+from CTFd.cache import cache, make_cache_key
 from CTFd.utils.scores import get_standings
 from CTFd.utils import get_config
 from CTFd.utils.modes import TEAMS_MODE
@@ -14,6 +15,7 @@ scoreboard_namespace = Namespace('scoreboard', description="Endpoint to retrieve
 class ScoreboardList(Resource):
     @check_account_visibility
     @check_score_visibility
+    @cache.cached(timeout=60, key_prefix=make_cache_key)
     def get(self):
         standings = get_standings()
         response = []
@@ -61,6 +63,7 @@ class ScoreboardList(Resource):
 class ScoreboardDetail(Resource):
     @check_account_visibility
     @check_score_visibility
+    @cache.cached(timeout=60, key_prefix=make_cache_key)
     def get(self, count):
         response = {}
 

--- a/CTFd/api/v1/submissions.py
+++ b/CTFd/api/v1/submissions.py
@@ -90,6 +90,9 @@ class Submission(Resource):
         db.session.commit()
         db.session.close()
 
+        # Delete standings cache
+        clear_standings()
+
         return {
             'success': True
         }

--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -1,6 +1,21 @@
+from flask import request
 from flask_caching import Cache
 
 cache = Cache()
+
+
+def make_cache_key(path=None, key_prefix='view/%s'):
+    """
+    This function mostly emulates Flask-Caching's `make_cache_key` function so we can delete cached api responses.
+    Over time this function may be replaced with a cleaner custom cache implementation.
+    :param path:
+    :param key_prefix:
+    :return:
+    """
+    if path is None:
+        path = request.endpoint
+    cache_key = key_prefix % path
+    return cache_key
 
 
 def clear_config():
@@ -11,7 +26,16 @@ def clear_config():
 
 def clear_standings():
     from CTFd.utils.scores import get_standings
+    from CTFd.api.v1.scoreboard import ScoreboardDetail, ScoreboardList
+    from CTFd.api import api
     cache.delete_memoized(get_standings)
+    cache.delete(
+        make_cache_key(path=api.name + '.' + ScoreboardList.endpoint)
+    )
+    cache.delete(
+        make_cache_key(path=api.name + '.' + ScoreboardDetail.endpoint)
+    )
+    cache.delete_memoized(ScoreboardList.get)
 
 
 def clear_pages():

--- a/tests/api/v1/test_scoreboard.py
+++ b/tests/api/v1/test_scoreboard.py
@@ -7,9 +7,7 @@ from tests.helpers import (
     destroy_ctfd,
     register_user,
     login_as_user,
-    get_scores,
     gen_challenge,
-    gen_award,
     gen_flag,
     gen_solve
 )

--- a/tests/api/v1/test_scoreboard.py
+++ b/tests/api/v1/test_scoreboard.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from CTFd.cache import clear_standings
+from tests.helpers import (
+    create_ctfd,
+    destroy_ctfd,
+    register_user,
+    login_as_user,
+    get_scores,
+    gen_challenge,
+    gen_award,
+    gen_flag,
+    gen_solve
+)
+
+
+def test_scoreboard_is_cached():
+    """Test that /api/v1/scoreboard is properly cached and cleared"""
+    app = create_ctfd()
+    with app.app_context():
+        # create user1
+        register_user(app, name="user1", email="user1@ctfd.io")
+
+        # create challenge
+        chal = gen_challenge(app.db, value=100)
+        gen_flag(app.db, challenge_id=chal.id, content='flag')
+        chal_id = chal.id
+
+        # create a solve for the challenge for user1. (the id is 2 because of the admin)
+        gen_solve(app.db, user_id=2, challenge_id=chal_id)
+
+        with login_as_user(app, 'user1') as client:
+            # No cached data
+            assert app.cache.get('view/api.scoreboard_scoreboard_list') is None
+            assert app.cache.get('view/api.scoreboard_scoreboard_detail') is None
+
+            # Load and check cached data
+            client.get('/api/v1/scoreboard')
+            assert app.cache.get('view/api.scoreboard_scoreboard_list')
+            client.get('/api/v1/scoreboard/top/10')
+            assert app.cache.get('view/api.scoreboard_scoreboard_detail')
+
+            # Empty standings and check that the cached data is gone
+            clear_standings()
+            assert app.cache.get('view/api.scoreboard_scoreboard_list') is None
+            assert app.cache.get('view/api.scoreboard_scoreboard_detail') is None
+    destroy_ctfd(app)


### PR DESCRIPTION
* Cache `/api/v1/scoreboard` and `/api/v1/scoreboard/top/[count]`
* Adds `cache.make_cache_key` because Flask-Caching is unable to cleanly determine the endpoint for Flask-Restful/Restplus
    * This helper may change in a future release or be deprecated by an improvement in Flask-Caching.
* Closes #874 