### PR TITLE
Remove redundant overriding link

### DIFF
--- a/CTFd/themes/admin/templates/teams/team.html
+++ b/CTFd/themes/admin/templates/teams/team.html
@@ -205,7 +205,7 @@
 				</thead>
 				<tbody>
 				{% for member in members %}
-					<tr data-href="{{ url_for('admin.users_detail', user_id=member.id) }}">
+					<tr>
 						<td class="text-center">
 							{% if team.captain_id == member.id %}
 								<span class="badge badge-primary">Captain</span>


### PR DESCRIPTION
See #1435 for issue description. This is an attempted quick fix. 

The link on the `<tr>` element is not necessary since there is already a link on line 215 (on the username column). 