### PR TITLE
Properly use relaxed email regex (Closes #1184)

### DIFF
--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -4,10 +4,6 @@ from CTFd.utils.formatters import safe_format
 from CTFd.utils.config import get_mail_provider
 from CTFd.utils.email import mailgun, smtp
 from CTFd.utils.security.signing import serialize
-import re
-
-
-EMAIL_REGEX = r"(^[^@\s]+@[^@\s]+\.[^@\s]+$)"
 
 
 def sendmail(addr, text, subject="Message from {ctf_name}"):
@@ -51,10 +47,6 @@ def user_created_notification(addr, name, password):
         password=password,
     )
     return sendmail(addr, text)
-
-
-def check_email_format(email):
-    return bool(re.match(EMAIL_REGEX, email))
 
 
 def check_email_is_whitelisted(email_address):

--- a/CTFd/utils/validators/__init__.py
+++ b/CTFd/utils/validators/__init__.py
@@ -6,6 +6,8 @@ from flask import request
 from marshmallow import ValidationError
 import re
 
+EMAIL_REGEX = r"(^[^@\s]+@[^@\s]+\.[^@\s]+$)"
+
 
 def is_safe_url(target):
     ref_url = urlparse(request.host_url)
@@ -18,7 +20,7 @@ def validate_url(url):
 
 
 def validate_email(email):
-    return bool(re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email))
+    return bool(re.match(EMAIL_REGEX, email))
 
 
 def unique_email(email, model=Users):

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -1,30 +1,10 @@
 from tests.helpers import create_ctfd, destroy_ctfd
 from CTFd.utils import get_config, set_config
-from CTFd.utils.email import sendmail, verify_email_address, check_email_format
+from CTFd.utils.email import sendmail, verify_email_address
 from freezegun import freeze_time
 from mock import patch, Mock
 from email.mime.text import MIMEText
 import requests
-
-
-def test_check_email_format():
-    """Test that the check_email_format() works properly"""
-    assert check_email_format("user@ctfd.io") is True
-    assert check_email_format("user+plus@gmail.com") is True
-    assert check_email_format("user.period1234@gmail.com") is True
-    assert check_email_format("user.period1234@b.c") is True
-    assert check_email_format("user.period1234@b") is False
-    assert check_email_format("no.ampersand") is False
-    assert check_email_format("user@") is False
-    assert check_email_format("@ctfd.io") is False
-    assert check_email_format("user.io@ctfd") is False
-    assert check_email_format("user\\@ctfd") is False
-
-    for invalid_email in ["user.@ctfd.io", ".user@ctfd.io", "user@ctfd..io"]:
-        try:
-            assert check_email_format(invalid_email) is False
-        except AssertionError:
-            print(invalid_email, "did not pass validation")
 
 
 @patch("smtplib.SMTP")

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -1,4 +1,4 @@
-from CTFd.utils.validators import validate_country_code
+from CTFd.utils.validators import validate_country_code, validate_email
 from marshmallow import ValidationError
 
 
@@ -9,3 +9,23 @@ def test_validate_country_code():
         validate_country_code("ZZ")
     except ValidationError:
         pass
+
+
+def test_validate_email():
+    """Test that the check_email_format() works properly"""
+    assert validate_email("user@ctfd.io") is True
+    assert validate_email("user+plus@gmail.com") is True
+    assert validate_email("user.period1234@gmail.com") is True
+    assert validate_email("user.period1234@b.c") is True
+    assert validate_email("user.period1234@b") is False
+    assert validate_email("no.ampersand") is False
+    assert validate_email("user@") is False
+    assert validate_email("@ctfd.io") is False
+    assert validate_email("user.io@ctfd") is False
+    assert validate_email("user\\@ctfd") is False
+
+    for invalid_email in ["user.@ctfd.io", ".user@ctfd.io", "user@ctfd..io"]:
+        try:
+            assert validate_email(invalid_email) is False
+        except AssertionError:
+            print(invalid_email, "did not pass validation")


### PR DESCRIPTION
* Close #1184 and properly close #622 by using the correct relaxed email regex
* Deprecate `CTFd.utils.email.check_email_format()`