### PR TITLE
Fixed minor error in plugin doc

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -15,7 +15,7 @@ The CTFd developers will do their best to not introduce breaking changes but kee
    Official CTFd plugins are available at https://ctfd.io/store. `Contact us <https://ctfd.io/contact/>`_ regarding custom plugins and special projects.
 
 .. Tip::
-   Community themes are available at https://github.com/CTFd/plugins.
+   Community plugins are available at https://github.com/CTFd/plugins.
 
 Architecture
 ------------


### PR DESCRIPTION
I was going through the plugin documentation and noticed a minor error. 

This PR fixes the description for the link to plugins repo 