### PR TITLE
Run as root when using docker-compose to be able to write to the volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   ctfd:
     build: .
+    user: root
     restart: always
     ports:
       - "8000:8000"


### PR DESCRIPTION
* Docker Compose needs to be run as root to be able to write to the bind mounted volumes. 