### PR TITLE
Fix typecasting exception when using utils.get_config to get theme

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -96,7 +96,7 @@ class ThemeLoader(FileSystemLoader):
             return super(ThemeLoader, self).get_source(environment, template)
 
         # Load regular theme data
-        theme = utils.get_config("ctf_theme")
+        theme = str(utils.get_config("ctf_theme"))
         template = "/".join([theme, "templates", template])
         return super(ThemeLoader, self).get_source(environment, template)
 


### PR DESCRIPTION
When CTFd attempts to load a theme that has a numeric value as a name (ie. `2020`), it will toss a `TypeError` exception, since `utils.get_config` automatically typecasted it to an `int`:

```
ctfd_1     | Traceback (most recent call last):
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base_async.py", line 56, in handle
ctfd_1     |     self.handle_request(listener_name, req, client, addr)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/ggevent.py", line 160, in handle_request
ctfd_1     |     addr)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base_async.py", line 107, in handle_request
ctfd_1     |     respiter = self.wsgi(environ, resp.start_response)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
ctfd_1     |     return self.wsgi_app(environ, start_response)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app
ctfd_1     |     response = self.handle_exception(e)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask_restplus/api.py", line 584, in error_router
ctfd_1     |     return original_handler(e)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1878, in handle_exception
ctfd_1     |     server_error = handler(server_error)
ctfd_1     |   File "/opt/CTFd/CTFd/errors.py", line 16, in general_error
ctfd_1     |     return render_template("errors/500.html"), 500
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask/templating.py", line 138, in render_template
ctfd_1     |     ctx.app.jinja_env.get_or_select_template(template_name_or_list),
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 930, in get_or_select_template
ctfd_1     |     return self.get_template(template_name_or_list, parent, globals)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 883, in get_template
ctfd_1     |     return self._load_template(name, self.make_globals(globals))
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 857, in _load_template
ctfd_1     |     template = self.loader.load(self, name, globals)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/jinja2/loaders.py", line 117, in load
ctfd_1     |     source, filename, uptodate = self.get_source(environment, name)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask/templating.py", line 60, in get_source
ctfd_1     |     return self._get_source_fast(environment, template)
ctfd_1     |   File "/usr/local/lib/python3.7/site-packages/flask/templating.py", line 86, in _get_source_fast
ctfd_1     |     return loader.get_source(environment, template)
ctfd_1     |   File "/opt/CTFd/CTFd/__init__.py", line 100, in get_source
ctfd_1     |     template = "/".join([theme, "templates", template])
ctfd_1     | TypeError: sequence item 0: expected str instance, int found
```

Here's the simple fix:

```python
         # Load regular theme data
-        theme = utils.get_config("ctf_theme")
+        theme = str(utils.get_config("ctf_theme"))
         template = "/".join([theme, "templates", template])
         return super(ThemeLoader, self).get_source(environment, template)
```