### PR TITLE
Dockerfile save 100MB image and clean-up

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,25 +17,29 @@ if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
     fi
 fi
 
+
 # Check that the database is available
-if [ -n "$DATABASE_URL" ]
-    then
+if [ -n "$DATABASE_URL" ] ; then
     url=`echo $DATABASE_URL | awk -F[@//] '{print $4}'`
-    database=`echo $url | awk -F[:] '{print $1}'`
+    host=`echo $url | awk -F[:] '{print $1}'`
     port=`echo $url | awk -F[:] '{print $2}'`
-    echo "Waiting for $database:$port to be ready"
-    while ! mysqladmin ping -h "$database" -P "$port" --silent; do
+    user=`echo $DATABASE_URL | awk -F[@//:] '{print $4}'`
+    pass=`echo $DATABASE_URL | awk -F[@//:] '{print $5}'`
+    echo "Waiting for $host:$port to be ready"
+    while ! mysqladmin ping -h "$host" -P "$port" -u "$user" -p$pass \
+        2>&1 | grep alive > /dev/null
+    do
         # Show some progress
         echo -n '.';
         sleep 1;
     done
-    echo "$database is ready"
+    echo "$host is ready"
     # Give it another second.
     sleep 1;
 fi
 
 # Initialize database
-python manage.py db upgrade
+python3 manage.py db upgrade
 
 # Start CTFd
 echo "Starting CTFd"


### PR DESCRIPTION
I replaced `COPY . /opt/CTFd` because it potentially includes a lot of things you do not want in the image (such as the .git repository and your local editor preferences.) This is probably better then attempting to keep `.dockerignore` up-to-date.

I completely removed the following command because there are no `requirements.txt` files in those directories anymore.
```
RUN for d in CTFd/plugins/*; do \
      if [ -f "$d/requirements.txt" ]; then \
        pip install -r $d/requirements.txt; \
      fi; \
    done;
```

I switched to the basic `alpine` image and use `apk add python3` instead of using the `python:3.7-alpine` image and this saves about a 100MB. On my system I built the following containers with `buildah`.
- 587 MB, 2.2.0-dev branch with python:3.7-alpine
- 473 MB, 2.2.0-dev branch with alpine and `apk add python3`
- 564 MB, master branch with python:3.7-alpine
- 457 MB, master branch with alpine and `apk add python3`
- 532 MB, docker.io/ctfd/ctfd:latest

I added some environment variables that are used for configuration in `docker-entrypoint.sh` to the Dockerfile. This should help people find those configuration options.

In `docker-entry.sh` I also added a password on the `mysqladmin ping` command. It didn't work on my system otherwise. (I was testing with the `mariadb:latest` container.)

------

I'm using this to run a pod with podman. I haven't tested this yet with docker-compose.
