### PR TITLE
[fix #1503] override_template cache error

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -110,7 +110,7 @@ class ThemeLoader(FileSystemLoader):
     def get_source(self, environment, template):
         # Check if the template has been overriden
         if template in self.overriden_templates:
-            return self.overriden_templates[template], template, True
+            return self.overriden_templates[template], template, lambda: True
 
         # Check if the template requested is for the admin panel
         if template.startswith("admin/"):


### PR DESCRIPTION
get_source expects the third return value to be callable

see documentation: https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.BaseLoader.get_source

this happened after https://github.com/CTFd/CTFd/commit/320feb91796f2eba538eef48c338fb37ade980d2 because the commit enabled the cache, and thus calling `up_to_date` surfaces the issue