### PR TITLE
Use /dev/shm for worker-tmp-dir in gunicorn in Docker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,6 +5,7 @@ WORKERS=${WORKERS:-1}
 WORKER_CLASS=${WORKER_CLASS:-gevent}
 ACCESS_LOG=${ACCESS_LOG:--}
 ERROR_LOG=${ERROR_LOG:--}
+WORKER_TEMP_DIR=${WORKER_TEMP_DIR:-/dev/shm}
 
 # Check that a .ctfd_secret_key file or SECRET_KEY envvar is set
 if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
@@ -41,6 +42,7 @@ echo "Starting CTFd"
 exec gunicorn 'CTFd:create_app()' \
     --bind '0.0.0.0:8000' \
     --workers $WORKERS \
+    --worker-tmp-dir "$WORKER_TEMP_DIR" \
     --worker-class "$WORKER_CLASS" \
     --access-logfile "$ACCESS_LOG" \
     --error-logfile "$ERROR_LOG"


### PR DESCRIPTION
* Use `/dev/shm` for `--worker-tmp-dir` in gunicorn in Docker
