### PR TITLE
Fix challenge preview for admins

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -65,8 +65,11 @@ class ChallengeList(Resource):
             solve_ids = set([value for value, in solve_ids])
 
             # TODO: Convert this into a re-useable decorator
-            if config.is_teams_mode() and get_current_team() is None:
-                abort(403)
+            if is_admin():
+                pass
+            else:
+                if config.is_teams_mode() and get_current_team() is None:
+                    abort(403)
         else:
             solve_ids = set()
 
@@ -211,8 +214,11 @@ class Challenge(Resource):
             team = get_current_team()
 
             # TODO: Convert this into a re-useable decorator
-            if config.is_teams_mode() and team is None:
-                abort(403)
+            if is_admin():
+                pass
+            else:
+                if config.is_teams_mode() and team is None:
+                    abort(403)
 
             unlocked_hints = set([
                 u.target for u in HintUnlocks.query.filter_by(type='hints', account_id=user.account_id)

--- a/tests/api/v1/test_challenges.py
+++ b/tests/api/v1/test_challenges.py
@@ -99,6 +99,22 @@ def test_api_challenges_post_non_admin():
     destroy_ctfd(app)
 
 
+def test_api_challenges_get_admin():
+    """Can a user GET /api/v1/challenges if admin without team"""
+    app = create_ctfd(user_mode="teams")
+    with app.app_context():
+        gen_challenge(app.db)
+        # Admin does not have a team but should still be able to see challenges
+        user = Users.query.filter_by(id=1).first()
+        assert user.team_id is None
+        with login_as_user(app, 'admin') as admin:
+            r = admin.get('/api/v1/challenges', json="")
+            assert r.status_code == 200
+            r = admin.get('/api/v1/challenges/1', json="")
+            assert r.status_code == 200
+    destroy_ctfd(app)
+
+
 def test_api_challenges_post_admin():
     """Can a user post /api/v1/challenges if admin"""
     app = create_ctfd()


### PR DESCRIPTION
* Allow admins to hit `/api/v1/challenges` and `/api/v1/challenges/[id]` without having a team