### PR TITLE
Fix: dynamic challenge points decrease when hidden user submit first ly

### DIFF
--- a/CTFd/plugins/dynamic_challenges/__init__.py
+++ b/CTFd/plugins/dynamic_challenges/__init__.py
@@ -211,7 +211,7 @@ class DynamicValueChallenge(BaseChallenge):
         )
 
         # We subtract -1 to allow the first solver to get max point value
-        solve_count -= 1
+        solve_count -= 1 if solve_count != 0 else solve_count
 
         # It is important that this calculation takes into account floats.
         # Hence this file uses from __future__ import division


### PR DESCRIPTION
# What this pr do
When I use CTFd, I find that when a hidden user solve a dynamic challenge first(Before any others), It will cause the points of this challenge to change.

# Detail of what happend

We should look at some lines of code

https://github.com/CTFd/CTFd/blob/master/CTFd/plugins/dynamic_challenges/__init__.py#L203-L222

Logic go through:
L203-L211: Get the solve_count with `hidden = False` and `banned = False` Because the hidden user is the first person solve the challenge and he is hidden, the solve_count should be 0.

L214: minus solve_count by 1. solve_count become -1. Which cause `((chal.minimum - chal.initial) / (chal.decay ** 2)) * (solve_count ** 2)` to be no zero. And change the value.

# The way to reproduce

In most of the case we don't notice the problem. Because when we hold a race and have a dynamic challenge the `((chal.minimum - chal.initial) / (chal.decay ** 2))` should be small than one at most of the cases. And it got `math.ceil` in L222

1. Create a dynamic challenge with a **Large** initial and a **Small** minimum and a **Small** decay
such as `10000` `10` `3`

2. Create a hidden user and submit the flag.

3. We can find the points changed.

![Bug](https://i.imgur.com/Hj5dRB0.png)

# Way to fix

Add a condition in L214