### PR TITLE
Fix scoreboard links created by update() in user mode

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -29,7 +29,7 @@ from CTFd.utils.config.visibility import (
     challenges_visible,
 )
 from CTFd.utils.user import is_admin, authed
-from CTFd.utils.modes import get_model, generate_account_url, USERS_MODE, TEAMS_MODE
+from CTFd.utils.modes import get_model, generate_account_url
 from CTFd.schemas.tags import TagSchema
 from CTFd.schemas.hints import HintSchema
 from CTFd.schemas.flags import FlagSchema

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -29,7 +29,7 @@ from CTFd.utils.config.visibility import (
     challenges_visible,
 )
 from CTFd.utils.user import is_admin, authed
-from CTFd.utils.modes import get_model, USERS_MODE, TEAMS_MODE
+from CTFd.utils.modes import get_model, generate_account_url, USERS_MODE, TEAMS_MODE
 from CTFd.schemas.tags import TagSchema
 from CTFd.schemas.hints import HintSchema
 from CTFd.schemas.flags import FlagSchema
@@ -529,21 +529,13 @@ class ChallengeSolves(Resource):
                 dt = datetime.datetime.utcfromtimestamp(freeze)
                 solves = solves.filter(Solves.date < dt)
 
-        endpoint = None
-        if get_config("user_mode") == TEAMS_MODE:
-            endpoint = "teams.public"
-            arg = "team_id"
-        elif get_config("user_mode") == USERS_MODE:
-            endpoint = "users.public"
-            arg = "user_id"
-
         for solve in solves:
             response.append(
                 {
                     "account_id": solve.account_id,
                     "name": solve.account.name,
                     "date": isoformat(solve.date),
-                    "account_url": url_for(endpoint, **{arg: solve.account_id}),
+                    "account_url": generate_account_url(account_id=solve.account_id),
                 }
             )
 

--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -38,7 +38,7 @@ class ScoreboardList(Resource):
             entry = {
                 "pos": i + 1,
                 "account_id": x.account_id,
-                "account_url": generate_account_url(x.account_id),
+                "account_url": generate_account_url(account_id=x.account_id),
                 "account_type": account_type,
                 "oauth_id": x.oauth_id,
                 "name": x.name,

--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -4,7 +4,7 @@ from CTFd.models import Solves, Awards, Teams
 from CTFd.cache import cache, make_cache_key
 from CTFd.utils.scores import get_standings
 from CTFd.utils import get_config
-from CTFd.utils.modes import TEAMS_MODE
+from CTFd.utils.modes import generate_account_url, get_mode_as_word, TEAMS_MODE
 from CTFd.utils.dates import unix_time_to_utc, isoformat
 from CTFd.utils.decorators.visibility import (
     check_account_visibility,
@@ -25,6 +25,7 @@ class ScoreboardList(Resource):
         standings = get_standings()
         response = []
         mode = get_config("user_mode")
+        account_type = get_mode_as_word()
 
         if mode == TEAMS_MODE:
             team_ids = []
@@ -37,6 +38,8 @@ class ScoreboardList(Resource):
             entry = {
                 "pos": i + 1,
                 "account_id": x.account_id,
+                "account_url": generate_account_url(x.account_id),
+                "account_type": account_type,
                 "oauth_id": x.oauth_id,
                 "name": x.name,
                 "score": int(x.score),

--- a/CTFd/themes/core/static/js/scoreboard.js
+++ b/CTFd/themes/core/static/js/scoreboard.js
@@ -7,9 +7,8 @@ function updatescores() {
       var row =
         "<tr>\n" +
         '<th scope="row" class="text-center">{0}</th>'.format(teams[i].pos) +
-        '<td><a href="{0}/team/{1}">{2}</a></td>'.format(
-          script_root,
-          teams[i].id,
+        '<td><a href="{0}">{1}</a></td>'.format(
+          teams[i].account_url,
           htmlentities(teams[i].name)
         ) +
         "<td>{0}</td>".format(teams[i].score) +


### PR DESCRIPTION
* Fixes account links on the scoreboard page created by `update()`. They now correctly point to the user instead of undefined when in user mode. 
* Add `account_type` and `account_url` field in `/api/v1/scoreboard`