### PR TITLE
Start to refactor tracker to cache user IPs

### DIFF
--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -44,3 +44,9 @@ def clear_pages():
 
     cache.delete_memoized(get_pages)
     cache.delete_memoized(get_page)
+
+
+def clear_user_ips(user_id):
+    from CTFd.utils.user import get_user_ips
+
+    cache.delete_memoized(get_user_ips, user_id=user_id)

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -202,7 +202,6 @@ def init_request_processors(app):
                     logout_user()
                 clear_user_ips(user_id=session["id"])
 
-
     @app.before_request
     def banned():
         if request.endpoint == "views.themes":

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -43,7 +43,7 @@ from CTFd.utils.user import (
     get_current_team,
     get_current_user,
     get_ip,
-    get_user_ips,
+    get_current_user_ips,
     is_admin,
 )
 
@@ -177,7 +177,7 @@ def init_request_processors(app):
             return
 
         if authed():
-            user_ips = get_user_ips(user_id=session["id"])
+            user_ips = get_current_user_ips()
             ip = get_ip()
             if ip not in user_ips:
                 visit = Tracking(ip=get_ip(), user_id=session["id"])

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -42,6 +42,7 @@ from CTFd.utils.security.csrf import generate_nonce
 from CTFd.utils.user import (
     authed,
     get_current_user_attrs,
+    get_current_user_ips,
     get_current_team_attrs,
     get_ip,
     is_admin,
@@ -201,7 +202,6 @@ def init_request_processors(app):
                     logout_user()
                 clear_user_ips(user_id=session["id"])
 
-            db.session.close()
 
     @app.before_request
     def banned():

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -81,6 +81,14 @@ def get_ip(req=None):
     return remote_addr
 
 
+def get_current_user_ips():
+    if authed():
+        return get_user_ips(user_id=session["id"])
+    else:
+        return None
+
+
+@cache.memoize
 def get_user_ips(user_id):
     addrs = (
         Tracking.query.with_entities(Tracking.ip.distinct())

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -7,7 +7,7 @@ from flask import request, session
 from CTFd.cache import cache
 from CTFd.constants.users import UserAttrs
 from CTFd.constants.teams import TeamAttrs
-from CTFd.models import Fails, Users, db, Teams
+from CTFd.models import Fails, Users, db, Teams, Tracking
 from CTFd.utils import get_config
 
 

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -88,7 +88,7 @@ def get_current_user_ips():
         return None
 
 
-@cache.memoize
+@cache.memoize(timeout=60)
 def get_user_ips(user_id):
     addrs = (
         Tracking.query.with_entities(Tracking.ip.distinct())

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -4,7 +4,8 @@ import re
 from flask import current_app as app
 from flask import request, session
 
-from CTFd.models import Fails, Users, db
+from CTFd.cache import cache
+from CTFd.models import Fails, Users, db, Tracking
 from CTFd.utils import get_config
 
 
@@ -78,6 +79,15 @@ def get_ip(req=None):
     else:
         remote_addr = req.remote_addr
     return remote_addr
+
+
+def get_user_ips(user_id):
+    addrs = (
+        Tracking.query.with_entities(Tracking.ip.distinct())
+        .filter_by(user_id=user_id)
+        .all()
+    )
+    return [ip for ip, in addrs]
 
 
 def get_wrong_submissions_per_minute(account_id):

--- a/tests/admin/test_config.py
+++ b/tests/admin/test_config.py
@@ -58,9 +58,6 @@ def test_reset():
             gen_fail(app.db, user_id=user_obj.id, challenge_id=random.randint(1, 10))
             gen_tracking(app.db, user_id=user_obj.id)
 
-        print("eet")
-        print(Tracking.query.all())
-
         # Add PageFiles
         for x in range(5):
             gen_file(

--- a/tests/admin/test_config.py
+++ b/tests/admin/test_config.py
@@ -58,6 +58,9 @@ def test_reset():
             gen_fail(app.db, user_id=user_obj.id, challenge_id=random.randint(1, 10))
             gen_tracking(app.db, user_id=user_obj.id)
 
+        print("eet")
+        print(Tracking.query.all())
+
         # Add PageFiles
         for x in range(5):
             gen_file(


### PR DESCRIPTION
User IPs should be cached for most actions but not updated without some kind of user action. 

* Cache user IPs and only update IP usage on new IPs or on non-GET requests