### PR TITLE
Remove data-href from pages.html to fix delete button

### DIFF
--- a/CTFd/themes/admin/templates/pages.html
+++ b/CTFd/themes/admin/templates/pages.html
@@ -32,7 +32,7 @@
 				</thead>
 				<tbody>
 				{% for page in pages %}
-					<tr data-href="{{ url_for('admin.pages_detail', page_id=page.id) }}">
+					<tr>
 						<td class="page-title">
 							{{ page.title }}
 						</td>


### PR DESCRIPTION
* Remove `data-href` from `pages.html` to fix the delete button
    * The delete action propagates too much causing issues. This should be re-implemented on page editor rewrite. 