### PR TITLE
Re-enable the Jinja LRU Cache

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import sys
+import weakref
 from distutils.version import StrictVersion
 
 from flask import Flask, Request
@@ -71,10 +72,29 @@ class SandboxedBaseEnvironment(SandboxedEnvironment):
     def __init__(self, app, **options):
         if "loader" not in options:
             options["loader"] = app.create_global_jinja_loader()
-        # Disable cache entirely so that themes can be switched (#662)
-        # If the cache is enabled, switching themes will cause odd rendering errors
-        SandboxedEnvironment.__init__(self, cache_size=0, **options)
+        SandboxedEnvironment.__init__(self, **options)
         self.app = app
+
+    def _load_template(self, name, globals):
+        if self.loader is None:
+            raise TypeError("no loader for this environment specified")
+
+        cache_name = name
+        if name.startswith("admin/") is False:
+            theme = str(utils.get_config("ctf_theme"))
+            cache_name = theme + "/" + name
+
+        cache_key = (weakref.ref(self.loader), cache_name)
+        if self.cache is not None:
+            template = self.cache.get(cache_key)
+            if template is not None and (
+                not self.auto_reload or template.is_up_to_date
+            ):
+                return template
+        template = self.loader.load(self, name, globals)
+        if self.cache is not None:
+            self.cache[cache_key] = template
+        return template
 
 
 class ThemeLoader(FileSystemLoader):

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -79,11 +79,14 @@ class SandboxedBaseEnvironment(SandboxedEnvironment):
         if self.loader is None:
             raise TypeError("no loader for this environment specified")
 
+        # Add theme to the LRUCache cache key
         cache_name = name
         if name.startswith("admin/") is False:
             theme = str(utils.get_config("ctf_theme"))
             cache_name = theme + "/" + name
 
+        # Rest of this code is copied from Jinja
+        # https://github.com/pallets/jinja/blob/master/src/jinja2/environment.py#L802-L815
         cache_key = (weakref.ref(self.loader), cache_name)
         if self.cache is not None:
             template = self.cache.get(cache_key)


### PR DESCRIPTION
Re-enable the Jinja LRU Cache by overriding the `Environment._load_template` function and adding a theme namespace. 

This is not a great solution but it's likely that this is causing a lot of slowdown because we're continually reparsing and compiling templates. 

We still cannot completely clear the jinja cache but this way theme changes don't trample each other. 

Closes #662