### PR TITLE
Add CTFtime.org as OAuth provider

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -307,9 +307,8 @@ def login():
 
 @auth.route("/oauth")
 def oauth_login():
-    endpoint = (
-        get_app_config("OAUTH_AUTHORIZATION_ENDPOINT")
-        or get_config("oauth_authorization_endpoint")
+    endpoint = get_app_config("OAUTH_AUTHORIZATION_ENDPOINT") or get_config(
+        "oauth_authorization_endpoint"
     )
 
     if get_config("user_mode") == "teams":
@@ -330,7 +329,9 @@ def oauth_login():
         endpoint=endpoint, client_id=client_id, scope=scope, state=session["nonce"]
     )
 
-    callback_url = get_app_config("OAUTH_CALLBACK_ENDPOINT") or get_config("oauth_callback_endpoint")
+    callback_url = get_app_config("OAUTH_CALLBACK_ENDPOINT") or get_config(
+        "oauth_callback_endpoint"
+    )
     if callback_url:
         redirect_url += "&redirect_uri={callback_url}".format(callback_url=callback_url)
     return redirect(redirect_url)
@@ -347,9 +348,8 @@ def oauth_redirect():
         return redirect(url_for("auth.login"))
 
     if oauth_code:
-        url = (
-            get_app_config("OAUTH_TOKEN_ENDPOINT")
-            or get_config("oauth_token_endpoint")
+        url = get_app_config("OAUTH_TOKEN_ENDPOINT") or get_config(
+            "oauth_token_endpoint"
         )
 
         client_id = get_app_config("OAUTH_CLIENT_ID") or get_config("oauth_client_id")
@@ -367,9 +367,8 @@ def oauth_redirect():
 
         if token_request.status_code == requests.codes.ok:
             token = token_request.json()["access_token"]
-            user_url = (
-                get_app_config("OAUTH_API_ENDPOINT")
-                or get_config("oauth_api_endpoint")
+            user_url = get_app_config("OAUTH_API_ENDPOINT") or get_config(
+                "oauth_api_endpoint"
             )
 
             headers = {
@@ -395,7 +394,10 @@ def oauth_redirect():
                     db.session.add(user)
                     db.session.commit()
                 else:
-                    log("logins", "[{date}] {ip} - Public registration via OAuth blocked")
+                    log(
+                        "logins",
+                        "[{date}] {ip} - Public registration via OAuth blocked",
+                    )
                     error_for(
                         endpoint="auth.login",
                         message="Public registration is disabled. Please try again later.",

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -77,9 +77,7 @@ class Config(object):
         CACHE_DIR = os.path.join(
             os.path.dirname(__file__), os.pardir, ".data", "filesystem_cache"
         )
-        CACHE_THRESHOLD = (
-            0
-        )  # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
+        CACHE_THRESHOLD = 0  # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
 
     """
     === SECURITY ===
@@ -259,7 +257,9 @@ class Config(object):
 
     if OAUTH_PROVIDER == "mlc":
         OAUTH_TOKEN_ENDPOINT = "https://auth.majorleaguecyber.org/oauth/token"
-        OAUTH_AUTHORIZATION_ENDPOINT = "https://auth.majorleaguecyber.org/oauth/authorize"
+        OAUTH_AUTHORIZATION_ENDPOINT = (
+            "https://auth.majorleaguecyber.org/oauth/authorize"
+        )
         OAUTH_API_ENDPOINT = "https://api.majorleaguecyber.org/user"
 
     elif OAUTH_PROVIDER == "ctftime":

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -79,7 +79,7 @@ class Config(object):
         )
         CACHE_THRESHOLD = (
             0
-        ) # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
+        )  # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
 
     """
     === SECURITY ===

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -77,7 +77,9 @@ class Config(object):
         CACHE_DIR = os.path.join(
             os.path.dirname(__file__), os.pardir, ".data", "filesystem_cache"
         )
-        CACHE_THRESHOLD = 0  # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
+        CACHE_THRESHOLD = (
+            0
+        ) # Override the threshold of cached values on the filesystem. The default is 500. Don't change unless you know what you're doing.
 
     """
     === SECURITY ===

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -247,7 +247,26 @@ class Config(object):
 
     MajorLeagueCyber Integration
         Register an event at https://majorleaguecyber.org/ and use the Client ID and Client Secret here
+
+    CTFtime Integration
+        Register an event at https://ctftime.org/ and use the Client ID and Client Secret here,
+        also set
+        OAUTH_PROVIDER = "ctftime"
+        OAUTH_CALLBACK_ENDPOINT = "https://yourctfd-domain.com/redirect"
     """
+    OAUTH_PROVIDER = os.getenv("OAUTH_PROVIDER") or "mlc"
+    OAUTH_CALLBACK_ENDPOINT = os.getenv("OAUTH_CALLBACK_ENDPOINT") or ""
+
+    if OAUTH_PROVIDER == "mlc":
+        OAUTH_TOKEN_ENDPOINT = "https://auth.majorleaguecyber.org/oauth/token"
+        OAUTH_AUTHORIZATION_ENDPOINT = "https://auth.majorleaguecyber.org/oauth/authorize"
+        OAUTH_API_ENDPOINT = "https://api.majorleaguecyber.org/user"
+
+    elif OAUTH_PROVIDER == "ctftime":
+        OAUTH_TOKEN_ENDPOINT = "https://oauth.ctftime.org/token"
+        OAUTH_AUTHORIZATION_ENDPOINT = "https://oauth.ctftime.org/authorize"
+        OAUTH_API_ENDPOINT = "https://oauth.ctftime.org/user"
+
     OAUTH_CLIENT_ID = os.getenv("OAUTH_CLIENT_ID")
     OAUTH_CLIENT_SECRET = os.getenv("OAUTH_CLIENT_SECRET")
 

--- a/CTFd/themes/admin/templates/config.html
+++ b/CTFd/themes/admin/templates/config.html
@@ -16,9 +16,16 @@
 				<li class="nav-item">
 					<a class="nav-link rounded-0" href="#accounts" role="tab" data-toggle="tab">Accounts</a>
 				</li>
+                {% if integrations.mlc() %}
 				<li class="nav-item">
 					<a class="nav-link rounded-0" href="#mlc" role="tab" data-toggle="tab">MajorLeagueCyber</a>
 				</li>
+                {% endif %}
+                {% if integrations.ctftime() %}
+				<li class="nav-item">
+					<a class="nav-link rounded-0" href="#ictftime" role="tab" data-toggle="tab">CTFtime.org</a>
+				</li>
+                {% endif %}
 				<li class="nav-item">
 					<a class="nav-link rounded-0" href="#settings" role="tab" data-toggle="tab">Settings</a>
 				</li>
@@ -53,6 +60,8 @@
 				{% include "admin/configs/accounts.html" %}
 
 				{% include "admin/configs/mlc.html" %}
+
+                {% include "admin/configs/ctftime.html" %}
 
 				{% include "admin/configs/settings.html" %}
 

--- a/CTFd/themes/admin/templates/configs/ctftime.html
+++ b/CTFd/themes/admin/templates/configs/ctftime.html
@@ -1,0 +1,44 @@
+<div role="tabpanel" class="tab-pane config-section" id="ictftime">
+	<form method="POST" autocomplete="off" class="w-100">
+
+		<div class="form-group">
+			<label>
+				Client ID
+				<small class="form-text text-muted">
+					OAuth Client ID for <a href="https://ctftime.org/">CTFtime</a> integration.
+				</small>
+			</label>
+			<input class="form-control" id='oauth_client_id' name='oauth_client_id' type='text'
+				   placeholder=""
+				   {% if oauth_client_id is defined and oauth_client_id != None %}value="{{ oauth_client_id }}"{% endif %}>
+		</div>
+
+		<div class="form-group">
+			<label>
+				Client Secret
+				<small class="form-text text-muted">
+					OAuth Client Secret for <a href="https://ctftime.org/">CTFtime.org</a> integration.
+				</small>
+			</label>
+			<input class="form-control" id='oauth_client_secret' name='oauth_client_secret' type='text'
+				   placeholder=""
+				   {% if oauth_client_secret is defined and oauth_client_secret != None %}value="{{ oauth_client_secret }}"{% endif %}>
+		</div>
+
+        <div class="form-group">
+			<label>
+				OAuth callback endpoint
+				<small class="form-text text-muted">
+					Basically, domain of your CTFd installation plus /redirect
+				</small>
+			</label>
+			<input class="form-control" id='oauth_callback_endpoint' name='oauth_callback_endpoint' type='text'
+				   placeholder=""
+				   {% if oauth_callback_endpoint is defined and oauth_callback_endpoint != None %}
+                   value="{{ oauth_callback_endpoint }}"{% endif %}>
+		</div>
+
+
+		<button type="submit" class="btn btn-md btn-primary float-right">Update</button>
+	</form>
+</div>

--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -83,9 +83,17 @@
 				<option value="private" {% if registration_visibility == 'private' %}selected{% endif %}>
 					Private
 				</option>
+                {% if integrations.mlc() %}
 				<option value="mlc" {% if registration_visibility == 'mlc' %}selected{% endif %}>
 					MajorLeagueCyber Only
 				</option>
+                {% endif %}
+
+                {% if integrations.ctftime() %}
+				<option value="ctftime" {% if registration_visibility == 'ctftime' %}selected{% endif %}>
+					CTFtime Only
+				</option>
+                {% endif %}
 			</select>
 		</div>
 

--- a/CTFd/themes/admin/templates/teams/team.html
+++ b/CTFd/themes/admin/templates/teams/team.html
@@ -77,9 +77,16 @@
 		</div>
 
 		{% if team.oauth_id %}
+            {% if integrations.mlc() %}
 			<a href="https://majorleaguecyber.org/t/{{ team.name }}">
 				<h3><span class="badge badge-primary">Official</span></h3>
 			</a>
+            {% endif %}
+            {% if integrations.ctftime() %}
+			<a href="https://ctftime.org/team/{{ team.oauth_id }}">
+				<h3><span class="badge badge-primary">CTFtime</span></h3>
+			</a>
+            {% endif %}
 		{% endif %}
 
 		{% if team.affiliation %}

--- a/CTFd/themes/admin/templates/teams/teams.html
+++ b/CTFd/themes/admin/templates/teams/teams.html
@@ -71,9 +71,16 @@
 								{{ team.name | truncate(32) }}
 							</a>
 							{% if team.oauth_id %}
+                                {% if integrations.mlc() %}
 								<a href="https://majorleaguecyber.org/t/{{ team.name }}">
 									<span class="badge badge-primary">Official</span>
 								</a>
+                                {% endif %}
+                                {% if integrations.ctftime() %}
+								<a href="https://ctftime.org/team/{{ team.oauth_id }}">
+									<span class="badge badge-primary">CTFtime</span>
+								</a>
+                                {% endif %}
 							{% endif %}
 							<span class="d-block text-muted">
 								<small>

--- a/CTFd/themes/admin/templates/users/user.html
+++ b/CTFd/themes/admin/templates/users/user.html
@@ -87,9 +87,16 @@
 
 		<h2 id="team-email" class="text-center">{{ user.email }}</h2>
 		{% if user.oauth_id %}
+            {% if integrations.mlc() %}
 			<a href="https://majorleaguecyber.org/u/{{ user.name }}">
 				<h3><span class="badge badge-primary">Official</span></h3>
 			</a>
+            {% endif %}
+            {% if integrations.ctftime() %}
+			<a href="https://ctftime.org/user/{{ user.oauth_id }}">
+				<h3><span class="badge badge-primary">CTFtime</span></h3>
+			</a>
+            {% endif %}
 		{% endif %}
 
 		{% if user.team_id %}

--- a/CTFd/themes/admin/templates/users/users.html
+++ b/CTFd/themes/admin/templates/users/users.html
@@ -78,9 +78,16 @@
 								{{ user.name | truncate(32) }}
 							</a>
 							{% if user.oauth_id %}
+                                {% if integrations.mlc() %}
 								<a href="https://majorleaguecyber.org/u/{{ user.name }}">
 									<span class="badge badge-primary">Official</span>
 								</a>
+                                {% endif %}
+                                {% if integrations.ctftime() %}
+								<a href="https://ctftime.org/user/{{ user.oauth_id }}">
+									<span class="badge badge-primary">CTFtime</span>
+								</a>
+                                {% endif %}
 							{% endif %}
 							{% if user.affiliation %}
 								<span class="d-block text-muted"><small>{{ user.affiliation | truncate(20) }}</small></span>

--- a/CTFd/themes/core/templates/login.html
+++ b/CTFd/themes/core/templates/login.html
@@ -28,6 +28,14 @@
 			<hr>
 			{% endif %}
 
+			{% if integrations.ctftime() %}
+			<a class="btn btn-secondary btn-lg btn-block" href="{{ url_for('auth.oauth_login') }}">
+				Login with CTFtime
+			</a>
+
+			<hr>
+			{% endif %}
+
 			<form method="post" accept-charset="utf-8" autocomplete="off" role="form" class="form-horizontal">
 				<div class="form-group">
 					<label for="name-input">

--- a/CTFd/themes/core/templates/register.html
+++ b/CTFd/themes/core/templates/register.html
@@ -28,6 +28,14 @@
 			<hr>
 			{% endif %}
 
+            {% if integrations.ctftime() %}
+			<a class="btn btn-secondary btn-lg btn-block" href="{{ url_for('auth.oauth_login') }}">
+				Login with CTFtime
+			</a>
+
+			<hr>
+			{% endif %}
+
 			<form method="post" accept-charset="utf-8" autocomplete="off" role="form" class="form-horizontal">
 				<div class="form-group">
 					<label for="name-input">

--- a/CTFd/themes/core/templates/scoreboard.html
+++ b/CTFd/themes/core/templates/scoreboard.html
@@ -51,13 +51,27 @@
 
 									{% if standing.oauth_id %}
 										{% if get_config('user_mode') == 'teams' %}
+                                            {% if integrations.mlc() %}
 										<a href="https://majorleaguecyber.org/t/{{ standing.name }}">
 											<span class="badge badge-primary">Official</span>
 										</a>
+                                                {% endif %}
+                                            {% if integrations.ctftime() %}
+										<a href="https://ctftime.org/team/{{ standing.oauth_id }}">
+											<span class="badge badge-primary">CTFtime</span>
+										</a>
+                                                {% endif %}
 										{% elif get_config('user_mode') == 'users' %}
+                                            {% if integrations.mlc() %}
 										<a href="https://majorleaguecyber.org/u/{{ standing.name }}">
 											<span class="badge badge-primary">Official</span>
 										</a>
+                                            {% endif %}
+                                            {% if integrations.ctftime() %}
+										<a href="https://ctftime.org/user/{{ standing.oauth_id }}">
+											<span class="badge badge-primary">CTFtime</span>
+										</a>
+                                            {% endif %}
 										{% endif %}
 									{% endif %}
 								</a>

--- a/CTFd/themes/core/templates/setup.html
+++ b/CTFd/themes/core/templates/setup.html
@@ -217,6 +217,51 @@
 						</div>
 					</div>
 					<div class="tab-pane fade" id="integrations" role="tabpanel">
+                        {% if integrations.ctftime() %}
+						<div class="form-group">
+							<h4>CTFtime Integration</h4>
+						</div>
+
+                    	<form method="POST" autocomplete="off" class="w-100">
+		                <div class="form-group">
+			            <label>
+				            Client ID
+				            <small class="form-text text-muted">
+                                Client ID for <a href="https://ctftime.org/">CTFtime</a> integration.
+            				</small>
+            			</label>
+            			<input class="form-control" id='oauth_client_id' name='oauth_client_id' type='text'
+				            placeholder=""
+    				   {% if oauth_client_id is defined and oauth_client_id != None %}
+                               value="{{ oauth_client_id }}"{% endif %}>
+		                </div>
+
+		                <div class="form-group">
+			            <label>
+				            Client Secret
+				            <small class="form-text text-muted">
+    					        OAuth Client Secret for <a href="https://ctftime.org/">CTFtime</a> integration.
+	    			        </small>
+			            </label>
+			            <input class="form-control" id='oauth_client_secret' name='oauth_client_secret' type='text'
+				            placeholder=""
+				            {% if oauth_client_secret is defined and oauth_client_secret != None %}
+                               value="{{ oauth_client_secret }}"{% endif %}>
+		                </div>
+
+                        <div class="form-group">
+			            <label>
+				            OAuth callback endpoint
+				            <small class="form-text text-muted">
+					            Basically, URL of your CTFd installation with "/redirect" as path
+				            </small>
+			            </label>
+			            <input class="form-control" id='oauth_callback_endpoint'
+                               name='oauth_callback_endpoint' type='text' placeholder=""
+				            {% if oauth_callback_endpoint is defined and oauth_callback_endpoint != None %}
+                                value="{{ oauth_callback_endpoint }}"{% endif %}>
+	                    </div>
+                        {% else %}
 						<div class="form-group">
 							<h4>MajorLeagueCyber Integration</h4>
 							<p>
@@ -233,6 +278,7 @@
 								Setup
 							</button>
 						</div>
+                        {% endif %}
 
 						<br>
 						<hr>

--- a/CTFd/themes/core/templates/teams/private.html
+++ b/CTFd/themes/core/templates/teams/private.html
@@ -104,9 +104,16 @@
 		<div class="container">
 			<h1 id="team-id" team-id="{{ team.id }}">{{ team.name }}</h1>
 			{% if team.oauth_id %}
+		        {% if integrations.mlc() %}
 				<a href="https://majorleaguecyber.org/t/{{ team.name }}">
 					<h3><span class="badge badge-primary">Official</span></h3>
 				</a>
+                {% endif %}
+		        {% if integrations.ctftime() %}
+				<a href="https://ctftime.org/team/{{ team.oauth_id }}">
+					<h3><span class="badge badge-primary">CTFtime</span></h3>
+				</a>
+                {% endif %}
 			{% endif %}
 			{% if team.affiliation %}
 				<h3 class="d-inline-block">

--- a/CTFd/themes/core/templates/teams/public.html
+++ b/CTFd/themes/core/templates/teams/public.html
@@ -8,9 +8,16 @@
 		<div class="container">
 			<h1 id="team-id" team-id="{{ team.id }}">{{ team.name }}</h1>
 			{% if team.oauth_id %}
+                {% if integrations.mlc() %}
 				<a href="https://majorleaguecyber.org/t/{{ team.name }}">
 					<h3><span class="badge badge-primary">Official</span></h3>
 				</a>
+                {% endif %}
+                {% if integrations.ctftime() %}
+				<a href="https://ctftime.org/team/{{ team.oauth_id }}">
+					<h3><span class="badge badge-primary">CTFtime</span></h3>
+				</a>
+                {% endif %}
 			{% endif %}
 			{% if team.affiliation %}
 				<h3 class="d-inline-block">

--- a/CTFd/themes/core/templates/teams/team_enrollment.html
+++ b/CTFd/themes/core/templates/teams/team_enrollment.html
@@ -32,6 +32,20 @@
 				<a class="btn btn-light w-100" href="{{ url_for('teams.new') }}">Create Unofficial Team</a>
 			</div>
 		</div>
+        {% elif integrations.ctftime() %}
+		<div class="row">
+			<div class="col-md-6 offset-md-3 text-center">
+				<a class="btn btn-primary w-100" href="{{ url_for('auth.oauth_login') }}">Play with CTFtime Team</a>
+			</div>
+		</div>
+		<div class="row pt-3">
+			<div class="col-md-3 offset-md-3 text-center">
+				<a class="btn btn-light w-100" href="{{ url_for('teams.join') }}">Join Unofficial Team</a>
+			</div>
+			<div class="col-md-3 text-center">
+				<a class="btn btn-light w-100" href="{{ url_for('teams.new') }}">Create Unofficial Team</a>
+			</div>
+		</div>
 		{% else %}
 		<div class="row pt-3">
 			<div class="col-md-3 offset-md-3 text-center">

--- a/CTFd/themes/core/templates/teams/teams.html
+++ b/CTFd/themes/core/templates/teams/teams.html
@@ -31,9 +31,16 @@
 							<span>{{ team.name | truncate(50) }}</span>
 						{% endif %}
 						{% if team.oauth_id %}
+                            {% if integrations.mlc() %}
 							<a href="https://majorleaguecyber.org/t/{{ team.name }}">
 								<span class="badge badge-primary">Official</span>
 							</a>
+                            {% endif %}
+                            {% if integrations.ctftime() %}
+							<a href="https://ctftime.org/team/{{ team.oauth_id }}">
+								<span class="badge badge-primary">CTftime</span>
+							</a>
+                            {% endif %}
 						{% endif %}
 						</td>
 						<td class="text-center" style="width: 10px;">

--- a/CTFd/themes/core/templates/users/private.html
+++ b/CTFd/themes/core/templates/users/private.html
@@ -19,9 +19,16 @@
 			{% endif %}
 
 			{% if user.oauth_id %}
+                {% if integrations.mlc() %}
 				<a href="https://majorleaguecyber.org/u/{{ user.name }}">
 					<h3><span class="badge badge-primary">Official</span></h3>
 				</a>
+                {% endif %}
+                {% if integrations.ctftime() %}
+				<a href="https://ctftime.org/user/{{ user.oauth_id }}">
+					<h3><span class="badge badge-primary">CTFtime</span></h3>
+				</a>
+                {% endif %}
 			{% endif %}
 
 			{% if user.affiliation %}

--- a/CTFd/themes/core/templates/users/public.html
+++ b/CTFd/themes/core/templates/users/public.html
@@ -19,9 +19,16 @@
 			{% endif %}
 
 			{% if user.oauth_id %}
+                {% if integrations.mlc() %}
 				<a href="https://majorleaguecyber.org/u/{{ user.name }}">
 					<h3><span class="badge badge-primary">Official</span></h3>
 				</a>
+                {% endif %}
+                {% if integrations.ctftime() %}
+				<a href="https://ctftime.org/user/{{ user.oauth_id }}">
+					<h3><span class="badge badge-primary">CTFtime</span></h3>
+				</a>
+                {% endif %}
 			{% endif %}
 
 			{% if user.affiliation %}

--- a/CTFd/themes/core/templates/users/users.html
+++ b/CTFd/themes/core/templates/users/users.html
@@ -33,9 +33,16 @@
 									<span>{{ user.name | truncate(50) }}</span>
 								{% endif %}
 								{% if user.oauth_id %}
+                                    {% if integrations.mlc() %}
 									<a href="https://majorleaguecyber.org/u/{{ user.name }}">
 										<span class="badge badge-primary">Official</span>
 									</a>
+                                    {% endif %}
+                                    {% if integrations.ctftime() %}
+									<a href="https://ctftime.org/user/{{ user.oauth_id }}">
+										<span class="badge badge-primary">CTFtime</span>
+									</a>
+                                    {% endif %}
 								{% endif %}
 							</td>
 							<td class="text-center" style="width: 10px;">

--- a/CTFd/utils/config/integrations.py
+++ b/CTFd/utils/config/integrations.py
@@ -1,10 +1,23 @@
-from CTFd.utils import get_config
+from CTFd.utils.config import is_setup
+from CTFd.utils import get_config, get_app_config
 
 
 def mlc():
+    if get_app_config("OAUTH_PROVIDER") != "mlc":
+        return False
+    if not is_setup():
+        return True
     return get_config("oauth_client_id") and get_config("oauth_client_secret")
 
 
-def mlc_registration():
+def ctftime():
+    if get_app_config("OAUTH_PROVIDER") != "ctftime":
+        return False
+    if not is_setup():
+        return True
+    return get_config("oauth_client_id") and get_config("oauth_client_secret")
+
+
+def oauth_registration():
     v = get_config("registration_visibility")
-    return v == "mlc"
+    return v in ["mlc", "ctftime"]

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -17,7 +17,7 @@ from CTFd.models import (
     UserTokens,
     db,
 )
-from CTFd.utils import config, get_config, markdown, set_config, get_app_config
+from CTFd.utils import config, get_config, markdown, set_config
 from CTFd.utils import user as current_user
 from CTFd.utils import validators
 from CTFd.utils.config import is_setup

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ OAUTH_CLIENT_ID = None
 OAUTH_CLIENT_SECRET = None
 ```
 
+## CTFtime.org
+CTFd can also be integrated with [CTFtime.org](https://ctftime.org/). CTF event tracking and archive plaform.
+By registering your CTF event with CTFtime.org users can automatically login and track their team scores.
+
+To integrate with CTFtime.org, register an account, create CTF an event.
+Switch oauth provider to "ctftime" and set OAuth callback endpoint:
+```
+OAUTH_PROVIDER = "ctftime"
+OAUTH_CALLBACK_ENDPOINT = "https://your-ctfd-domain.com/redirect"
+```
+then set client ID and client secret in the relevant portion in `CTFd/config.py` or in the admin panel.
+
+
 ## Credits
  * Logo by [Laura Barbera](http://www.laurabb.com/)
  * Theme by [Christopher Thompson](https://github.com/breadchris)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -141,11 +141,24 @@ Specifies whether or not to enable to server-sent events based Notifications sys
 
 OAUTH_CLIENT_ID
 ~~~~~~~~~~~~~~~
-
+OAuth client ID
 
 OAUTH_CLIENT_SECRET
 ~~~~~~~~~~~~~~~~~~~
+OAuth client secret
 
+OAUTH_CALLBACK_ENDPOINT
+~~~~~~~~~~~~~~~~~~~~~~~
+URL handling OAuth callback.
+Usually is is URL of your CTFd installation with "/redirect" path.
+
+OAUTH_PROVIDER
+~~~~~~~~~~~~~~
+Can be used to switch OAuth integration endpoints.
+Current OAuth providers:
+"mlc" - [MajorLeagueCyber](https://majorleaguecyber.org/)
+"ctftime" - [CTFtime](https://ctftime.org/)
+Default: mlc
 
 Application Level Configuration
 -------------------------------


### PR DESCRIPTION
First of all - thanks for this amazing CTF board engine!
I'm pretty sure it made CTF running much easier for a lot of people.
And I understand that MajorLeagueCyber was part of the project, but still - people use CTFtime.org and they have to create and manage teams in multiple places.
So I decided to make their life a bit easier and run OAuth engine at CTFtime and added some hacks to integrate it to CTFd. Not sure if I used correct way, but I was not able to do it only with currect plugin system.

Thanks.