### PR TITLE
Prevent browser from caching the export

### DIFF
--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -110,7 +110,9 @@ def export_ctf():
     ctf_name = ctf_config.ctf_name()
     day = datetime.datetime.now().strftime("%Y-%m-%d")
     full_name = u"{}.{}.zip".format(ctf_name, day)
-    return send_file(backup, as_attachment=True, attachment_filename=full_name)
+    return send_file(
+        backup, cache_timeout=-1, as_attachment=True, attachment_filename=full_name
+    )
 
 
 @admin.route("/admin/export/csv")


### PR DESCRIPTION
* Add `cache_timeout` parameter to `send_file`response in `/admin/export`.
* Closes #1032 