### PR TITLE
Update Flask-Migrate and regenerate the migration env

### DIFF
--- a/migrations/README
+++ b/migrations/README
@@ -1,1 +1,0 @@
-Generic single-database configuration.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,17 +1,12 @@
 from __future__ import with_statement
 
 import logging
+from logging.config import fileConfig
 
-# from logging.config import fileConfig
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
 
 from alembic import context
-
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-from flask import current_app
-from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -19,12 +14,18 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-# http://stackoverflow.com/questions/42427487/using-alembic-config-main-redirects-log-output
-# fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 logger = logging.getLogger("alembic.env")
 
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from flask import current_app
+
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    "sqlalchemy.url",
+    str(current_app.extensions["migrate"].db.engine.url).replace("%", "%%"),
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 
@@ -47,7 +48,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
 
     with context.begin_transaction():
         context.run_migrations()
@@ -63,7 +64,7 @@ def run_migrations_online():
 
     # this callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema
-    # reference: http://alembic.readthedocs.org/en/latest/cookbook.html
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
     def process_revision_directives(context, revision, directives):
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
@@ -71,26 +72,22 @@ def run_migrations_online():
                 directives[:] = []
                 logger.info("No changes in schema detected.")
 
-    engine = engine_from_config(
+    connectable = engine_from_config(
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
 
-    connection = engine.connect()
-    context.configure(
-        connection=connection,
-        target_metadata=target_metadata,
-        compare_type=True,
-        process_revision_directives=process_revision_directives,
-        **current_app.extensions["migrate"].configure_args
-    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+            **current_app.extensions["migrate"].configure_args
+        )
 
-    try:
         with context.begin_transaction():
             context.run_migrations()
-    finally:
-        connection.close()
 
 
 if context.is_offline_mode():

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.1.1
 Werkzeug==0.16.0
 Flask-SQLAlchemy==2.4.1
 Flask-Caching==1.4.0
-Flask-Migrate==2.5.2
+Flask-Migrate==2.5.3
 Flask-Script==2.0.6
 SQLAlchemy==1.3.11
 SQLAlchemy-Utils==0.36.0


### PR DESCRIPTION
* Update Flask-Migrate to 2.5.3
* Regenerate the `env.py` file for migrations and delete useless README file
* Supercedes #1447 