### PR TITLE
Cache scoreboard page

### DIFF
--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -33,6 +33,7 @@ def clear_standings():
     cache.delete_memoized(get_standings)
     cache.delete_memoized(get_team_standings)
     cache.delete_memoized(get_user_standings)
+    cache.delete(make_cache_key(path="scoreboard.listing"))
     cache.delete(make_cache_key(path=api.name + "." + ScoreboardList.endpoint))
     cache.delete(make_cache_key(path=api.name + "." + ScoreboardDetail.endpoint))
     cache.delete_memoized(ScoreboardList.get)

--- a/CTFd/scoreboard.py
+++ b/CTFd/scoreboard.py
@@ -1,5 +1,6 @@
 from flask import render_template, Blueprint
 
+from CTFd.cache import cache, make_cache_key
 from CTFd.utils import config
 from CTFd.utils.decorators.visibility import check_score_visibility
 
@@ -10,6 +11,7 @@ scoreboard = Blueprint("scoreboard", __name__)
 
 @scoreboard.route("/scoreboard")
 @check_score_visibility
+@cache.cached(timeout=60, key_prefix=make_cache_key)
 def listing():
     standings = get_standings()
     return render_template(

--- a/tests/api/v1/test_scoreboard.py
+++ b/tests/api/v1/test_scoreboard.py
@@ -48,4 +48,5 @@ def test_scoreboard_is_cached():
             clear_standings()
             assert app.cache.get("view/api.scoreboard_scoreboard_list") is None
             assert app.cache.get("view/api.scoreboard_scoreboard_detail") is None
+            assert app.cache.get('view/scoreboard.listing') is None
     destroy_ctfd(app)

--- a/tests/api/v1/test_scoreboard.py
+++ b/tests/api/v1/test_scoreboard.py
@@ -40,6 +40,7 @@ def test_scoreboard_is_cached():
             assert app.cache.get("view/api.scoreboard_scoreboard_detail")
 
             # Check scoreboard page
+            assert app.cache.get('view/scoreboard.listing') is None
             client.get("/scoreboard")
             assert app.cache.get('view/scoreboard.listing')
 

--- a/tests/api/v1/test_scoreboard.py
+++ b/tests/api/v1/test_scoreboard.py
@@ -39,6 +39,10 @@ def test_scoreboard_is_cached():
             client.get("/api/v1/scoreboard/top/10")
             assert app.cache.get("view/api.scoreboard_scoreboard_detail")
 
+            # Check scoreboard page
+            client.get("/scoreboard")
+            assert app.cache.get('view/scoreboard.listing')
+
             # Empty standings and check that the cached data is gone
             clear_standings()
             assert app.cache.get("view/api.scoreboard_scoreboard_list") is None


### PR DESCRIPTION
* Cache the `/scoreboard` page to avoid having to rebuild the response so often
* Update `tests.api.v1.test_scoreboard:test_scoreboard_is_cached` to also test if `/scoreboard` is cached