### PR TITLE
Fix error on flag submission when using dynamic challenge.

### DIFF
--- a/CTFd/plugins/dynamic_challenges/assets/view.js
+++ b/CTFd/plugins/dynamic_challenges/assets/view.js
@@ -15,7 +15,7 @@ CTFd._internal.challenge.postRender = function () { }
 
 CTFd._internal.challenge.submit = function (preview) {
     var challenge_id = parseInt(CTFd.lib.$('#challenge-id').val())
-    var submission = CTFd.lib.$('#submission-input').val()
+    var submission = CTFd.lib.$('#challenge-input').val()
 
     var body = {
         'challenge_id': challenge_id,


### PR DESCRIPTION
The reason this happens is because the view.js in this plugin uses #submission-input as id for the input field when it's in fact #challenge-input.

* Closes #1542