### PR TITLE
Update Readme to remove Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check out the [wiki](https://github.com/CTFd/CTFd/wiki) for [deployment options]
 https://demo.ctfd.io/
 
 ## Support
-To get basic support, you can join the [CTFd Slack Community](https://slack.ctfd.io/): [![CTFd Slack](https://slack.ctfd.io/badge.svg)](https://slack.ctfd.io/)
+To get basic support, you can join the [Major League Cyber Community](https://community.majorleaguecyber.org/)
 
 If you prefer commercial support or have a special project, feel free to [contact us](https://ctfd.io/contact/).
 


### PR DESCRIPTION
Slack is no longer used and instead the community is used.