### PR TITLE
bugfix: affix @authed_only to /notifications

### DIFF
--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -266,6 +266,7 @@ def integrations():
 
 
 @views.route("/notifications", methods=["GET"])
+@authed_only
 def notifications():
     notifications = Notifications.query.order_by(Notifications.id.desc()).all()
     return render_template("notifications.html", notifications=notifications)


### PR DESCRIPTION
I am a student using CTFd to create a small CTF for my university, I found the platform very efficient and easy to setup. CTFd is simply amazing!

While exploring the codebase, I found that anonymous users can also access notifications which, in most cases, is not what organizers want.

Thus this pull simply adds `@authed_only` decorator to `/notifications` route to make it view-able by authenticated users only.