### PR TITLE
Support SQLALCHEMY URLS with "%" sign

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -24,7 +24,7 @@ config = context.config
 logger = logging.getLogger("alembic.env")
 
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI").replace("%","%%")
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -24,7 +24,7 @@ config = context.config
 logger = logging.getLogger("alembic.env")
 
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI").replace("%","%%")
+    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI").replace("%", "%%")
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 


### PR DESCRIPTION
Sometimes the SQLALCHEMY URL must contain a percent sign (%). One example of this is when your password contains a %. Another example is when deploying to azure mysql. The username contains an @ sign, which must be encoded as "%40" to pass to sqlalchemy as a URL. Having a percent sign in the URL breaks line 27, because the Python ConfigParser uses % as a special character for evaluating interpolated values.
In order to place the value into the Configuration, the % sign must be escaped with %%.