### PR TITLE
Add support for limited privilege databases (ej. Heroku)

### DIFF
--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -21,6 +21,7 @@ from CTFd.utils.exports.freeze import freeze_export
 from CTFd.utils.migrations import (
     create_database,
     drop_database,
+    truncate_database,
     get_current_revision,
     stamp_latest_revision,
 )
@@ -123,8 +124,10 @@ def import_ctf(backup, erase=True):
         )
 
     if erase:
-        drop_database()
-        create_database()
+        if drop_database():
+            create_database()
+        else:
+            truncate_database()
         # We explicitly do not want to upgrade or stamp here.
         # The import will have this information.
 

--- a/CTFd/utils/migrations/__init__.py
+++ b/CTFd/utils/migrations/__init__.py
@@ -8,6 +8,22 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy_utils import create_database as create_database_util
 from sqlalchemy_utils import database_exists as database_exists_util
 from sqlalchemy_utils import drop_database as drop_database_util
+from CTFd.utils.uploads import delete_file
+from CTFd.cache import cache, clear_config, clear_standings, clear_pages
+from CTFd.models import (
+    Awards,
+    Challenges,
+    Configs,
+    Notifications,
+    Pages,
+    Solves,
+    Submissions,
+    Teams,
+    Tracking,
+    Unlocks,
+    Users,
+    db,
+)
 
 migrations = Migrate()
 
@@ -20,8 +36,17 @@ def create_database():
     if url.drivername.startswith("mysql"):
         url.query["charset"] = "utf8mb4"
 
-    # Creates database if the database database does not exist
-    if not database_exists_util(url):
+    # Creates database if the database does not exist
+    try:
+        # If the user don't have permission to access to "postres" databasen  this
+        # will fail: https://github.com/kvesteri/sqlalchemy-utils/pull/372
+        # in that case we asume that the database was previously created and we can't
+        # drop or create the database
+        exists = database_exists_util(url)
+    except Exception:
+        exists = True
+
+    if not exists:
         if url.drivername.startswith("mysql"):
             create_database_util(url, encoding="utf8mb4")
         else:
@@ -29,11 +54,51 @@ def create_database():
     return url
 
 
+def truncate_database():
+    # delete all table data (but keep tables)
+    _pages = Pages.query.all()
+    for p in _pages:
+        for f in p.files:
+            delete_file(file_id=f.id)
+
+    Pages.query.delete()
+
+    Notifications.query.delete()
+
+    _challenges = Challenges.query.all()
+    for c in _challenges:
+        for f in c.files:
+            delete_file(file_id=f.id)
+    Challenges.query.delete()
+
+    Users.query.delete()
+    Teams.query.delete()
+
+    Solves.query.delete()
+    Submissions.query.delete()
+    Awards.query.delete()
+    Unlocks.query.delete()
+    Tracking.query.delete()
+
+    Configs.query.delete()
+    clear_config()
+    clear_pages()
+    clear_standings()
+    cache.clear()
+
+    db.session.commit()
+
+
 def drop_database():
-    url = make_url(app.config["SQLALCHEMY_DATABASE_URI"])
-    if url.drivername == "postgres":
-        url.drivername = "postgresql"
-    drop_database_util(url)
+    try:
+        url = make_url(app.config["SQLALCHEMY_DATABASE_URI"])
+        if url.drivername == "postgres":
+            url.drivername = "postgresql"
+        drop_database_util(url)
+        return True
+    except Exception:
+        # Drop database failed
+        return False
 
 
 def get_current_revision():

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apk update && \
         musl-dev \
         py-pip \
         mysql-client \
+        postgresql-dev \
         git \
         openssl-dev
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python manage.py db upgrade && gunicorn "CTFd:create_app()" --workers 1 --worker-class gevent

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/CTFd/CTFd.svg?branch=master)](https://travis-ci.org/CTFd/CTFd)
 [![MajorLeagueCyber Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.majorleaguecyber.org%2F)](https://community.majorleaguecyber.org/)
 [![Documentation Status](https://readthedocs.org/projects/ctfd/badge/?version=latest)](https://docs.ctfd.io/en/latest/?badge=latest)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ## What is CTFd?
 CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,45 @@
+{
+  "name": "CTFd",
+  "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
+  "repository": "https://github.com/CTFd/CTFd",
+  "logo": "https://github.com/CTFd/CTFd/raw/master/CTFd/themes/core/static/img/logo.png?raw=true",
+  "buildpacks": [{
+    "url": "heroku/python"
+  }],
+  "addons": [{
+      "plan": "heroku-postgresql:hobby-dev",
+      "as": "DATABASE"
+    },
+    {
+      "plan": "heroku-redis:hobby-dev",
+      "as": "REDIS"
+    }
+  ],
+  "env": {
+    "UPLOAD_PROVIDER": {
+      "description": "Specifies the service that CTFd should use to store files",
+      "required": true,
+      "value": "s3"
+    },
+    "AWS_ACCESS_KEY_ID": {
+      "description": "AWS access token used to authenticate to the S3 bucket",
+      "required": true,
+      "value": ""
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+      "description": "AWS secret token used to authenticate to the S3 bucket.",
+      "required": true,
+      "value": ""
+    },
+    "AWS_S3_BUCKET": {
+      "description": "The unique identifier for your S3 bucket",
+      "required": true,
+      "value": ""
+    },
+    "AWS_S3_ENDPOINT_URL": {
+      "description": "A URL pointing to a custom S3 implementation. Leave empty for default AWS S3 endpoint",
+      "required": false,
+      "value": ""
+    }
+  }
+}

--- a/development.txt
+++ b/development.txt
@@ -5,8 +5,6 @@ coverage==5.0.3
 mock==2.0.0
 flake8==3.7.7
 freezegun==0.3.11
-psycopg2==2.7.5
-psycopg2-binary==2.7.5
 codecov==2.0.15
 moto==1.3.7
 bandit==1.5.1

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -89,6 +89,20 @@ To access the internal gunicorn terminal session inside Vagrant run:
 
     CTFd's Vagrantfile is not commonly used and is only community supported
 
+Heroku
+-------
+
+CTFd provides a basic Procfile and app.json for use with Heroku. To run using Heroku click on the Deploy to Heroku button
+
+Hosting CTFd on Heroku is intended for testing purposes.
+Heroku provides a free PostgreSQL database with a limitation of 10k rows.
+Heroku provides a free Redis database with a limit of 25MB.
+Heroku provides a ephemeral filesystem, so you must configure s3 as UPLOAD_PROVIDER. You can also use the `CTFd Dropbox plugin`_
+
+.. Note::
+
+    Running CTFd on Heroku is not commonly used and is only community supported
+
 Debug Server
 ------------
 
@@ -105,4 +119,5 @@ The absolute simplest way to deploy CTFd merely involves running `python serve.p
 .. _Docker images: https://hub.docker.com/r/ctfd/ctfd/
 .. _Docker: https://docs.docker.com/install/
 .. _Docker Compose: https://docs.docker.com/compose/install/
+.. _CTFd Dropbox plugin: https://github.com/erseco/CTFd-dropbox-plugin
 .. _contact us: https://ctfd.io/contact/

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ flask-marshmallow==0.10.1
 marshmallow-sqlalchemy==0.17.0
 boto3==1.10.39
 marshmallow==2.20.2
+psycopg2==2.7.5
+psycopg2-binary==2.7.5


### PR DESCRIPTION
I'm running CTFd on Heroku for testing purposes. Heroku provides a PostgreSQL database without permission to create/drop the database. Also, revoke privileges in `postgres` database, used by `sqlalchemy-utils` to check if the database exists. 

You can duplicate this permission behavior in a database running the next queries:

```
CREATE DATABASE ctfd;
CREATE USER ctfd WITH PASSWORD 'ctfd';
REVOKE CONNECT ON DATABASE postgres FROM PUBLIC;
REVOKE ALL PRIVILEGES ON DATABASE postgres from ctfd;
```
and using this url for database `DATABASE_URL=postgres://ctfd:ctfd@localhost/ctfd`

To fix this we can try-catch the comprobation of the database. Also fixed the import. Because we don't have drop support we just truncate all CTFd tables like in `reset` feature.

Added a basic Procfile and app.json for use with Heroku. We can easily deploy with the button `deploy to heroku` in Readme.

- Hosting CTFd on Heroku is intended for **testing** purposes.
- Heroku provides a free PostgreSQL database with a **limitation of 10K rows**.
- Heroku provides a free Redis database with a **limit of 25MB**.
- Heroku provides an ephemeral filesystem, so you **must** configure _s3_ as `UPLOAD_PROVIDER`

This PR refers to #1127 and #1327
