### PR TITLE
Use generally unique string to bust browser cache on server restart

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -21,7 +21,9 @@ from CTFd.utils.initialization import (
     init_logs,
     init_events,
 )
+from CTFd.utils.crypto import sha256
 from CTFd.plugins import init_plugins
+import datetime
 
 # Hack to support Unicode in Python 2 properly
 if sys.version_info[0] < 3:
@@ -50,6 +52,12 @@ class CTFdFlask(Flask):
         self.jinja_environment = SandboxedBaseEnvironment
         self.session_interface = CachingSessionInterface(key_prefix="session")
         self.request_class = CTFdRequest
+
+        # Store server start time
+        self.start_time = datetime.datetime.utcnow()
+
+        # Create generally unique run identifier
+        self.run_id = sha256(str(self.start_time))[0:8]
         Flask.__init__(self, *args, **kwargs)
 
     def create_jinja_environment(self):

--- a/CTFd/utils/helpers/__init__.py
+++ b/CTFd/utils/helpers/__init__.py
@@ -2,8 +2,7 @@ from flask import (
     request,
     flash,
     get_flashed_messages,
-    url_for as flask_url_for,
-    current_app
+    current_app,
 )
 import os
 
@@ -24,14 +23,22 @@ def get_errors():
     return get_flashed_messages(category_filter=request.endpoint + ".errors")
 
 
-def url_for(endpoint, **values):
-    if endpoint == 'views.themes':
-        path = values.get('path', '')
-        static_asset = path.endswith('.js') or path.endswith('.css')
-        direct_access = '.dev' in path or '.min' in path
+@current_app.url_defaults
+def env_asset_url_default(endpoint, values):
+    """Create asset URLs dependent on the current env"""
+    if endpoint == "views.themes":
+        path = values.get("path", "")
+        static_asset = path.endswith(".js") or path.endswith(".css")
+        direct_access = ".dev" in path or ".min" in path
         if static_asset and not direct_access:
-            env = values.get('env', current_app.env)
-            mode = '.dev' if env == 'development' else '.min'
+            env = values.get("env", current_app.env)
+            mode = ".dev" if env == "development" else ".min"
             base, ext = os.path.splitext(path)
-            values['path'] = base + mode + ext
-    return flask_url_for(endpoint, **values)
+            values["path"] = base + mode + ext
+
+
+@current_app.url_defaults
+def asset_cache_url_default(endpoint, values):
+    """Used to cache bust per server restarts"""
+    if endpoint == "views.themes":
+        values["d"] = current_app.run_id

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -23,7 +23,6 @@ from CTFd.utils.modes import generate_account_url, get_mode_as_word
 from CTFd.utils.config import is_setup
 from CTFd.utils.security.csrf import generate_nonce
 from CTFd.utils.security.auth import logout_user
-from CTFd.utils.helpers import url_for as custom_url_for
 from CTFd.utils.config.visibility import (
     accounts_visible,
     challenges_visible,
@@ -70,7 +69,6 @@ def init_template_globals(app):
     app.jinja_env.globals.update(challenges_visible=challenges_visible)
     app.jinja_env.globals.update(registration_visible=registration_visible)
     app.jinja_env.globals.update(scores_visible=scores_visible)
-    app.jinja_env.globals.update(url_for=custom_url_for)
     app.jinja_env.globals.update(get_mode_as_word=get_mode_as_word)
 
 


### PR DESCRIPTION
* Closes #912 
* Adds the `d` parameter to urls generated for static assets to bust the browser cache