### PR TITLE
undefined name 'six' in 1_2_0_upgrade_2_0_0.py

### DIFF
--- a/migrations/1_2_0_upgrade_2_0_0.py
+++ b/migrations/1_2_0_upgrade_2_0_0.py
@@ -15,13 +15,13 @@ from CTFd import config, create_app
 from sqlalchemy_utils import (
     drop_database,
 )
-from six.moves import input
+from six.moves import input, string_types
 import dataset
 
 def cast_bool(value):
     if value and value.isdigit():
         return int(value)
-    elif value and isinstance(value, six.string_types):
+    elif value and isinstance(value, string_types):
         if value.lower() == 'true':
             return True
         elif value.lower() == 'false':


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/CTFd/CTFd on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./migrations/1_2_0_upgrade_2_0_0.py:24:38: F821 undefined name 'six'
    elif value and isinstance(value, six.string_types):
                                     ^
1     F821 undefined name 'six'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.