### PR TITLE
Fix logging without root in container

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -35,6 +35,7 @@ from sqlalchemy.exc import InvalidRequestError, IntegrityError
 import datetime
 import logging
 import os
+import sys
 
 
 def init_template_filters(app):
@@ -89,18 +90,33 @@ def init_logs(app):
         if not os.path.exists(log):
             open(log, 'a').close()
 
-    submission_log = logging.handlers.RotatingFileHandler(logs['submissions'], maxBytes=10000)
-    login_log = logging.handlers.RotatingFileHandler(logs['logins'], maxBytes=10000)
-    registration_log = logging.handlers.RotatingFileHandler(logs['registrations'], maxBytes=10000)
+    try:
+        submission_log = logging.handlers.RotatingFileHandler(logs['submissions'], maxBytes=10000)
+        login_log = logging.handlers.RotatingFileHandler(logs['logins'], maxBytes=10000)
+        registration_log = logging.handlers.RotatingFileHandler(logs['registrations'], maxBytes=10000)
+
+        logger_submissions.addHandler(
+            submission_log
+        )
+        logger_logins.addHandler(
+            login_log
+        )
+        logger_registrations.addHandler(
+            registration_log
+        )
+    except IOError:
+        pass
+
+    stdout = logging.StreamHandler(stream=sys.stdout)
 
     logger_submissions.addHandler(
-        submission_log
+        stdout
     )
     logger_logins.addHandler(
-        login_log
+        stdout
     )
     logger_registrations.addHandler(
-        registration_log
+        stdout
     )
 
     logger_submissions.propagate = 0

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -86,11 +86,11 @@ def init_logs(app):
         'registrations': os.path.join(log_dir, 'registrations.log')
     }
 
-    for log in logs.values():
-        if not os.path.exists(log):
-            open(log, 'a').close()
-
     try:
+        for log in logs.values():
+            if not os.path.exists(log):
+                open(log, 'a').close()
+
         submission_log = logging.handlers.RotatingFileHandler(logs['submissions'], maxBytes=10000)
         login_log = logging.handlers.RotatingFileHandler(logs['logins'], maxBytes=10000)
         registration_log = logging.handlers.RotatingFileHandler(logs['registrations'], maxBytes=10000)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && \
 RUN adduser -D -u 1001 -s /bin/bash ctfd
 
 WORKDIR /opt/CTFd
-RUN mkdir -p /opt/CTFd
+RUN mkdir -p /opt/CTFd /var/log/CTFd /var/uploads
 
 COPY requirements.txt .
 
@@ -20,6 +20,7 @@ RUN for d in CTFd/plugins/*; do \
 
 RUN chmod +x /opt/CTFd/docker-entrypoint.sh
 RUN chown -R 1001:1001 /opt/CTFd
+RUN chown -R 1001:1001 /var/log/CTFd /var/uploads
 
 USER 1001
 EXPOSE 8000


### PR DESCRIPTION
* Catch IOError issues (i.e. permission issues) with writing to log files
    * Related to #844
* Logs now have a sys.stdout handler
* Update Dockerfile to create and chown/chmod the folders used by `docker-compose` to store files/logs (`/var/log/CTFd`, `/var/uploads`)
* Closes #961