### PR TITLE
Add a Content-Disposition header to s3 downloads

### DIFF
--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -111,7 +111,14 @@ class S3Uploader(BaseUploader):
 
     def download(self, filename):
         url = self.s3.generate_presigned_url(
-            "get_object", Params={"Bucket": self.bucket, "Key": filename}
+            "get_object",
+            Params={
+                "Bucket": self.bucket,
+                "Key": filename,
+                "ResponseContentDisposition": "attachment; filename={}".format(
+                    filename
+                ),
+            },
         )
         return redirect(url)
 


### PR DESCRIPTION
* Add a Content-Disposition header to s3 downloads so `wget` doesn't generate long invalid filenames. 