### PR TITLE
Add fix for SMTP server overriding and #1306

### DIFF
--- a/CTFd/utils/config/__init__.py
+++ b/CTFd/utils/config/__init__.py
@@ -53,13 +53,13 @@ def can_send_mail():
 
 
 def get_mail_provider():
-    if app.config.get("MAIL_SERVER") and app.config.get("MAIL_PORT"):
-        return "smtp"
     if get_config("mail_server") and get_config("mail_port"):
         return "smtp"
-    if app.config.get("MAILGUN_API_KEY") and app.config.get("MAILGUN_BASE_URL"):
-        return "mailgun"
     if get_config("mailgun_api_key") and get_config("mailgun_base_url"):
+        return "mailgun"
+    if app.config.get("MAIL_SERVER") and app.config.get("MAIL_PORT"):
+        return "smtp"
+    if app.config.get("MAILGUN_API_KEY") and app.config.get("MAILGUN_BASE_URL"):
         return "mailgun"
 
 

--- a/CTFd/utils/email/smtp.py
+++ b/CTFd/utils/email/smtp.py
@@ -1,5 +1,9 @@
+import six
 import smtplib
 from email.mime.text import MIMEText
+
+if six.PY3:
+    from email.message import EmailMessage
 from socket import timeout
 
 from CTFd.utils import get_app_config, get_config
@@ -47,12 +51,22 @@ def sendmail(addr, text, subject):
 
     try:
         smtp = get_smtp(**data)
-        msg = MIMEText(text)
+
+        if six.PY2:
+            msg = MIMEText(text)
+        else:
+            msg = EmailMessage()
+            msg.set_content(text)
+
         msg["Subject"] = subject
         msg["From"] = mailfrom_addr
         msg["To"] = addr
 
-        smtp.sendmail(msg["From"], [msg["To"]], msg.as_string())
+        if six.PY2:
+            smtp.sendmail(msg["From"], [msg["To"]], msg.as_string())
+        else:
+            smtp.send_message(msg)
+
         smtp.quit()
         return True, "Email sent"
     except smtplib.SMTPException as e:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format:
 	prettier --write 'CTFd/themes/**/assets/**/*'
 
 test:
-	pytest --cov=CTFd --cov-context=test --ignore=node_modules/ --disable-warnings -n auto
+	pytest -rf --cov=CTFd --cov-context=test --ignore=node_modules/ --disable-warnings -n auto
 	bandit -r CTFd -x CTFd/uploads
 	yarn verify
 

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import six
 from freezegun import freeze_time
 from mock import patch
 
@@ -304,8 +305,11 @@ def test_user_can_confirm_email(mock_smtp):
         r = client.get("http://localhost/confirm")
         assert "Need to resend the confirmation email?" in r.get_data(as_text=True)
 
-        # smtp.sendmail was called
-        mock_smtp.return_value.sendmail.assert_called()
+        # smtp send message function was called
+        if six.PY2:
+            mock_smtp.return_value.sendmail.assert_called()
+        else:
+            mock_smtp.return_value.send_message.assert_called()
 
         with client.session_transaction() as sess:
             data = {"nonce": sess.get("nonce")}
@@ -333,6 +337,8 @@ def test_user_can_confirm_email(mock_smtp):
 def test_user_can_reset_password(mock_smtp):
     """Test that a user is capable of resetting their password"""
     from email.mime.text import MIMEText
+    if six.PY3:
+        from email.message import EmailMessage
 
     app = create_ctfd()
     with app.app_context(), freeze_time("2012-01-14 03:21:34"):
@@ -369,7 +375,13 @@ def test_user_can_reset_password(mock_smtp):
                 "http://localhost/reset_password/InVzZXJAdXNlci5jb20i.TxD0vg.28dY_Gzqb1TH9nrcE_H7W8YFM-U"
             )
             ctf_name = get_config("ctf_name")
-            email_msg = MIMEText(msg)
+
+            if six.PY2:
+                email_msg = MIMEText(msg)
+            else:
+                email_msg = EmailMessage()
+                email_msg.set_content(msg)
+
             email_msg["Subject"] = "Password Reset Request from {ctf_name}".format(
                 ctf_name=ctf_name
             )
@@ -377,9 +389,13 @@ def test_user_can_reset_password(mock_smtp):
             email_msg["To"] = to_addr
 
             # Make sure that the reset password email is sent
-            mock_smtp.return_value.sendmail.assert_called_with(
-                from_addr, [to_addr], email_msg.as_string()
-            )
+            if six.PY2:
+                mock_smtp.return_value.sendmail.assert_called_with(
+                    from_addr, [to_addr], email_msg.as_string()
+                )
+            else:
+                mock_smtp.return_value.send_message.assert_called()
+                assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(email_msg)
 
             # Get user's original password
             user = Users.query.filter_by(email="user@user.com").first()

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -337,6 +337,7 @@ def test_user_can_confirm_email(mock_smtp):
 def test_user_can_reset_password(mock_smtp):
     """Test that a user is capable of resetting their password"""
     from email.mime.text import MIMEText
+
     if six.PY3:
         from email.message import EmailMessage
 
@@ -395,7 +396,9 @@ def test_user_can_reset_password(mock_smtp):
                 )
             else:
                 mock_smtp.return_value.send_message.assert_called()
-                assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(email_msg)
+                assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(
+                    email_msg
+                )
 
             # Get user's original password
             user = Users.query.filter_by(email="user@user.com").first()

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -1,5 +1,6 @@
 import six
 from email.mime.text import MIMEText
+
 if six.PY3:
     from email.message import EmailMessage
 
@@ -53,7 +54,9 @@ def test_sendmail_with_smtp_from_config_file(mock_smtp):
             )
         else:
             mock_smtp.return_value.send_message.assert_called()
-            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(email_msg)
+            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(
+                email_msg
+            )
     destroy_ctfd(app)
 
 
@@ -93,7 +96,9 @@ def test_sendmail_with_smtp_from_db_config(mock_smtp):
             )
         else:
             mock_smtp.return_value.send_message.assert_called()
-            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(email_msg)
+            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(
+                email_msg
+            )
     destroy_ctfd(app)
 
 
@@ -105,7 +110,6 @@ def test_sendmail_with_mailgun_from_config_file(fake_post_request):
         app.config["MAILGUN_API_KEY"] = "key-1234567890-file-config"
         app.config["MAILGUN_BASE_URL"] = "https://api.mailgun.net/v3/file.faked.com"
 
-        from_addr = get_config("mailfrom_addr") or app.config.get("MAILFROM_ADDR")
         to_addr = "user@user.com"
         msg = "this is a test"
 
@@ -146,7 +150,6 @@ def test_sendmail_with_mailgun_from_db_config(fake_post_request):
         set_config("mailgun_api_key", "key-1234567890-db-config")
         set_config("mailgun_base_url", "https://api.mailgun.net/v3/db.faked.com")
 
-        from_addr = get_config("mailfrom_addr") or app.config.get("MAILFROM_ADDR")
         to_addr = "user@user.com"
         msg = "this is a test"
 
@@ -221,7 +224,9 @@ def test_verify_email(mock_smtp):
             )
         else:
             mock_smtp.return_value.send_message.assert_called()
-            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(email_msg)
+            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(
+                email_msg
+            )
     destroy_ctfd(app)
 
 
@@ -264,5 +269,7 @@ def test_successful_registration_email(mock_smtp):
             )
         else:
             mock_smtp.return_value.send_message.assert_called()
-            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(email_msg)
+            assert str(mock_smtp.return_value.send_message.call_args[0][0]) == str(
+                email_msg
+            )
     destroy_ctfd(app)


### PR DESCRIPTION
* Fix a potential issue where config.py SMTP settings might not have been overrideable from the Admin Panel
* Closes #1306 by using `email.message.EmailMessage` in Python 3. Python 2 will use the old `sendmail` behavior. 