### PR TITLE
Fix SMTP email From header and remove 'Admin' from the From header

### DIFF
--- a/CTFd/utils/email/mailgun.py
+++ b/CTFd/utils/email/mailgun.py
@@ -5,6 +5,8 @@ import requests
 def sendmail(addr, text, subject):
     ctf_name = get_config("ctf_name")
     mailfrom_addr = get_config("mailfrom_addr") or get_app_config("MAILFROM_ADDR")
+    mailfrom_addr = "{} <{}>".format(ctf_name, mailfrom_addr)
+
     mailgun_base_url = get_config("mailgun_base_url") or get_app_config(
         "MAILGUN_BASE_URL"
     )
@@ -14,7 +16,7 @@ def sendmail(addr, text, subject):
             mailgun_base_url + "/messages",
             auth=("api", mailgun_api_key),
             data={
-                "from": "{} Admin <{}>".format(ctf_name, mailfrom_addr),
+                "from": mailfrom_addr,
                 "to": [addr],
                 "subject": subject,
                 "text": text,

--- a/CTFd/utils/email/smtp.py
+++ b/CTFd/utils/email/smtp.py
@@ -19,7 +19,10 @@ def get_smtp(host, port, username=None, password=None, TLS=None, SSL=None, auth=
 
 
 def sendmail(addr, text, subject):
+    ctf_name = get_config("ctf_name")
     mailfrom_addr = get_config("mailfrom_addr") or get_app_config("MAILFROM_ADDR")
+    mailfrom_addr = "{} <{}>".format(ctf_name, mailfrom_addr)
+
     data = {
         "host": get_config("mail_server") or get_app_config("MAIL_SERVER"),
         "port": int(get_config("mail_port") or get_app_config("MAIL_PORT")),

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -355,7 +355,10 @@ def test_user_can_reset_password(mock_smtp):
             # Issue the password reset request
             client.post("/reset_password", data=data)
 
+            ctf_name = get_config("ctf_name")
             from_addr = get_config("mailfrom_addr") or app.config.get("MAILFROM_ADDR")
+            from_addr = "{} <{}>".format(ctf_name, from_addr)
+
             to_addr = "user@user.com"
 
             # Build the email

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -18,7 +18,10 @@ def test_sendmail_with_smtp_from_config_file(mock_smtp):
         app.config["MAIL_USERNAME"] = "username"
         app.config["MAIL_PASSWORD"] = "password"
 
+        ctf_name = get_config("ctf_name")
         from_addr = get_config("mailfrom_addr") or app.config.get("MAILFROM_ADDR")
+        from_addr = "{} <{}>".format(ctf_name, from_addr)
+
         to_addr = "user@user.com"
         msg = "this is a test"
 

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -47,7 +47,10 @@ def test_sendmail_with_smtp_from_db_config(mock_smtp):
         set_config("mail_username", "username")
         set_config("mail_password", "password")
 
+        ctf_name = get_config("ctf_name")
         from_addr = get_config("mailfrom_addr") or app.config.get("MAILFROM_ADDR")
+        from_addr = "{} <{}>".format(ctf_name, from_addr)
+
         to_addr = "user@user.com"
         msg = "this is a test"
 
@@ -98,7 +101,7 @@ def test_sendmail_with_mailgun_from_config_file(fake_post_request):
         assert kwargs["data"] == {
             "to": ["user@user.com"],
             "text": "this is a test",
-            "from": "CTFd Admin <noreply@ctfd.io>",
+            "from": "CTFd <noreply@ctfd.io>",
             "subject": "Message from CTFd",
         }
 
@@ -145,7 +148,7 @@ def test_sendmail_with_mailgun_from_db_config(fake_post_request):
         assert kwargs["data"] == {
             "to": ["user@user.com"],
             "text": "this is a test",
-            "from": "CTFd Admin <noreply@ctfd.io>",
+            "from": "CTFd <noreply@ctfd.io>",
             "subject": "Message from CTFd",
         }
 
@@ -167,7 +170,10 @@ def test_verify_email(mock_smtp):
         set_config("mail_password", "password")
         set_config("verify_emails", True)
 
+        ctf_name = get_config("ctf_name")
         from_addr = get_config("mailfrom_addr") or app.config.get("MAILFROM_ADDR")
+        from_addr = "{} <{}>".format(ctf_name, from_addr)
+
         to_addr = "user@user.com"
 
         with freeze_time("2012-01-14 03:21:34"):


### PR DESCRIPTION
* Fix SMTP email From header to display human readable name
* Remove "Admin" from the From header in the Mailgun integration