### PR TITLE
Mark 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+2.3.3 / 2020-04-12
+==================
+
+**General**
+* Re-enable the Jinja LRU Cache for **significant speedups** when returning HTML content
+
+**API**
+* `POST /api/v1/unlocks` will no longer allow duplicate unlocks to happen
+
+**Admin Panel**
+* Makes `Account Visibility` subtext clearer by explaining the `Private` setting in Config Panel
+
+**Themes**
+* Fixes an issue with using a theme with a purely numeric name
+* Fixes issue where the scoreboard graph always said Teams regardless of mode
+
+**Miscellaneous**
+* Bump max log file size to 10 MB and fix log rotation
+* Docker image dependencies (apk & pip) are no longer cached reducing the image size slightly
+
+
 2.3.2 / 2020-03-15
 ==================
 

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -31,7 +31,7 @@ if sys.version_info[0] < 3:
     reload(sys)  # noqa: F821
     sys.setdefaultencoding("utf-8")
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 
 
 class CTFdRequest(Request):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u"Kevin Chung"
 # The short X.Y version
 version = u""
 # The full version, including alpha/beta/rc tags
-release = u"2.3.2"
+release = u"2.3.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
2.3.3 / 2020-04-12
==================

**General**
* Re-enable the Jinja LRU Cache for **significant speedups** when returning HTML content

**API**
* `POST /api/v1/unlocks` will no longer allow duplicate unlocks to happen

**Admin Panel**
* Makes `Account Visibility` subtext clearer by explaining the `Private` setting in Config Panel

**Themes**
* Fixes an issue with using a theme with a purely numeric name
* Fixes issue where the scoreboard graph always said Teams regardless of mode

**Miscellaneous**
* Bump max log file size to 10 MB and fix log rotation
* Docker image dependencies (apk & pip) are no longer cached reducing the image size slightly