### PR TITLE
Deprecates storing user type in session

### DIFF
--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -13,7 +13,7 @@ from CTFd.utils.decorators.visibility import (
     check_account_visibility,
     check_score_visibility,
 )
-from CTFd.utils.user import get_current_team, is_admin
+from CTFd.utils.user import get_current_team, get_current_user, get_current_user_type, is_admin
 
 teams_namespace = Namespace("teams", description="Endpoint to retrieve Teams")
 
@@ -23,7 +23,8 @@ class TeamList(Resource):
     @check_account_visibility
     def get(self):
         teams = Teams.query.filter_by(hidden=False, banned=False)
-        view = copy.deepcopy(TeamSchema.views.get(session.get("type", "user")))
+        user_type = get_current_user_type(fallback="user")
+        view = copy.deepcopy(TeamSchema.views.get(user_type))
         view.remove("members")
         response = TeamSchema(view=view, many=True).dump(teams)
 
@@ -35,7 +36,8 @@ class TeamList(Resource):
     @admins_only
     def post(self):
         req = request.get_json()
-        view = TeamSchema.views.get(session.get("type", "self"))
+        user_type = get_current_user_type()
+        view = TeamSchema.views.get(user_type)
         schema = TeamSchema(view=view)
         response = schema.load(req)
 
@@ -63,7 +65,8 @@ class TeamPublic(Resource):
         if (team.banned or team.hidden) and is_admin() is False:
             abort(404)
 
-        view = TeamSchema.views.get(session.get("type", "user"))
+        user_type = get_current_user_type(fallback="user")
+        view = TeamSchema.views.get(user_type)
         schema = TeamSchema(view=view)
         response = schema.dump(team)
 

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -13,7 +13,7 @@ from CTFd.utils.decorators.visibility import (
     check_account_visibility,
     check_score_visibility,
 )
-from CTFd.utils.user import get_current_team, get_current_user, get_current_user_type, is_admin
+from CTFd.utils.user import get_current_team, get_current_user_type, is_admin
 
 teams_namespace = Namespace("teams", description="Endpoint to retrieve Teams")
 

--- a/CTFd/api/v1/tokens.py
+++ b/CTFd/api/v1/tokens.py
@@ -7,7 +7,7 @@ from CTFd.models import Tokens, db
 from CTFd.schemas.tokens import TokenSchema
 from CTFd.utils.decorators import authed_only, require_verified_emails
 from CTFd.utils.security.auth import generate_user_token
-from CTFd.utils.user import get_current_user, is_admin
+from CTFd.utils.user import get_current_user, get_current_user_type, is_admin
 
 tokens_namespace = Namespace("tokens", description="Endpoint to retrieve Tokens")
 
@@ -62,7 +62,8 @@ class TokenDetail(Resource):
                 id=token_id, user_id=session["id"]
             ).first_or_404()
 
-        schema = TokenSchema(view=session.get("type", "user"))
+        user_type = get_current_user_type(fallback="user")
+        schema = TokenSchema(view=user_type)
         response = schema.dump(token)
 
         if response.errors:

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -1,4 +1,4 @@
-from flask import abort, request, session
+from flask import abort, request
 from flask_restx import Namespace, Resource
 
 from CTFd.cache import clear_standings

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -22,7 +22,7 @@ from CTFd.utils.decorators.visibility import (
     check_score_visibility,
 )
 from CTFd.utils.email import sendmail, user_created_notification
-from CTFd.utils.user import get_current_user, is_admin
+from CTFd.utils.user import get_current_user, get_current_user_type, is_admin
 
 users_namespace = Namespace("users", description="Endpoint to retrieve Users")
 
@@ -80,7 +80,8 @@ class UserPublic(Resource):
         if (user.banned or user.hidden) and is_admin() is False:
             abort(404)
 
-        response = UserSchema(view=session.get("type", "user")).dump(user)
+        user_type = get_current_user_type(fallback="user")
+        response = UserSchema(view=user_type).dump(user)
 
         if response.errors:
             return {"success": False, "errors": response.errors}, 400

--- a/CTFd/utils/logging/__init__.py
+++ b/CTFd/utils/logging/__init__.py
@@ -13,7 +13,6 @@ def log(logger, format, **kwargs):
         "id": session.get("id"),
         "name": session.get("name"),
         "email": session.get("email"),
-        "type": session.get("type"),
         "date": time.strftime("%m/%d/%Y %X"),
         "ip": get_ip(),
     }

--- a/CTFd/utils/security/auth.py
+++ b/CTFd/utils/security/auth.py
@@ -12,7 +12,6 @@ from CTFd.utils.security.csrf import generate_nonce
 def login_user(user):
     session["id"] = user.id
     session["name"] = user.name
-    session["type"] = user.type
     session["email"] = user.email
     session["nonce"] = generate_nonce()
 

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -24,13 +24,22 @@ def get_current_team():
         return None
 
 
+def get_current_user_type(fallback=None):
+    if authed():
+        user = Users.query.filter_by(id=session["id"]).first()
+        return user.type
+    else:
+        return fallback
+
+
 def authed():
     return bool(session.get("id", False))
 
 
 def is_admin():
     if authed():
-        return session["type"] == "admin"
+        user = get_current_user()
+        return user.type == "admin"
     else:
         return False
 

--- a/tests/challenges/test_dynamic.py
+++ b/tests/challenges/test_dynamic.py
@@ -213,7 +213,6 @@ def test_dynamic_challenge_loses_value_properly():
                 with client.session_transaction() as sess:
                     sess["id"] = team_id
                     sess["name"] = name
-                    sess["type"] = "user"
                     sess["email"] = email
                     sess["nonce"] = "fake-nonce"
 
@@ -306,7 +305,6 @@ def test_dynamic_challenge_value_isnt_affected_by_hidden_users():
                 with client.session_transaction() as sess:
                     sess["id"] = team_id
                     sess["name"] = name
-                    sess["type"] = "user"
                     sess["email"] = email
                     sess["nonce"] = "fake-nonce"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -150,7 +150,6 @@ def register_user(
                 with client.session_transaction() as sess:
                     assert sess["id"]
                     assert sess["name"] == name
-                    assert sess["type"]
                     assert sess["email"]
                     assert sess["nonce"]
 
@@ -178,7 +177,6 @@ def login_as_user(app, name="user", password="password", raise_for_error=True):
                 with client.session_transaction() as sess:
                     assert sess["id"]
                     assert sess["name"]
-                    assert sess["type"]
                     assert sess["email"]
                     assert sess["nonce"]
             return client
@@ -237,7 +235,6 @@ def login_with_mlc(
             with client.session_transaction() as sess:
                 assert sess["id"]
                 assert sess["name"]
-                assert sess["type"]
                 assert sess["email"]
                 assert sess["nonce"]
         return client

--- a/tests/oauth/test_redirect.py
+++ b/tests/oauth/test_redirect.py
@@ -72,7 +72,6 @@ def test_oauth_configured_flow():
         with client.session_transaction() as sess:
             assert sess["id"]
             assert sess["name"]
-            assert sess["type"]
             assert sess["email"]
             assert sess["nonce"]
     destroy_ctfd(app)


### PR DESCRIPTION
* Deprecates storing session["type"] as a means of referring to the user's current level. Instead you should refer to the database.
* Adds `CTFd.utils.user.get_current_user_type()` to get the current user's type or return None if the user is unauthed. 
* Closes #1279 