### PR TITLE
Start challenge plugin redesign

### DIFF
--- a/CTFd/themes/core/templates/challenge.html
+++ b/CTFd/themes/core/templates/challenge.html
@@ -1,0 +1,117 @@
+<div class="modal-dialog" role="document">
+	<div class="modal-content">
+		<div class="modal-body">
+			<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+				<span aria-hidden="true">&times;</span>
+			</button>
+			<ul class="nav nav-tabs">
+				<li class="nav-item">
+					<a class="nav-link active" href="#challenge">Challenge</a>
+				</li>
+				{% if solves == None %}
+				{% else %}
+					<li class="nav-item">
+						<a class="nav-link challenge-solves" href="#solves">
+							{{ solves }} {% if solves > 1 %}Solves{% else %}Solves{% endif %}
+						</a>
+					</li>
+				{% endif %}
+			</ul>
+			<div role="tabpanel">
+				<div class="tab-content">
+					<div role="tabpanel" class="tab-pane fade show active" id="challenge">
+						<h2 class='challenge-name text-center pt-3'>{{ name }}</h2>
+						<h3 class="challenge-value text-center">{{ value }}</h3>
+						<div class="challenge-tags text-center">
+							{% for tag in tags %}
+								<span class='badge badge-info challenge-tag'>{{ tag }}</span>
+							{% endfor %}
+						</div>
+						<span class="challenge-desc">{{ description | safe }}</span>
+						<div class="challenge-hints hint-row row">
+							{% for hint in hints %}
+								<div class='col-md-12 hint-button-wrapper text-center mb-3'>
+									<a class="btn btn-info btn-hint btn-block load-hint" href="javascript:;" data-hint-id="{{ hint.id }}">
+										{% if hint.content %}
+											<small>
+												View Hint
+											</small>
+										{% else %}
+											{% if hint.cost %}
+												<small>
+													Unlock Hint for {{ hint.cost }} points
+												</small>
+											{% else %}
+												<small>
+													View Hint
+												</small>
+											{% endif %}
+										{% endif %}
+									</a>
+								</div>
+							{% endfor %}
+						</div>
+						<div class="row challenge-files text-center pb-3">
+							{% for file in files %}
+								<div class='col-md-4 col-sm-4 col-xs-12 file-button-wrapper d-block'>
+									<a class='btn btn-info btn-file mb-1 d-inline-block px-2 w-100 text-truncate'
+									   href='{{ file }}'>
+										<i class="fas fa-download"></i>
+										<small>
+											{% set segments = file.split('/') %}
+											{% set file = segments | last %}
+											{% set token = file.split('?') | last %}
+											{% if token %}
+												{{ file | replace("?" + token, "") }}
+											{% else %}
+												{{ file }}
+											{% endif %}
+										</small>
+									</a>
+								</div>
+							{% endfor %}
+						</div>
+
+						<div class="row submit-row">
+							<div class="col-md-9 form-group">
+								<input class="form-control" type="text" name="answer" id="submission-input" placeholder="Flag"/>
+								<input id="challenge-id" type="hidden" value="{{ id }}">
+							</div>
+							<div class="col-md-3 form-group key-submit">
+								<button type="submit" id="submit-key" tabindex="0"
+										class="btn btn-md btn-outline-secondary float-right">Submit
+								</button>
+							</div>
+						</div>
+						<div class="row notification-row">
+							<div class="col-md-12">
+								<div id="result-notification" class="alert alert-dismissable text-center w-100"
+									 role="alert" style="display: none;">
+									<strong id="result-message"></strong>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div role="tabpanel" class="tab-pane fade" id="solves">
+						<div class="row">
+							<div class="col-md-12">
+								<table class="table table-striped text-center">
+									<thead>
+									<tr>
+										<td><b>Name</b>
+										</td>
+										<td><b>Date</b>
+										</td>
+									</tr>
+									</thead>
+									<tbody id="challenge-solves-names">
+									</tbody>
+								</table>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
Challenge plugins while good, are not easy to write. 

We want to address the theme issues here where we pass HTML and JS to the front end. 

1. It was a mistake to move HTML generation to the client. It meant supporting two renderers also incurring more HTTP requests. Instead HTML should be generated by the server. 
How? Create a `challenge.html` theme file that is not directly used but used to encapsulate the aesthetics of a theme. Thus we are saying that a theme is in control of how a challenge looks, not the challenge plugin. 

2. Come up with what each theme must implement for `challenge.html`. So far I see:
- Challenge
- Solves
- Hints
- Tags
- Files

These must be provided as jinja blocks/sections/variables/whatever for the API to inject into and then return as HTML in the API. 

3. A challenge plugin really should only be concerned with the description. What is the UI that the challenge plugin description can control? How much segmentation do we do from the theme overall? A challenge plugin should NOT be concerned with the rendering of solves, hints, files, tags, etc. Only the pure challenge content whatever it may be. 

Related issues: #1314, #1477 