### PR TITLE
Mark 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+2.1.5 / 2019-10-2
+=================
+
+**General**
+* Fixes `flask run` debug server by not monkey patching in `wsgi.py`
+* Fix CSV exports in Python 3 by converting StringIO to BytesIO
+* Avoid exception on sessions without a valid user and force logout
+* Fix several issues in Vagrant provisioning
+
+**API**
+* Prevent users from nulling out profile values and breaking certain pages
+
+
 2.1.4 / 2019-08-31
 ==================
 

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -28,7 +28,7 @@ if sys.version_info[0] < 3:
     reload(sys)  # noqa: F821
     sys.setdefaultencoding("utf-8")
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 
 class CTFdRequest(Request):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'Kevin Chung'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'2.1.4'
+release = u'2.1.5'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
2.1.5 / 2019-10-2
=================

**General**
* Fixes `flask run` debug server by not monkey patching in `wsgi.py`
* Fix CSV exports in Python 3 by converting StringIO to BytesIO
* Avoid exception on sessions without a valid user and force logout
* Fix several issues in Vagrant provisioning

**API**
* Prevent users from nulling out profile values and breaking certain pages
