### PR TITLE
Revert "Switch Dockerfile from python:2.7-alpine to python:3.7-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:2.7-alpine
 RUN apk update && \
     apk add python python-dev linux-headers libffi-dev gcc make musl-dev py-pip mysql-client git openssl-dev
 RUN adduser -D -u 1001 -s /bin/bash ctfd


### PR DESCRIPTION
Revert "Switch Dockerfile from python:2.7-alpine to python:3.7-alpine

This reverts commit 7eff04dc4c26234f4c062222e7eb9ef87b722623.

Better to put this into 2.2.0 even though I suspect there's no major breaking changes here. 