### PR TITLE
Have EventManagers yield before timer code to force SSE response head…

### DIFF
--- a/CTFd/utils/events/__init__.py
+++ b/CTFd/utils/events/__init__.py
@@ -52,6 +52,10 @@ class EventManager(object):
         self.clients.append(q)
         while True:
             try:
+                # Immediately yield a ping event to force Response headers to be set
+                # or else some reverse proxies will incorrectly buffer SSE
+                yield ServerSentEvent(data="", type="ping")
+
                 with Timeout(10):
                     message = q[channel].get()
                     yield ServerSentEvent(**message)
@@ -76,6 +80,10 @@ class RedisEventManager(EventManager):
             pubsub = self.client.pubsub()
             pubsub.subscribe(channel)
             try:
+                # Immediately yield a ping event to force Response headers to be set
+                # or else some reverse proxies will incorrectly buffer SSE
+                yield ServerSentEvent(data="", type="ping")
+
                 with Timeout(10) as timeout:
                     for message in pubsub.listen():
                         if message["type"] == "message":

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -35,11 +35,18 @@ def test_event_manager_subscription():
 
         fake_queue.return_value = saved_event
         event_manager = EventManager()
-        for message in event_manager.subscribe():
-            assert message.to_dict() == saved_event
-            assert message.__str__().startswith("event:notification\ndata:")
-            assert len(event_manager.clients) == 1
-            break
+        events = event_manager.subscribe()
+        message = next(events)
+        assert isinstance(message, ServerSentEvent)
+        assert message.to_dict() == {"data": "", "type": "ping"}
+        assert message.__str__().startswith("event:ping")
+        assert len(event_manager.clients) == 1
+
+        message = next(events)
+        assert isinstance(message, ServerSentEvent)
+        assert message.to_dict() == saved_event
+        assert message.__str__().startswith("event:notification\ndata:")
+        assert len(event_manager.clients) == 1
 
 
 def test_event_manager_publish():
@@ -144,11 +151,19 @@ def test_redis_event_manager_subscription():
             with patch.object(redis.client.PubSub, "listen") as fake_pubsub_listen:
                 fake_pubsub_listen.return_value = [saved_event]
                 event_manager = RedisEventManager()
-                for message in event_manager.subscribe():
-                    assert isinstance(message, ServerSentEvent)
-                    assert message.to_dict() == saved_data
-                    assert message.__str__().startswith("event:notification\ndata:")
-                    break
+
+                events = event_manager.subscribe()
+                message = next(events)
+                assert isinstance(message, ServerSentEvent)
+                assert message.to_dict() == {"data": "", "type": "ping"}
+                assert message.__str__().startswith("event:ping")
+                assert len(event_manager.clients) == 1
+
+                message = next(events)
+                assert isinstance(message, ServerSentEvent)
+                assert message.to_dict() == saved_data
+                assert message.__str__().startswith("event:notification\ndata:")
+                assert len(event_manager.clients) == 1
         destroy_ctfd(app)
 
 

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -157,13 +157,11 @@ def test_redis_event_manager_subscription():
                 assert isinstance(message, ServerSentEvent)
                 assert message.to_dict() == {"data": "", "type": "ping"}
                 assert message.__str__().startswith("event:ping")
-                assert len(event_manager.clients) == 1
 
                 message = next(events)
                 assert isinstance(message, ServerSentEvent)
                 assert message.to_dict() == saved_data
                 assert message.__str__().startswith("event:notification\ndata:")
-                assert len(event_manager.clients) == 1
         destroy_ctfd(app)
 
 


### PR DESCRIPTION
Some reverse proxies will buffer SSE responses until they see a valid SSE response header. Thus we need to force the EventManagers to yield a ping event immediatley to force Flask to set right headers. 

* EventManagers should send an initial ping event to force `text/event-steam` header to be set