### PR TITLE
Allow email modifications

### DIFF
--- a/CTFd/themes/admin/templates/configs/email.html
+++ b/CTFd/themes/admin/templates/configs/email.html
@@ -24,7 +24,8 @@
 							Email address used to send email
 						</small>
 					</label>
-					<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text' {% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
+					<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text'
+							{% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
 				</div>
 
 				<div class="form-group">
@@ -109,7 +110,8 @@
 							Email address used to send email
 						</small>
 					</label>
-					<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text' {% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
+					<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text'
+								{% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
 				</div>
 
 				<div class="form-group">

--- a/CTFd/themes/admin/templates/configs/email.html
+++ b/CTFd/themes/admin/templates/configs/email.html
@@ -8,20 +8,24 @@
 			<li class="nav-item">
 				<a class="nav-link" href="#mailgun" role="tab" data-toggle="tab">Mailgun</a>
 			</li>
+			<li class="nav-item">
+				<a class="nav-link" href="#emailtext" role="tab" data-toggle="tab">Email Text</a>
+			</li>
 		</ul>
 
-		<div class="form-group">
-			<label>
-				Mail From Address<br>
-				<small class="form-text text-muted">
-					Email address used to send email
-				</small>
-			</label>
-			<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text' {% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
-		</div>
 
 		<div class="tab-content">
 			<div role="tabpanel" class="tab-pane active" id="mailserver">
+
+				<div class="form-group">
+					<label>
+						Mail From Address<br>
+						<small class="form-text text-muted">
+							Email address used to send email
+						</small>
+					</label>
+					<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text' {% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
+				</div>
 
 				<div class="form-group">
 					<label>
@@ -100,6 +104,16 @@
 			<div role="tabpanel" class="tab-pane" id="mailgun">
 				<div class="form-group">
 					<label>
+						Mail From Address<br>
+						<small class="form-text text-muted">
+							Email address used to send email
+						</small>
+					</label>
+					<input class="form-control" id='mailfrom_addr' name='mailfrom_addr' type='text' {% if mailfrom_addr is defined and mailfrom_addr != None %}value="{{ mailfrom_addr }}"{% endif %}>
+				</div>
+
+				<div class="form-group">
+					<label>
 						Mailgun API Base URL<br>
 						<small class="form-text text-muted">
 							Mailgun API Base URL
@@ -119,6 +133,54 @@
 						   {% if mailgun_api_key is defined and mailgun_api_key != None %}value="{{ mailgun_api_key }}"{% endif %}>
 				</div>
 			</div>
+
+			<div role="tabpanel" class="tab-pane" id="emailtext">
+
+				<div class="form-group">
+					<label>
+						Reset Password Email<br>
+						<small class="form-text text-muted">
+							Password Reset Email Subject
+						</small>
+					</label>
+					<input class="form-control" id='password_reset_subject' name='password_reset_subject' type='text'
+						   {% if password_reset_subject is defined and password_reset_subject != None %}value="{{ password_reset_subject }}"{% endif %}>
+					<small class="form-text text-muted">
+		 				Password Reset Email Body
+		 			</small>
+		 			<textarea class="form-control" id="password_reset_body" name="password_reset_body" rows="7">{{ password_reset_body }}</textarea>
+				</div>
+				<div class="form-group">
+					<label>
+						Verication Email<br>
+						<small class="form-text text-muted">
+							Verication Email Subject
+						</small>
+					</label>
+					<input class="form-control" id='verification_email_subject' name='verification_email_subject' type='text'
+						   {% if verification_email_subject is defined and verification_email_subject != None %}value="{{ verification_email_subject }}"{% endif %}>
+					<small class="form-text text-muted">
+		 				Verification Email Body
+		 			</small>
+		 			<textarea class="form-control" id="verification_email_body" name="verification_email_body" rows="7">{{ verification_email_body }}</textarea>
+				</div>
+
+				<div class="form-group">
+					<label>
+						User Creation Email<br>
+						<small class="form-text text-muted">
+							User Creation Email Subject
+						</small>
+					</label>
+					<input class="form-control" id='user_creation_email_subject' name='user_creation_email_subject' type='text'
+							 {% if user_creation_email_subject is defined and user_creation_email_subject != None %}value="{{ user_creation_email_subject }}"{% endif %}>
+					<small class="form-text text-muted">
+						User Creation Email Body
+					</small>
+					<textarea class="form-control" id="user_creation_email_body" name="user_creation_email_body" rows="7">{{ user_creation_email_body }}</textarea>
+				</div>
+			</div>
+
 		</div>
 		<button type="submit" class="btn btn-md btn-primary float-right">Update</button>
 	</form>

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -18,35 +18,52 @@ def sendmail(addr, text, subject="Message from {ctf_name}"):
 
 def forgot_password(email, team_name):
     token = serialize(team_name)
-    text = """Did you initiate a password reset? Click the following link to reset your password:
-
-{0}/{1}
-
-""".format(
-        url_for("auth.reset_password", _external=True), token
+    text = safe_format(
+        get_config("password_reset_body"),
+        ctf_name=get_config("ctf_name"),
+        ctf_description=get_config("ctf_description"),
+        email_sender=get_config("mailfrom_addr"),
+        url=url_for("auth.reset_password", _external=True),
+        token=token,
     )
-
-    return sendmail(email, text)
+    subject = safe_format(
+        get_config("password_reset_subject"), ctf_name=get_config("ctf_name")
+    )
+    return sendmail(email, text, subject)
 
 
 def verify_email_address(addr):
     token = serialize(addr)
-    text = """Please click the following link to confirm your email address for {ctf_name}: {url}/{token}""".format(
+    text = safe_format(
+        get_config("verification_email_body"),
         ctf_name=get_config("ctf_name"),
+        ctf_description=get_config("ctf_description"),
+        email_sender=get_config("mailfrom_addr"),
         url=url_for("auth.confirm", _external=True),
         token=token,
     )
-    return sendmail(addr, text)
+    subject = safe_format(
+        get_config("verification_email_subject"), ctf_name=get_config("ctf_name")
+    )
+    return sendmail(addr, text, subject)
 
 
 def user_created_notification(addr, name, password):
-    text = """An account has been created for you for {ctf_name} at {url}. \n\nUsername: {name}\nPassword: {password}""".format(
+    text = safe_format(
+        get_config("user_creation_email_body"),
         ctf_name=get_config("ctf_name"),
+        ctf_description=get_config("ctf_description"),
+        email_sender=get_config("mailfrom_addr"),
+        token=token,
         url=url_for("views.static_html", _external=True),
         name=name,
         password=password,
     )
-    return sendmail(addr, text)
+
+    subject = safe_format(
+        get_config("user_creation_email_subject"), ctf_name=get_config("ctf_name")
+    )
+    return sendmail(addr, text, subject)
 
 
 def check_email_is_whitelisted(email_address):

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -54,7 +54,6 @@ def user_created_notification(addr, name, password):
         ctf_name=get_config("ctf_name"),
         ctf_description=get_config("ctf_description"),
         email_sender=get_config("mailfrom_addr"),
-        token=token,
         url=url_for("views.static_html", _external=True),
         name=name,
         password=password,

--- a/CTFd/utils/email/smtp.py
+++ b/CTFd/utils/email/smtp.py
@@ -19,6 +19,7 @@ def get_smtp(host, port, username=None, password=None, TLS=None, SSL=None, auth=
 
 
 def sendmail(addr, text, subject):
+    addr = str(addr)
     mailfrom_addr = get_config("mailfrom_addr") or get_app_config("MAILFROM_ADDR")
     data = {
         "host": get_config("mail_server") or get_app_config("MAIL_SERVER"),

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -171,6 +171,27 @@ def setup():
             set_config("mail_password", None)
             set_config("mail_useauth", None)
 
+            # Set up default emails
+            set_config("verification_email_subject", "Message from {ctf_name}")
+            set_config(
+                "verification_email_body",
+                """Please click the following link to confirm your email address for {ctf_name}: {url}/{token}""",
+            )
+            set_config("user_creation_email_subject", "Message from {ctf_name}")
+            set_config(
+                "user_creation_email_body",
+                """An account has been created for you for {ctf_name} at {url}. \n\nUsername: {name}\nPassword: {password}""",
+            )
+            set_config("password_reset_subject", "Message from {ctf_name}")
+            set_config(
+                "password_reset_body",
+                """Did you initiate a password reset? Click the following link to reset your password:
+
+        {0}/{1}
+
+        """,
+            )
+
             set_config("setup", True)
 
             try:

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -185,7 +185,7 @@ def setup():
             set_config("password_reset_subject", "Message from {ctf_name}")
             set_config(
                 "password_reset_body",
-                """Did you initiate a password reset? Click the following link to reset your password:\n\n{url}/{token}""",
+                """Did you initiate a password reset? Click the following link to reset your password:\n\n{url}/{token}\n\n""",
             )
 
             set_config("setup", True)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -185,11 +185,7 @@ def setup():
             set_config("password_reset_subject", "Message from {ctf_name}")
             set_config(
                 "password_reset_body",
-                """Did you initiate a password reset? Click the following link to reset your password:
-
-        {url}/{token}
-
-        """,
+                """Did you initiate a password reset? Click the following link to reset your password:\n\n{url}/{token}""",
             )
 
             set_config("setup", True)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -187,7 +187,7 @@ def setup():
                 "password_reset_body",
                 """Did you initiate a password reset? Click the following link to reset your password:
 
-        {0}/{1}
+        {url}/{token}
 
         """,
             )


### PR DESCRIPTION
This works fine on my end but I encourage you to find ways to escape the formatting like it is shown here. https://www.palletsprojects.com/blog/jinja-281-released/
I hope this works for you, and I am considering if the from email address would be better suited to being on the email text page instead of its current location.

Should take care of #1002 