### PR TITLE
Fix S3 file downloads to not contain the folder name

### DIFF
--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -110,11 +110,13 @@ class S3Uploader(BaseUploader):
         return dst
 
     def download(self, filename):
+        key = filename
+        filename = filename.split('/').pop()
         url = self.s3.generate_presigned_url(
             "get_object",
             Params={
                 "Bucket": self.bucket,
-                "Key": filename,
+                "Key": key,
                 "ResponseContentDisposition": "attachment; filename={}".format(
                     filename
                 ),


### PR DESCRIPTION
* Fixes a bug in S3 downloads where a downloaded file would have its parent folder name in the filename