### PR TITLE
Add config manipulation to manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
 from CTFd import create_app
+from CTFd.utils import get_config as get_config_util, set_config as set_config_util
 from CTFd.models import *
 
 app = create_app()
@@ -10,5 +11,18 @@ app = create_app()
 manager = Manager(app)
 manager.add_command('db', MigrateCommand)
 
-if __name__ == '__main__':
+
+@manager.command
+def get_config(key):
+    with app.app_context():
+        print(get_config_util(key))
+
+
+@manager.command
+def set_config(key, value):
+    with app.app_context():
+        print(set_config_util(key, value).value)
+
+
+if __name__ == "__main__":
     manager.run()


### PR DESCRIPTION
* Adds `get_config` and `set_config` commands to `manage.py` to manipulate the Config table from a CLI
* Closes #1226 