### PR TITLE
Fix hidden pages not being able to load

### DIFF
--- a/CTFd/utils/config/pages.py
+++ b/CTFd/utils/config/pages.py
@@ -13,5 +13,5 @@ def get_pages():
 @cache.memoize()
 def get_page(route):
     return Pages.query.filter(
-        Pages.route == route, Pages.draft.isnot(True), Pages.hidden.isnot(True)
+        Pages.route == route, Pages.draft.isnot(True)
     ).first()


### PR DESCRIPTION
* Fixes bug where pages marked as `hidden` weren't loading
    * It's possible that some users used this behavior however this fix implements the correct behavior. The `draft` setting can be used to completely hide pages. 