### PR TITLE
Bugfix: Improved MySQL server connectivity

### DIFF
--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import column_property, validates
 from CTFd.utils.crypto import hash_password
 from CTFd.utils.humanize.numbers import ordinalize
 
-db = SQLAlchemy()
+db = SQLAlchemy(engine_options=dict(pool_pre_ping=True))
 ma = Marshmallow()
 
 


### PR DESCRIPTION
CTFd does not send queries to MySQL for a certain amount of time, so it loses connection to the MySQL server.
It doesn't happen with Docker deployments, but it does frequently occur on-premises.
In this PR, CTFd's connection pool sends a ping to the MySQL server using the SQLAlchemy feature.

Related Issue: #1395 #467
SQLAlchemy document: https://docs.sqlalchemy.org/en/13/core/pooling.html#dealing-with-disconnects