### PR TITLE
Create a prototype Redis Jinja env cache

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -68,7 +68,7 @@ class SandboxedBaseEnvironment(SandboxedEnvironment):
             self.bytecode_cache = None
         if "loader" not in options:
             options["loader"] = app.create_global_jinja_loader()
-        SandboxedEnvironment.__init__(self, cache_size=0, bytecode_cache=self.bytecode_cache, **options)
+        SandboxedEnvironment.__init__(self, bytecode_cache=self.bytecode_cache, **options)
         self.app = app
 
 

--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -1,7 +1,24 @@
 from flask import request
 from flask_caching import Cache
+from jinja2 import BytecodeCache
 
 cache = Cache()
+
+
+class RedisJinjaBytecodeCache(BytecodeCache):
+    """
+    Jinja bytecode cache based on Flask-Caching
+    """
+
+    def load_bytecode(self, bucket):
+        key = make_cache_key(path=bucket.key, key_prefix="template/%s")
+        bc = cache.get(key)
+        if bc:
+            bucket.bytecode_from_string(bc)
+
+    def dump_bytecode(self, bucket):
+        key = make_cache_key(path=bucket.key, key_prefix="template/%s")
+        cache.set(key=key, value=bucket.bytecode_to_string(), timeout=300)
 
 
 def make_cache_key(path=None, key_prefix="view/%s"):


### PR DESCRIPTION
This showcases a prototype jinja env cache that uses Flask-Caching to store the jinja env. It doesn't work in the situation of changing themes. This is because Flask doesn't use parent templates as part of the checksum. If you switch themes you could end up using the parent template of the previous theme instead of the new theme. 

If you did want to pull this off you need to investigate what the loader is doing that's causing it to still cache the previous theme and figure out a way to invalidate it on theme change. 

https://github.com/pallets/jinja/blob/9550dc85ff826442c4609b139c20f5698b2c9b5d/jinja2/bccache.py#L166 