### PR TITLE
Add ability to send user email for created account notification

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -214,7 +214,7 @@ class Config(object):
     REVERSE_PROXY = os.getenv("REVERSE_PROXY") or False
     TEMPLATES_AUTO_RELOAD = (not os.getenv("TEMPLATES_AUTO_RELOAD"))  # Defaults True
     SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv("SQLALCHEMY_TRACK_MODIFICATIONS") is not None  # Defaults False
-    SWAGGER_UI = os.getenv("SWAGGER_UI") is not None  # Defaults False
+    SWAGGER_UI = '/' if os.getenv("SWAGGER_UI") is not None else False  # Defaults False
     UPDATE_CHECK = (not os.getenv("UPDATE_CHECK"))  # Defaults True
     APPLICATION_ROOT = os.getenv('APPLICATION_ROOT') or '/'
 

--- a/CTFd/themes/admin/static/js/users/new.js
+++ b/CTFd/themes/admin/static/js/users/new.js
@@ -2,8 +2,13 @@ $(document).ready(function () {
     $('#user-info-form').submit(function (e) {
         e.preventDefault();
         var params = $('#user-info-form').serializeJSON(true);
+        var url = '/api/v1/users';
+        if (params.notify) {
+            url += '?notify=true'
+        }
+        delete params.notify;
 
-        CTFd.fetch('/api/v1/users', {
+        CTFd.fetch(url, {
             method: 'POST',
             credentials: 'same-origin',
             headers: {

--- a/CTFd/themes/admin/templates/modals/users/edit.html
+++ b/CTFd/themes/admin/templates/modals/users/edit.html
@@ -60,16 +60,6 @@
 			<label class="form-check-label" for="banned-checkbox">Banned</label>
 		</div>
 	</div>
-
-	{% if can_send_mail() %}
-	<div class="form-group">
-		<div class="form-check form-check-inline">
-			<input class="form-check-input" type="checkbox" name="notify" id="notify-checkbox" checked>
-			<label class="form-check-label" for="notify-checkbox">Email account credentials to user</label>
-		</div>
-	</div>
-	{% endif %}
-
 	<div id="results">
 	</div>
 	<button id="update-user" type="submit" class="btn btn-primary btn-outlined float-right modal-action">

--- a/CTFd/themes/admin/templates/users/user.html
+++ b/CTFd/themes/admin/templates/users/user.html
@@ -14,7 +14,7 @@
 				</button>
 			</div>
 			<div class="modal-body clearfix">
-				{% include "admin/modals/users/create.html" %}
+				{% include "admin/modals/users/edit.html" %}
 			</div>
 		</div>
 	</div>

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -26,7 +26,7 @@ def forgot_password(email, team_name):
 
 """.format(url_for('auth.reset_password', _external=True), token)
 
-    sendmail(email, text)
+    return sendmail(email, text)
 
 
 def verify_email_address(addr):
@@ -36,7 +36,17 @@ def verify_email_address(addr):
         url=url_for('auth.confirm', _external=True),
         token=token
     )
-    sendmail(addr, text)
+    return sendmail(addr, text)
+
+
+def user_created_notification(addr, name, password):
+    text = """An account has been created for you for {ctf_name} at {url}. \n\nUsername: {name}\nPassword: {password}""".format(
+        ctf_name=get_config('ctf_name'),
+        url=url_for('views.static_html', _external=True),
+        name=name,
+        password=password,
+    )
+    return sendmail(addr, text)
 
 
 def check_email_format(email):


### PR DESCRIPTION
* Add `/api/v1/users?notify=true` to email user & password after creating new account. 
* Separate `admin/templates/modals/users/create.html` into `admin/templates/modals/users/edit.html`
* Return result of email wrapper functions in `CTFd.utils.email`
* SWAGGER_UI config.py setting to properly default to `/`