### PR TITLE
Fixed bug that caused apache2+wsgi deployment to break

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -151,7 +151,11 @@ def create_app(config="CTFd.config.Config"):
             db.create_all()
             # stamp call needs the migrations directory passed to it.
             migrations_dir = utils.__file__.split("CTFd")[0] + "CTFd/migrations"
-            stamp(directory=migrations_dir)
+            if os.path.isdir(migrations_dir):
+                stamp(directory=migrations_dir)
+            else:
+                stamp()
+                
         else:
             # This creates tables instead of db.create_all()
             # Allows migrations to happen properly

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -149,13 +149,9 @@ def create_app(config="CTFd.config.Config"):
         # Alembic sqlite support is lacking so we should just create_all anyway
         if url.drivername.startswith("sqlite"):
             db.create_all()
-            # stamp call needs the migrations directory passed to it.
-            migrations_dir = utils.__file__.split("CTFd")[0] + "CTFd/migrations"
-            if os.path.isdir(migrations_dir):
-                stamp(directory=migrations_dir)
-            else:
-                stamp()
-
+            # Get proper migrations directory regardless of cwd
+            directory = os.path.join(os.path.dirname(app.root_path), 'migrations')
+            stamp(directory=directory)
         else:
             # This creates tables instead of db.create_all()
             # Allows migrations to happen properly

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -149,7 +149,9 @@ def create_app(config="CTFd.config.Config"):
         # Alembic sqlite support is lacking so we should just create_all anyway
         if url.drivername.startswith("sqlite"):
             db.create_all()
-            stamp()
+            # stamp call needs the migrations directory passed to it.
+            migrations_dir = utils.__file__.split("CTFd")[0] + "CTFd/migrations"
+            stamp(directory=migrations_dir)
         else:
             # This creates tables instead of db.create_all()
             # Allows migrations to happen properly

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -11,7 +11,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from six.moves import input
 
 from CTFd import utils
-from CTFd.utils.migrations import migrations, create_database
+from CTFd.utils.migrations import migrations, create_database, stamp_latest_revision
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.initialization import (
@@ -149,9 +149,7 @@ def create_app(config="CTFd.config.Config"):
         # Alembic sqlite support is lacking so we should just create_all anyway
         if url.drivername.startswith("sqlite"):
             db.create_all()
-            # Get proper migrations directory regardless of cwd
-            directory = os.path.join(os.path.dirname(app.root_path), 'migrations')
-            stamp(directory=directory)
+            stamp_latest_revision()
         else:
             # This creates tables instead of db.create_all()
             # Allows migrations to happen properly

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -3,7 +3,7 @@ import os
 
 from distutils.version import StrictVersion
 from flask import Flask, Request
-from flask_migrate import upgrade, stamp
+from flask_migrate import upgrade
 from werkzeug.utils import cached_property
 from werkzeug.middleware.proxy_fix import ProxyFix
 from jinja2 import FileSystemLoader

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -155,7 +155,7 @@ def create_app(config="CTFd.config.Config"):
                 stamp(directory=migrations_dir)
             else:
                 stamp()
-                
+
         else:
             # This creates tables instead of db.create_all()
             # Allows migrations to happen properly

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -278,7 +278,9 @@ def import_ctf(backup, erase=True):
         upgrade(revision="head")
     except (CommandError, RuntimeError, SystemExit):
         app.db.create_all()
-        stamp()
+        # Get proper migrations directory regardless of cwd
+        directory = os.path.join(os.path.dirname(app.root_path), 'migrations')
+        stamp(directory=directory)
 
     # Invalidate all cached data
     cache.clear()

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -1,5 +1,5 @@
 from CTFd.utils import get_app_config, set_config
-from CTFd.utils.migrations import get_current_revision, create_database, drop_database
+from CTFd.utils.migrations import get_current_revision, create_database, drop_database, stamp_latest_revision
 from CTFd.utils.uploads import get_uploader
 from CTFd.models import db
 from CTFd.cache import cache
@@ -278,9 +278,7 @@ def import_ctf(backup, erase=True):
         upgrade(revision="head")
     except (CommandError, RuntimeError, SystemExit):
         app.db.create_all()
-        # Get proper migrations directory regardless of cwd
-        directory = os.path.join(os.path.dirname(app.root_path), 'migrations')
-        stamp(directory=directory)
+        stamp_latest_revision()
 
     # Invalidate all cached data
     cache.clear()

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -5,7 +5,7 @@ from CTFd.models import db
 from CTFd.cache import cache
 from datafreeze.format import SERIALIZERS
 from flask import current_app as app
-from flask_migrate import upgrade, stamp
+from flask_migrate import upgrade
 from datafreeze.format.fjson import JSONSerializer, JSONEncoder
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from alembic.util import CommandError

--- a/CTFd/utils/migrations/__init__.py
+++ b/CTFd/utils/migrations/__init__.py
@@ -44,6 +44,7 @@ def get_current_revision():
     current_rev = context.get_current_revision()
     return current_rev
 
+
 def stamp_latest_revision():
     # Get proper migrations directory regardless of cwd
     directory = os.path.join(os.path.dirname(app.root_path), 'migrations')

--- a/CTFd/utils/migrations/__init__.py
+++ b/CTFd/utils/migrations/__init__.py
@@ -1,5 +1,5 @@
 from flask import current_app as app
-from flask_migrate import Migrate
+from flask_migrate import Migrate, stamp
 from alembic.migration import MigrationContext
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
@@ -8,6 +8,7 @@ from sqlalchemy_utils import (
     create_database as create_database_util,
     drop_database as drop_database_util,
 )
+import os
 
 migrations = Migrate()
 
@@ -42,3 +43,8 @@ def get_current_revision():
     context = MigrationContext.configure(conn)
     current_rev = context.get_current_revision()
     return current_rev
+
+def stamp_latest_revision():
+    # Get proper migrations directory regardless of cwd
+    directory = os.path.join(os.path.dirname(app.root_path), 'migrations')
+    stamp(directory=directory)


### PR DESCRIPTION
stamp() call missing the migrations directory causes apache2 w/ mod_wsgi support to break.

Issues #257 seems to be directly related to this issue, but was never fixed because the user moved onto another deployment method.