### PR TITLE
Update to Python v3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 WORKDIR /opt/CTFd
 RUN mkdir -p /opt/CTFd /var/log/CTFd /var/uploads
 


### PR DESCRIPTION
Python version 3.8 is the most current stable version of Python, and I was able to successfully build and start a Docker image using this version of Python. Will continue to test on 3.8 to validate that it functions.