### PR TITLE
Reduce default gunicorn worker count to reduce memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@
 * Update Dockerfile to create and chown/chmod the folders used by `docker-compose` to store files/logs (`/var/log/CTFd`, `/var/uploads`)
     * This allows the container to write to the folder despite it being a volume mounted from the host
 * Default worker changed back to `gevent`
-* Worker count set to 4 and document updated to reflect that you must set a `SECRET_KEY`
 * Removed Flask-SocketIO dependency
     * Removed the `SOCKETIO_ASYNC_MODE` config
 * `gevent` is now required to allow the Server Sent Events client polling code to work

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ You can use the auto-generated Docker images with the following command:
 `docker run -p 8000:8000 -it ctfd/ctfd`
 
 Or you can use Docker Compose with the following command from the source repository:
-  1. Specify a random `SECRET_KEY` environment variable value in `docker-compose.yml`
-  2. Run `docker-compose up`
+
+`docker-compose up`
 
 Check out the [wiki](https://github.com/CTFd/CTFd/wiki) for [deployment options](https://github.com/CTFd/CTFd/wiki/Basic-Deployment) and the [Getting Started](https://github.com/CTFd/CTFd/wiki/Getting-Started) guide
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - UPLOAD_FOLDER=/var/uploads
       - DATABASE_URL=mysql+pymysql://root:ctfd@db/ctfd
       - REDIS_URL=redis://cache:6379
-      - WORKERS=4
+      - WORKERS=1
       - LOG_FOLDER=/var/log/CTFd
       - ACCESS_LOG=-
       - ERROR_LOG=-

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eo pipefail
 
-WORKERS=${WORKERS:-4}
+WORKERS=${WORKERS:-1}
 WORKER_CLASS=${WORKER_CLASS:-gevent}
 ACCESS_LOG=${ACCESS_LOG:--}
 ERROR_LOG=${ERROR_LOG:--}


### PR DESCRIPTION
Drop the default worker count in `docker-entrypoint.sh` because the default memory usage was higher than it needed to be. If you need more workers you can still increase the values and set a `SECRET_KEY` as before. 