### PR TITLE
Fix bug which causes user creation email to never be sent out

### DIFF
--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -56,7 +56,7 @@ class UserList(Resource):
         db.session.add(response.data)
         db.session.commit()
 
-        if request.args.get("notify"):
+        if req.get("notify"):
             name = response.data.name
             email = response.data.email
             password = req.get("password")


### PR DESCRIPTION
This makes sure that e-mails will be sent when the user ticks the `Email account credentials to user` box on user creation.

The request data should be accessed through `req` instead of `request.args`, since `request.args` will always return an empty `ImmutableMultiDict` here.

Please see the issue attatched below for more details.

Fix #1398 