### PR TITLE
Mark 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.2.2 / 2020-01-09
+==================
+
+**General**
+* Add jQuery, Moment, nunjucks, and Howl to window globals to make it easier for plugins to access JS modules
+* Fix issue with timezone loading in config page which was preventing display of CTF times
+
+
 2.2.1 / 2020-01-04
 ==================
 

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -30,7 +30,7 @@ if sys.version_info[0] < 3:
     reload(sys)  # noqa: F821
     sys.setdefaultencoding("utf-8")
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 
 class CTFdRequest(Request):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'Kevin Chung'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'2.2.1'
+release = u'2.2.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
2.2.2 / 2020-01-09
==================

**General**
* Add jQuery, Moment, nunjucks, and Howl to window globals to make it easier for plugins to access JS modules
* Fix issue with timezone loading in config page which was preventing display of CTF times