### PR TITLE
Remove normality dependency b/c it isn't required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ itsdangerous==1.1.0
 requests>=2.20.0
 PyMySQL==0.9.3
 gunicorn==19.9.0
-normality==2.0.0
 dataset==1.1.2
 mistune==0.8.4
 netaddr==0.7.19


### PR DESCRIPTION
* Removes `normality` because it shouldn't be required by `dataset` based on its `setup.py`