### PR TITLE
(Optionally) require an auth key for registration

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -196,6 +196,11 @@ def register():
         if name_len:
             errors.append("Pick a longer user name")
 
+        auth_key = get_app_config("REGISTRATION_AUTH_KEY") or get_config("registration_auth_key")
+        if auth_key:
+            if auth_key != request.form["authkey"]:
+                errors.append("Invalid auth key")
+
         if len(errors) > 0:
             return render_template(
                 "register.html",

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -61,6 +61,9 @@ class Config(object):
     REDIS_URL is the URL to connect to a Redis server.
         e.g. redis://user:password@localhost:6379
         http://pythonhosted.org/Flask-Caching/#configuring-flask-caching
+
+    REGISTRATION_AUTH_KEY:
+        A string required when registering an account. Leave empty to disable.
     """
     SECRET_KEY = os.getenv("SECRET_KEY") or key
     DATABASE_URL = os.getenv("DATABASE_URL") or "sqlite:///{}/ctfd.db".format(
@@ -80,6 +83,8 @@ class Config(object):
         CACHE_THRESHOLD = (
             0
         )  # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
+
+    REGISTRATION_AUTH_KEY = os.getenv("REGISTRATION_AUTH_KEY")
 
     """
     === SECURITY ===

--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -87,6 +87,18 @@
 		</div>
 
 		<div class="form-group">
+			<label>
+				Registration Auth Key<br>
+				<small class="form-text text-muted">
+					An authorization key required to register an account (leave empty to disable)
+				</small>
+			</label>
+			<input class="form-control" id='registration_auth_key' name='registration_auth_key' type='text'
+				   placeholder=""
+				   {% if registration_auth_key is defined and registration_auth_key != None %}value="{{ registration_auth_key }}"{% endif %}>
+		</div>
+
+		<div class="form-group">
 			<div class="form-check">
 				<label>
 					<input id="paused" name="paused" type="checkbox" {% if paused %}checked{% endif %}>

--- a/CTFd/themes/core/templates/register.html
+++ b/CTFd/themes/core/templates/register.html
@@ -43,6 +43,14 @@
 					</label>
 					<input class="form-control" type="password" name="password" id="password-input" {% if password %}value="{{ password }}"{% endif %}/>
 				</div>
+				{% if config.app.config.REGISTRATION_AUTH_KEY or get_config('REGISTRATION_AUTH_KEY') %}
+				<div class="form-group">
+					<label for="authkey-input">
+						Auth Key
+					</label>
+					<input class="form-control" type="text" name="authkey" id="authkey-input" {% if authkey %}value="{{ authkey }}"{% endif %} />
+				</div>
+				{% endif %}
 				<div class="row pt-3">
 					<div class="col-md-12">
 						<button type="submit" id="submit" tabindex="5" class="btn btn-md btn-primary btn-outlined float-right">Submit</button>

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,6 +34,9 @@ e.g. ``redis://user:password@localhost:6379``
 
 http://pythonhosted.org/Flask-Caching/#configuring-flask-caching
 
+REGISTRATION_AUTH_KEY
+~~~~~~~~~~~~~~~~~~~~~
+An authorization key required to register. Leave empty to disable.
 
 MAILFROM_ADDR
 ~~~~~~~~~~~~~

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -117,7 +117,7 @@ def destroy_ctfd(app):
 
 
 def register_user(
-    app, name="user", email="user@ctfd.io", password="password", raise_for_error=True
+    app, name="user", email="user@ctfd.io", password="password", authkey=None, raise_for_error=True
 ):
     with app.app_context():
         with app.test_client() as client:
@@ -127,6 +127,7 @@ def register_user(
                     "name": name,
                     "email": email,
                     "password": password,
+                    "authkey": authkey,
                     "nonce": sess.get("nonce"),
                 }
             client.post("/register", data=data)

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -99,6 +99,60 @@ def test_register_whitelisted_email():
     destroy_ctfd(app)
 
 
+def test_register_with_authkey_via_env():
+    """Check that a user register if and only if the correct auth key is supplied (auth key configured via env)"""
+    app = create_ctfd()
+    app.config.update({"REGISTRATION_AUTH_KEY": "secretkey"})
+    with app.app_context():
+        register_user(
+            app,
+            name="user1",
+            email="user1@ctfd.io",
+            password="password",
+            authkey="wrongkey",
+            raise_for_error=False,
+        )
+        user_count = Users.query.count()
+        assert user_count == 1  # no user has been created (admin only)
+        register_user(
+            app,
+            name="user1",
+            email="user1@ctfd.io",
+            password="password",
+            authkey="secretkey",
+        )
+        user_count = Users.query.count()
+        assert user_count == 2  # now the user has been created
+    destroy_ctfd(app)
+
+
+def test_register_with_authkey_via_conf():
+    """Check that a user register if and only if the correct auth key is supplied (auth key configured over the web interface)"""
+    app = create_ctfd()
+    with app.app_context():
+        set_config("registration_auth_key", "secretkey")
+        register_user(
+            app,
+            name="user1",
+            email="user1@ctfd.io",
+            password="password",
+            authkey="wrongkey",
+            raise_for_error=False,
+        )
+        user_count = Users.query.count()
+        assert user_count == 1  # no user has been created (admin only)
+        register_user(
+            app,
+            name="user1",
+            email="user1@ctfd.io",
+            password="password",
+            authkey="secretkey",
+        )
+        user_count = Users.query.count()
+        assert user_count == 2  # now the user has been created
+    destroy_ctfd(app)
+
+
 def test_user_bad_login():
     """A user should not be able to login with an incorrect password"""
     app = create_ctfd()


### PR DESCRIPTION
This pull requests adds an "auth key" to the registration form which can be configured via the admin panel or environment variables. If an auth key is configured, it is required to register a new user account.

This allows to leave the registration open but still restrict who is able to register.