### PR TITLE
Cache User & Team score and place

### DIFF
--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -26,6 +26,7 @@ def clear_config():
 
 
 def clear_standings():
+    from CTFd.models import Users, Teams
     from CTFd.utils.scores import get_standings, get_team_standings, get_user_standings
     from CTFd.api.v1.scoreboard import ScoreboardDetail, ScoreboardList
     from CTFd.api import api
@@ -33,6 +34,10 @@ def clear_standings():
     cache.delete_memoized(get_standings)
     cache.delete_memoized(get_team_standings)
     cache.delete_memoized(get_user_standings)
+    cache.delete_memoized(Users.get_score)
+    cache.delete_memoized(Users.get_place)
+    cache.delete_memoized(Teams.get_score)
+    cache.delete_memoized(Users.get_place)
     cache.delete(make_cache_key(path="scoreboard.listing"))
     cache.delete(make_cache_key(path=api.name + "." + ScoreboardList.endpoint))
     cache.delete(make_cache_key(path=api.name + "." + ScoreboardDetail.endpoint))

--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -37,7 +37,7 @@ def clear_standings():
     cache.delete_memoized(Users.get_score)
     cache.delete_memoized(Users.get_place)
     cache.delete_memoized(Teams.get_score)
-    cache.delete_memoized(Users.get_place)
+    cache.delete_memoized(Teams.get_place)
     cache.delete(make_cache_key(path="scoreboard.listing"))
     cache.delete(make_cache_key(path=api.name + "." + ScoreboardList.endpoint))
     cache.delete(make_cache_key(path=api.name + "." + ScoreboardDetail.endpoint))

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -5,6 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import column_property, validates
 
+from CTFd.cache import cache
 from CTFd.utils.crypto import hash_password
 from CTFd.utils.humanize.numbers import ordinalize
 
@@ -322,6 +323,7 @@ class Users(db.Model):
             awards = awards.filter(Awards.date < dt)
         return awards.all()
 
+    @cache.memoize()
     def get_score(self, admin=False):
         score = db.func.sum(Challenges.value).label("score")
         user = (
@@ -354,6 +356,7 @@ class Users(db.Model):
         else:
             return 0
 
+    @cache.memoize()
     def get_place(self, admin=False, numeric=False):
         """
         This method is generally a clone of CTFd.scoreboard.get_standings.
@@ -487,12 +490,14 @@ class Teams(db.Model):
 
         return awards.all()
 
+    @cache.memoize()
     def get_score(self, admin=False):
         score = 0
         for member in self.members:
             score += member.get_score(admin=admin)
         return score
 
+    @cache.memoize()
     def get_place(self, admin=False, numeric=False):
         """
         This method is generally a clone of CTFd.scoreboard.get_standings.


### PR DESCRIPTION
* Cache Users.get_score and Users.get_place. Clear on `clear_standings()`
* Cache Teams.get_score and Teams.get_place. Clear on `clear_standings()`

This caches the score and place attributes of users with the aim of speeding up the `/api/v1/scoreboard` views. 