### PR TITLE
Fix freeze time regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ target/
 *.db
 *.log
 .idea/
+.vscode/
 CTFd/static/uploads
 CTFd/uploads
 .data/

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -38,6 +38,7 @@ from CTFd.utils.dates import ctf_ended, ctf_paused, ctftime
 from CTFd.utils.logging import log
 from CTFd.utils.security.signing import serialize
 from sqlalchemy.sql import and_
+import datetime
 
 challenges_namespace = Namespace('challenges',
                                  description="Endpoint to retrieve Challenges")
@@ -522,6 +523,13 @@ class ChallengeSolves(Resource):
         solves = Solves.query.join(Model, Solves.account_id == Model.id)\
             .filter(Solves.challenge_id == challenge_id, Model.banned == False, Model.hidden == False)\
             .order_by(Solves.date.asc())
+
+        freeze = get_config('freeze')
+        if freeze:
+            preview = request.args.get('preview')
+            if (is_admin() is False) or (is_admin() is True and preview):
+                dt = datetime.datetime.utcfromtimestamp(freeze)
+                solves = solves.filter(Solves.date < dt)
 
         endpoint = None
         if get_config('user_mode') == TEAMS_MODE:

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -304,6 +304,7 @@ class TeamSolves(Resource):
             if not authed():
                 abort(403)
             team = get_current_team()
+            solves = team.get_solves(admin=True)
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
@@ -311,10 +312,7 @@ class TeamSolves(Resource):
 
             if (team.banned or team.hidden) and is_admin() is False:
                 abort(404)
-
-        solves = team.get_solves(
-            admin=is_admin()
-        )
+            solves = team.get_solves(admin=is_admin())
 
         view = 'admin' if is_admin() else 'user'
         schema = SubmissionSchema(view=view, many=True)
@@ -341,6 +339,7 @@ class TeamFails(Resource):
             if not authed():
                 abort(403)
             team = get_current_team()
+            fails = team.get_fails(admin=True)
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
@@ -348,10 +347,7 @@ class TeamFails(Resource):
 
             if (team.banned or team.hidden) and is_admin() is False:
                 abort(404)
-
-        fails = team.get_fails(
-            admin=is_admin()
-        )
+            fails = team.get_fails(admin=is_admin())
 
         view = 'admin' if is_admin() else 'user'
 
@@ -388,6 +384,7 @@ class TeamAwards(Resource):
             if not authed():
                 abort(403)
             team = get_current_team()
+            awards = team.get_awards(admin=True)
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
@@ -395,10 +392,7 @@ class TeamAwards(Resource):
 
             if (team.banned or team.hidden) and is_admin() is False:
                 abort(404)
-
-        awards = team.get_awards(
-            admin=is_admin()
-        )
+            awards = team.get_awards(admin=is_admin())
 
         schema = AwardSchema(many=True)
         response = schema.dump(awards)

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -200,6 +200,7 @@ class UserSolves(Resource):
             if not authed():
                 abort(403)
             user = get_current_user()
+            solves = user.get_solves(admin=True)
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
@@ -207,12 +208,7 @@ class UserSolves(Resource):
 
             if (user.banned or user.hidden) and is_admin() is False:
                 abort(404)
-
-        solves = user.get_solves(
-            admin=is_admin()
-        )
-        for solve in solves:
-            setattr(solve, 'value', 100)
+            solves = user.get_solves(admin=is_admin())
 
         view = 'user' if not is_admin() else 'admin'
         response = SubmissionSchema(view=view, many=True).dump(solves)
@@ -237,6 +233,7 @@ class UserFails(Resource):
             if not authed():
                 abort(403)
             user = get_current_user()
+            fails = user.get_fails(admin=True)
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
@@ -244,10 +241,7 @@ class UserFails(Resource):
 
             if (user.banned or user.hidden) and is_admin() is False:
                 abort(404)
-
-        fails = user.get_fails(
-            admin=is_admin()
-        )
+            fails = user.get_fails(admin=is_admin())
 
         view = 'user' if not is_admin() else 'admin'
         response = SubmissionSchema(view=view, many=True).dump(fails)
@@ -280,6 +274,7 @@ class UserAwards(Resource):
             if not authed():
                 abort(403)
             user = get_current_user()
+            awards = user.get_awards(admin=True)
         else:
             if accounts_visible() is False or scores_visible() is False:
                 abort(404)
@@ -287,10 +282,7 @@ class UserAwards(Resource):
 
             if (user.banned or user.hidden) and is_admin() is False:
                 abort(404)
-
-        awards = user.get_awards(
-            admin=is_admin()
-        )
+            awards = user.get_awards(admin=is_admin())
 
         view = 'user' if not is_admin() else 'admin'
         response = AwardSchema(view=view, many=True).dump(awards)

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -310,7 +310,7 @@ class Users(db.Model):
         freeze = get_config('freeze')
         if freeze and admin is False:
             dt = datetime.datetime.utcfromtimestamp(freeze)
-            fails = fails.filter(Solves.date < dt)
+            fails = fails.filter(Fails.date < dt)
         return fails.all()
 
     def get_awards(self, admin=False):
@@ -318,7 +318,7 @@ class Users(db.Model):
         freeze = get_config('freeze')
         if freeze and admin is False:
             dt = datetime.datetime.utcfromtimestamp(freeze)
-            awards = awards.filter(Solves.date < dt)
+            awards = awards.filter(Awards.date < dt)
         return awards.all()
 
     def get_score(self, admin=False):
@@ -513,7 +513,7 @@ class Teams(db.Model):
         freeze = get_config('freeze')
         if freeze and admin is False:
             dt = datetime.datetime.utcfromtimestamp(freeze)
-            fails = fails.filter(Solves.date < dt)
+            fails = fails.filter(Fails.date < dt)
 
         return fails.all()
 
@@ -529,7 +529,7 @@ class Teams(db.Model):
         freeze = get_config('freeze')
         if freeze and admin is False:
             dt = datetime.datetime.utcfromtimestamp(freeze)
-            awards = awards.filter(Solves.date < dt)
+            awards = awards.filter(Awards.date < dt)
 
         return awards.all()
 

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from CTFd.models import Users
+from CTFd.models import Users, Solves, Awards, Fails
 from CTFd.utils import set_config
 from CTFd.utils.crypto import verify_password
 from CTFd.schemas.users import UserSchema
@@ -10,9 +10,14 @@ from tests.helpers import (
     destroy_ctfd,
     register_user,
     login_as_user,
+    simulate_user_activity,
+    gen_challenge,
     gen_user,
-    simulate_user_activity
+    gen_solve,
+    gen_award,
+    gen_fail,
 )
+from freezegun import freeze_time
 
 
 def test_api_users_get_public():
@@ -543,6 +548,49 @@ def test_api_user_get_solves():
     destroy_ctfd(app)
 
 
+def test_api_user_get_solves_after_freze_time():
+    """Can a user get /api/v1/users/<user_id>/solves after freeze time"""
+    app = create_ctfd(user_mode="users")
+    with app.app_context():
+        register_user(app, name="user1", email="user1@ctfd.io")
+        register_user(app, name="user2", email="user2@ctfd.io")
+
+        # Friday, October 6, 2017 12:00:00 AM GMT-04:00 DST
+        set_config('freeze', '1507262400')
+        with freeze_time("2017-10-4"):
+            chal = gen_challenge(app.db)
+            chal_id = chal.id
+            gen_solve(app.db, user_id=2, challenge_id=chal_id)
+            chal2 = gen_challenge(app.db)
+            chal2_id = chal2.id
+
+        with freeze_time("2017-10-8"):
+            chal2 = gen_solve(app.db, user_id=2, challenge_id=chal2_id)
+
+            # There should now be two solves assigned to the same user.
+            assert Solves.query.count() == 2
+
+            # User 2 should have 2 solves when seen by themselves
+            client = login_as_user(app, name="user1")
+            r = client.get('/api/v1/users/me/solves')
+            data = r.get_json()['data']
+            assert len(data) == 2
+
+            # User 2 should have 1 solve when seen by another user
+            client = login_as_user(app, name="user2")
+            r = client.get('/api/v1/users/2/solves')
+            data = r.get_json()['data']
+            assert len(data) == 1
+
+            # Admins should see all solves for the user
+            admin = login_as_user(app, name="admin")
+
+            r = admin.get('/api/v1/users/2/solves')
+            data = r.get_json()['data']
+            assert len(data) == 2
+    destroy_ctfd(app)
+
+
 def test_api_user_get_me_fails_not_logged_in():
     """Can a user get /api/v1/users/me/fails if not logged in"""
     app = create_ctfd()
@@ -575,6 +623,47 @@ def test_api_user_get_fails():
     destroy_ctfd(app)
 
 
+def test_api_user_get_fails_after_freze_time():
+    """Can a user get /api/v1/users/<user_id>/fails after freeze time"""
+    app = create_ctfd(user_mode="users")
+    with app.app_context():
+        register_user(app, name="user1", email="user1@ctfd.io")
+        register_user(app, name="user2", email="user2@ctfd.io")
+
+        # Friday, October 6, 2017 12:00:00 AM GMT-04:00 DST
+        set_config('freeze', '1507262400')
+        with freeze_time("2017-10-4"):
+            chal = gen_challenge(app.db)
+            chal_id = chal.id
+            chal2 = gen_challenge(app.db)
+            chal2_id = chal2.id
+            gen_fail(app.db, user_id=2, challenge_id=chal_id)
+
+        with freeze_time("2017-10-8"):
+            chal2 = gen_fail(app.db, user_id=2, challenge_id=chal2_id)
+
+            # There should now be two fails assigned to the same user.
+            assert Fails.query.count() == 2
+
+            # User 2 should have 2 fail when seen by themselves
+            client = login_as_user(app, name="user1")
+            r = client.get('/api/v1/users/me/fails')
+            print r.get_json()
+            assert r.get_json()['meta']['count'] == 2
+
+            # User 2 should have 1 fail when seen by another user
+            client = login_as_user(app, name="user2")
+            r = client.get('/api/v1/users/2/fails')
+            assert r.get_json()['meta']['count'] == 1
+
+            # Admins should see all fails for the user
+            admin = login_as_user(app, name="admin")
+
+            r = admin.get('/api/v1/users/2/fails')
+            assert r.get_json()['meta']['count'] == 2
+    destroy_ctfd(app)
+
+
 def test_api_user_get_me_awards_not_logged_in():
     """Can a user get /api/v1/users/me/awards if not logged in"""
     app = create_ctfd()
@@ -604,6 +693,45 @@ def test_api_user_get_awards():
         with login_as_user(app) as client:
             r = client.get('/api/v1/users/2/awards')
             assert r.status_code == 200
+    destroy_ctfd(app)
+
+
+def test_api_user_get_awards_after_freze_time():
+    """Can a user get /api/v1/users/<user_id>/awards after freeze time"""
+    app = create_ctfd(user_mode="users")
+    with app.app_context():
+        register_user(app, name="user1", email="user1@ctfd.io")
+        register_user(app, name="user2", email="user2@ctfd.io")
+
+        # Friday, October 6, 2017 12:00:00 AM GMT-04:00 DST
+        set_config('freeze', '1507262400')
+        with freeze_time("2017-10-4"):
+            gen_award(app.db, user_id=2)
+
+        with freeze_time("2017-10-8"):
+            gen_award(app.db, user_id=2)
+
+            # There should now be two awards assigned to the same user.
+            assert Awards.query.count() == 2
+
+            # User 2 should have 2 awards when seen by themselves
+            client = login_as_user(app, name="user1")
+            r = client.get('/api/v1/users/me/awards')
+            data = r.get_json()['data']
+            assert len(data) == 2
+
+            # User 2 should have 1 award when seen by another user
+            client = login_as_user(app, name="user2")
+            r = client.get('/api/v1/users/2/awards')
+            data = r.get_json()['data']
+            assert len(data) == 1
+
+            # Admins should see all awards for the user
+            admin = login_as_user(app, name="admin")
+
+            r = admin.get('/api/v1/users/2/awards')
+            data = r.get_json()['data']
+            assert len(data) == 2
     destroy_ctfd(app)
 
 

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -648,7 +648,6 @@ def test_api_user_get_fails_after_freze_time():
             # User 2 should have 2 fail when seen by themselves
             client = login_as_user(app, name="user1")
             r = client.get('/api/v1/users/me/fails')
-            print r.get_json()
             assert r.get_json()['meta']['count'] == 2
 
             # User 2 should have 1 fail when seen by another user


### PR DESCRIPTION
* Fix freeze time regressions in 2.x
* Make `/api/v1/[users,teams]/[me,id]/[solves,fails,awards]` endpoints load as admin to load all rows and bypass freeze
    * Closes #988
* Make `/api/v1/challenges/[id]/solves` respect freeze time. `/api/v1/challenges/[id]/solves?preview=true` is exposed for admins to see solves as a user would. 
    * Closes #986