### PR TITLE
Python 2 has been removed from Alpine so install Python 3 deps in Alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 **Deployment**
 * `docker-compose` now provides a basic nginx configuration and deploys nginx on port 80
+* `Dockerfile` now installs `python3` and `python3-dev` instead of `python` and `python-dev` because Alpine no longer provides those dependencies
 
 **Miscellaneous**
 * The `get_config` and `get_page` config utilities now use SQLAlchemy Core instead of SQLAlchemy ORM for slight speedups

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /opt/CTFd /var/log/CTFd /var/uploads
 
 RUN apk update && \
     apk add --no-cache \
-        python \
-        python-dev \
+        python3 \
+        python3-dev \
         linux-headers \
         libffi-dev \
         gcc \


### PR DESCRIPTION
* Closes #1472 

```
docker build --no-cache -t ctfd .
docker run -p 8000:8000 -it ctfd
```
works for me