### PR TITLE
Add User and Team Jinja globals to access User/Team attrs

### DIFF
--- a/CTFd/constants/teams.py
+++ b/CTFd/constants/teams.py
@@ -18,3 +18,32 @@ TeamAttrs = namedtuple(
         "created",
     ],
 )
+
+
+class _TeamAttrsWrapper:
+    def __getattr__(self, attr):
+        from CTFd.utils.user import get_current_team_attrs
+
+        attrs = get_current_team_attrs()
+        return getattr(attrs, attr, None)
+
+    @property
+    def place(self):
+        from CTFd.utils.user import get_current_team
+
+        team = get_current_team()
+        if team:
+            return team.place
+        return None
+
+    @property
+    def score(self):
+        from CTFd.utils.user import get_current_team
+
+        team = get_current_team()
+        if team:
+            return team.score
+        return None
+
+
+Team = _TeamAttrsWrapper()

--- a/CTFd/constants/users.py
+++ b/CTFd/constants/users.py
@@ -20,3 +20,32 @@ UserAttrs = namedtuple(
         "created",
     ],
 )
+
+
+class _UserAttrsWrapper:
+    def __getattr__(self, attr):
+        from CTFd.utils.user import get_current_user_attrs
+
+        attrs = get_current_user_attrs()
+        return getattr(attrs, attr, None)
+
+    @property
+    def place(self):
+        from CTFd.utils.user import get_current_user
+
+        user = get_current_user()
+        if user:
+            return user.place
+        return None
+
+    @property
+    def score(self):
+        from CTFd.utils.user import get_current_user
+
+        user = get_current_user()
+        if user:
+            return user.score
+        return None
+
+
+User = _UserAttrsWrapper()

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -56,6 +56,8 @@ def init_template_globals(app):
     from CTFd.constants.config import Configs
     from CTFd.constants.plugins import Plugins
     from CTFd.constants.sessions import Session
+    from CTFd.constants.users import User
+    from CTFd.constants.teams import Team
     from CTFd.forms import Forms
     from CTFd.utils.config.visibility import (
         accounts_visible,
@@ -98,6 +100,8 @@ def init_template_globals(app):
     app.jinja_env.globals.update(Plugins=Plugins)
     app.jinja_env.globals.update(Session=Session)
     app.jinja_env.globals.update(Forms=Forms)
+    app.jinja_env.globals.update(User=User)
+    app.jinja_env.globals.update(Team=Team)
 
 
 def init_logs(app):


### PR DESCRIPTION
* Adds User and Team globals to Jinja theme files. 
* Closes #1234 

This should allow for more sharing from the Python code to Jinja and thus to JS allowing for easier theme development. 