### PR TITLE
fix missing modal-body param in modalTpl

### DIFF
--- a/CTFd/themes/core/assets/js/ezq.js
+++ b/CTFd/themes/core/assets/js/ezq.js
@@ -11,8 +11,7 @@ const modalTpl =
   '          <span aria-hidden="true">&times;</span>' +
   "        </button>" +
   "      </div>" +
-  '      <div class="modal-body">' +
-  "      </div>" +
+  '      <div class="modal-body">{1}</div>' +
   '      <div class="modal-footer">' +
   "      </div>" +
   "    </div>" +
@@ -58,7 +57,7 @@ const yesTpl =
   '<button type="button" class="btn btn-primary" data-dismiss="modal">Yes</button>';
 
 export function ezAlert(args) {
-  const modal = modalTpl.format(args.title, args.body);
+  const modal = modalTpl.format(args.title, '');
   const obj = $(modal);
 
   if (typeof args.body === "string") {
@@ -141,7 +140,7 @@ export function ezToast(args) {
 }
 
 export function ezQuery(args) {
-  const modal = modalTpl.format(args.title, args.body);
+  const modal = modalTpl.format(args.title, '');
   const obj = $(modal);
 
   if (typeof args.body === "string") {


### PR DESCRIPTION
the modalTpl in `themes/core/assets/js/ezq.js` file missed a format param for modal-body, caused no progress bar when import saved CTFd exports.

ezProgressBar call the function `modalTpl.format(args.title, progress)`，however there is no second param for progress.

```js
const modalTpl =
  '<div class="modal fade" tabindex="-1" role="dialog">' +
  '  <div class="modal-dialog" role="document">' +
  '    <div class="modal-content">' +
  '      <div class="modal-header">' +
  '        <h5 class="modal-title">{0}</h5>' +
  '        <button type="button" class="close" data-dismiss="modal" aria-label="Close">' +
  '          <span aria-hidden="true">&times;</span>' +
  "        </button>" +
  "      </div>" +
  '      <div class="modal-body">' + 
  "      </div>" +
  '      <div class="modal-footer">' +
  "      </div>" +
  "    </div>" +
  "  </div>" +
  "</div>";


export function ezProgressBar(args) {
  if (args.target) {
    const obj = $(args.target);
    const pbar = obj.find(".progress-bar");
    pbar.css("width", args.width + "%");
    return obj;
  }

  const progress = progressTpl.format(args.width);
  // problem is here, no progress bar in modal body
  const modal = modalTpl.format(args.title, progress);

  const obj = $(modal);
  $("main").append(obj);

  return obj.modal("show");
}
```

