### PR TITLE
Mark 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 2.2.3 / 2020-01-21
 ==================
 
-This release includes a critical security fix for CTFd versions >= 2.0.0.
+### This release includes a critical security fix for CTFd versions >= 2.0.0
 
 All CTFd administrators are recommended to take the following steps:
-* Upgrade their installations to the latest version
-* Rotate the `SECRET_KEY` value
-* Reset the passwords for all administrator users
+1. Upgrade their installations to the latest version
+2. Rotate the `SECRET_KEY` value
+3. Reset the passwords for all administrator users
 
 **Security**
 * This release includes a fix for a vulnerability allowing an arbitrary user to take over other accounts given their username and a CTFd instance with emails enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+2.2.3 / 2020-01-21
+==================
+
+This release includes a critical security fix for CTFd versions >= 2.0.0.
+
+All CTFd administrators are recommended to take the following steps:
+* Upgrade their installations to the latest version
+* Rotate the `SECRET_KEY` value
+* Reset the passwords for all administrator users
+
+**Security**
+* This release includes a fix for a vulnerability allowing an arbitrary user to take over other accounts given their username and a CTFd instance with emails enabled
+
+**General**
+* Users will receive an email notification when their passwords are reset
+* Fixed an error when users provided incorrect team join information
+
+
 2.2.2 / 2020-01-09
 ==================
 

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -30,7 +30,7 @@ if sys.version_info[0] < 3:
     reload(sys)  # noqa: F821
     sys.setdefaultencoding("utf-8")
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 
 
 class CTFdRequest(Request):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'Kevin Chung'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'2.2.2'
+release = u'2.2.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
2.2.3 / 2020-01-21
==================

### This release includes a critical security fix for CTFd versions >= 2.0.0

All CTFd administrators are recommended to take the following steps:
1. Upgrade their installations to the latest version
2. Rotate the `SECRET_KEY` value
3. Reset the passwords for all administrator users

**Security**
* This release includes a fix for a vulnerability allowing an arbitrary user to take over other accounts given their username and a CTFd instance with emails enabled

**General**
* Users will receive an email notification when their passwords are reset
* Fixed an error when users provided incorrect team join information

