### PR TITLE
Improve import_ctf reliability

### DIFF
--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -124,7 +124,8 @@ def import_ctf(backup, erase=True):
 
     if erase:
         # Clear out existing connections to release any locks
-        app.db.engine.dispose()
+        db.session.close()
+        db.engine.dispose()
 
         # Drop database and recreate it to get to a clean state
         drop_database()

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -123,6 +123,10 @@ def import_ctf(backup, erase=True):
         )
 
     if erase:
+        # Clear out existing connections to release any locks
+        app.db.engine.dispose()
+
+        # Drop database and recreate it to get to a clean state
         drop_database()
         create_database()
         # We explicitly do not want to upgrade or stamp here.

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -201,6 +201,7 @@ def init_request_processors(app):
                     db.session.commit()
                 except (InvalidRequestError, IntegrityError):
                     db.session.rollback()
+                    db.session.close()
                     logout_user()
                 else:
                     clear_user_recent_ips(user_id=session["id"])


### PR DESCRIPTION
* Improve `import_ctf()` reliability by closing all connections before dropping & recreating database
* Close database session in IP tracking code in failure situations