### PR TITLE
Speed up testing with parallelization 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ install:
 before_script:
     - psql -c 'create database ctfd;' -U postgres
 script:
-    - flake8 --ignore=E402,E501,E712 CTFd/ tests/
-    - pytest --disable-warnings
-    - bandit -r CTFd
+    - make lint
+    - make test
 after_success:
     - codecov

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ lint:
 	flake8 --ignore=E402,E501,E712 CTFd/ tests/
 
 test:
-	echo Running on `python -c 'import multiprocessing as m; print(m.cpu_count())'` cores
-	pytest --disable-warnings -n `python -c 'import multiprocessing as m; print(m.cpu_count())'`
+	pytest --disable-warnings -n auto
 	bandit -r CTFd -x CTFd/uploads
 
 serve:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ lint:
 	flake8 --ignore=E402,E501,E712 CTFd/ tests/
 
 test:
-	pytest --disable-warnings
+	echo Running on `python -c 'import multiprocessing as m; print(m.cpu_count())'` cores
+	pytest --disable-warnings -n `python -c 'import multiprocessing as m; print(m.cpu_count())'`
 	bandit -r CTFd -x CTFd/uploads
 
 serve:

--- a/development.txt
+++ b/development.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==4.2.1
+pytest==4.4.0
 pytest-randomly==1.2.3
 coverage==4.5.2
 mock==2.0.0

--- a/development.txt
+++ b/development.txt
@@ -11,3 +11,4 @@ codecov==2.0.15
 moto==1.3.7
 bandit==1.5.1
 flask_profiler==1.8.1
+pytest-xdist==1.28.0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -72,7 +72,6 @@ def create_ctfd(ctf_name="CTFd",
     if url.database:
         url.database = str(uuid.uuid4())
     config.SQLALCHEMY_DATABASE_URI = str(url)
-    print config.SQLALCHEMY_DATABASE_URI
 
     app = create_app(config)
     app.test_client_class = CTFdTestClient

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,10 +22,12 @@ from CTFd.cache import cache
 from sqlalchemy_utils import drop_database
 from collections import namedtuple
 from mock import Mock, patch
+from sqlalchemy.engine.url import make_url
 import datetime
 import six
 import gc
 import requests
+import uuid
 
 if six.PY2:
     text_type = unicode  # noqa: F821
@@ -66,6 +68,11 @@ def create_ctfd(ctf_name="CTFd",
         config.SAFE_MODE = True
 
     config.APPLICATION_ROOT = application_root
+    url = make_url(config.SQLALCHEMY_DATABASE_URI)
+    if url.database:
+        url.database = str(uuid.uuid4())
+    config.SQLALCHEMY_DATABASE_URI = str(url)
+    print config.SQLALCHEMY_DATABASE_URI
 
     app = create_app(config)
     app.test_client_class = CTFdTestClient

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -7,6 +7,7 @@ from flask import url_for
 from tests.helpers import create_ctfd, destroy_ctfd, register_user, \
     login_as_user, gen_challenge, gen_file, gen_page
 from CTFd.utils import set_config
+from CTFd.utils.encoding import hexencode
 from freezegun import freeze_time
 
 
@@ -203,7 +204,9 @@ def test_user_can_access_files_with_auth_token():
         chal_id = chal.id
         path = app.config.get('UPLOAD_FOLDER')
 
-        location = os.path.join(path, 'test_file_path', 'test.txt')
+        md5hash = hexencode(os.urandom(16)).decode('utf-8')
+
+        location = os.path.join(path, md5hash, 'test.txt')
         directory = os.path.dirname(location)
         model_path = os.path.join('test_file_path', 'test.txt')
 

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -208,7 +208,7 @@ def test_user_can_access_files_with_auth_token():
 
         location = os.path.join(path, md5hash, 'test.txt')
         directory = os.path.dirname(location)
-        model_path = os.path.join('test_file_path', 'test.txt')
+        model_path = os.path.join(md5hash, 'test.txt')
 
         try:
             os.makedirs(directory)


### PR DESCRIPTION
* Make tests run in parallel with `pytest-xdist`
    * When using a non-memory database, test helpers will now randomize the database so that tests can run in parallel
* Upgrade to `pytest` 4.4.0