### PR TITLE
Add note to notifications template when none exist

### DIFF
--- a/CTFd/themes/core/templates/notifications.html
+++ b/CTFd/themes/core/templates/notifications.html
@@ -7,6 +7,9 @@
 		</div>
 	</div>
 	<div class="container">
+		{% if not notifications %}
+		<h2 class="text-center">There are no notifications yet</h2>
+		{% endif %}
 		{% for notification in notifications %}
 		<div class="card bg-light mb-4">
 			<div class="card-body">


### PR DESCRIPTION
Just a cosmetic fix so there isn't a blank page staring at you.