### PR TITLE
1422 block imports without db folder

### DIFF
--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -96,10 +96,10 @@ def import_ctf(backup, erase=True):
             if info.file_size > max_content_length:
                 raise zipfile.LargeZipFile
 
-    member_dirs = [os.path.split(m)[0] for m in members if '/' in m]
+    member_dirs = [os.path.split(m)[0] for m in members if "/" in m]
     if "db" not in member_dirs:
         raise Exception(
-            "CTFd couldn't find the \"db\" folder in this backup. The backup may be malformed or corrupted and the import process cannot continue."
+            'CTFd couldn\'t find the "db" folder in this backup. The backup may be malformed or corrupted and the import process cannot continue.'
         )
 
     try:

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -96,6 +96,12 @@ def import_ctf(backup, erase=True):
             if info.file_size > max_content_length:
                 raise zipfile.LargeZipFile
 
+    member_dirs = [os.path.split(m)[0] for m in members if '/' in m]
+    if "db" not in member_dirs:
+        raise Exception(
+            "CTFd couldn't find the \"db\" folder in this backup. The backup may be malformed or corrupted and the import process cannot continue."
+        )
+
     try:
         alembic_version = json.loads(backup.open("db/alembic_version.json").read())
         alembic_version = alembic_version["results"][0]["version_num"]

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -101,7 +101,7 @@ def import_ctf(backup, erase=True):
     if "db" not in member_dirs:
         raise Exception(
             'CTFd couldn\'t find the "db" folder in this backup. '
-            'The backup may be malformed or corrupted and the import process cannot continue.'
+            "The backup may be malformed or corrupted and the import process cannot continue."
         )
 
     try:

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -96,10 +96,12 @@ def import_ctf(backup, erase=True):
             if info.file_size > max_content_length:
                 raise zipfile.LargeZipFile
 
+    # Get list of directories in zipfile
     member_dirs = [os.path.split(m)[0] for m in members if "/" in m]
     if "db" not in member_dirs:
         raise Exception(
-            'CTFd couldn\'t find the "db" folder in this backup. The backup may be malformed or corrupted and the import process cannot continue.'
+            'CTFd couldn\'t find the "db" folder in this backup. '
+            'The backup may be malformed or corrupted and the import process cannot continue.'
         )
 
     try:


### PR DESCRIPTION
* Don't allow backups to be imported if they do not have a `db` folder
* Closes #1422