### PR TITLE
Handle missing challenge types better.

### DIFF
--- a/CTFd/admin/challenges.py
+++ b/CTFd/admin/challenges.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, url_for
+from flask import abort, render_template, request, url_for
 
 from CTFd.admin import admin
 from CTFd.models import Challenges, Flags, Solves
@@ -44,7 +44,14 @@ def challenges_detail(challenge_id):
         .all()
     )
     flags = Flags.query.filter_by(challenge_id=challenge.id).all()
-    challenge_class = get_chal_class(challenge.type)
+
+    try:
+        challenge_class = get_chal_class(challenge.type)
+    except:
+        abort(
+            500,
+            f"The underlying challenge type ({challenge.type}) is not installed. This challenge can not be loaded.",
+        )
 
     update_j2 = render_template(
         challenge_class.templates["update"].lstrip("/"), challenge=challenge

--- a/CTFd/admin/challenges.py
+++ b/CTFd/admin/challenges.py
@@ -47,7 +47,7 @@ def challenges_detail(challenge_id):
 
     try:
         challenge_class = get_chal_class(challenge.type)
-    except:
+    except KeyError:
         abort(
             500,
             f"The underlying challenge type ({challenge.type}) is not installed. This challenge can not be loaded.",

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -187,7 +187,13 @@ class ChallengeList(Resource):
                     # Fallthrough to continue
                     continue
 
-            challenge_type = get_chal_class(challenge.type)
+            try:
+                challenge_type = get_chal_class(challenge.type)
+            except KeyError:
+                # Challenge type does not exist. Fall through to next challenge.
+                continue
+
+            # Challenge passes all checks, add it to response
             response.append(
                 {
                     "id": challenge.id,
@@ -268,7 +274,13 @@ class Challenge(Resource):
                 and_(Challenges.state != "hidden", Challenges.state != "locked"),
             ).first_or_404()
 
-        chal_class = get_chal_class(chal.type)
+        try:
+            chal_class = get_chal_class(chal.type)
+        except KeyError:
+            abort(
+                500,
+                f"The underlying challenge type ({chal.type}) is not installed. This challenge can not be loaded.",
+            )
 
         if chal.requirements:
             requirements = chal.requirements.get("prerequisites", [])

--- a/CTFd/errors.py
+++ b/CTFd/errors.py
@@ -1,4 +1,5 @@
 from flask import render_template
+from werkzeug.exceptions import InternalServerError
 
 
 # 404
@@ -13,7 +14,10 @@ def forbidden(error):
 
 # 500
 def general_error(error):
-    return render_template("errors/500.html"), 500
+    if error.description == InternalServerError.description:
+        error.description = "An Internal Server Error has occurred"
+
+    return render_template("errors/500.html", error=error.description), 500
 
 
 # 502

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+from collections import defaultdict
 
 from flask_marshmallow import Marshmallow
 from flask_sqlalchemy import SQLAlchemy
@@ -77,7 +78,15 @@ class Challenges(db.Model):
     hints = db.relationship("Hints", backref="challenge")
     flags = db.relationship("Flags", backref="challenge")
 
-    __mapper_args__ = {"polymorphic_identity": "standard", "polymorphic_on": type}
+    class alt_defaultdict(defaultdict):
+        def __missing__(self, key):
+            return self["standard"]
+
+    __mapper_args__ = {
+        "polymorphic_identity": "standard",
+        "polymorphic_on": type,
+        "_polymorphic_map": alt_defaultdict(),
+    }
 
     @property
     def html(self):

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -79,6 +79,13 @@ class Challenges(db.Model):
     flags = db.relationship("Flags", backref="challenge")
 
     class alt_defaultdict(defaultdict):
+        """
+        This slightly modified defaultdict is intended to allow SQLAlchemy to
+        not fail when querying Challenges that contain a missing challenge type.
+
+        e.g. Challenges.query.all() should not fail if `type` is `a_missing_type`
+        """
+
         def __missing__(self, key):
             return self["standard"]
 

--- a/CTFd/themes/core/templates/errors/500.html
+++ b/CTFd/themes/core/templates/errors/500.html
@@ -8,7 +8,7 @@
 			<div class="pt-5 mt-5 text-center">
 				<h1>500</h1>
 				<hr class="w-50">
-				<h2>An Internal Server Error has occurred</h2>
+				<h2>{{ error }}</h2>
 			</div>
 		</div>
 	</div>

--- a/tests/challenges/test_challenge_types.py
+++ b/tests/challenges/test_challenge_types.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from CTFd.models import Challenges
+from tests.helpers import create_ctfd, destroy_ctfd, login_as_user, register_user
+
+
+def test_missing_challenge_type():
+    """Test that missing challenge types don't cause total challenge rendering failure"""
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        register_user(app)
+        client = login_as_user(app, name="admin", password="password")
+
+        challenge_data = {
+            "name": "name",
+            "category": "category",
+            "description": "description",
+            "value": 100,
+            "decay": 20,
+            "minimum": 1,
+            "state": "visible",
+            "type": "dynamic",
+        }
+
+        r = client.post("/api/v1/challenges", json=challenge_data)
+        assert r.get_json().get("data")["id"] == 1
+        assert r.get_json().get("data")["type"] == "dynamic"
+
+        chal_count = Challenges.query.count()
+        assert chal_count == 1
+
+        # Delete the dynamic challenge type
+        from CTFd.plugins.challenges import CHALLENGE_CLASSES
+
+        del CHALLENGE_CLASSES["dynamic"]
+
+        r = client.get("/admin/challenges")
+        assert r.status_code == 200
+        assert b"dynamic" in r.data
+
+        r = client.get("/admin/challenges/1")
+        assert r.status_code == 500
+        assert b"The underlying challenge type (dynamic) is not installed" in r.data
+
+        challenge_data = {
+            "name": "name",
+            "category": "category",
+            "description": "description",
+            "value": 100,
+            "state": "visible",
+            "type": "standard",
+        }
+        r = client.post("/api/v1/challenges", json=challenge_data)
+
+        r = client.get("/challenges")
+        assert r.status_code == 200
+
+        # We should still see the one visible standard challenge
+        r = client.get("/api/v1/challenges")
+        assert r.status_code == 200
+        assert len(r.json["data"]) == 1
+        assert r.json["data"][0]["type"] == "standard"
+
+        # We cannot load the broken challenge
+        r = client.get("/api/v1/challenges/1")
+        assert r.status_code == 500
+        assert (
+            "The underlying challenge type (dynamic) is not installed"
+            in r.json["message"]
+        )
+
+        # We can load other challenges
+        r = client.get("/api/v1/challenges/2")
+        assert r.status_code == 200
+    destroy_ctfd(app)


### PR DESCRIPTION
* Handle missing challenge types better by letting challenges fall back to the main Challenges model. This lets us better detect when a challenge type isn't loaded but exists in the database. 
* Closes #1526 