### PR TITLE
Disable safe_attrs_only for sanitize_html()

### DIFF
--- a/CTFd/utils/security/sanitize.py
+++ b/CTFd/utils/security/sanitize.py
@@ -14,6 +14,7 @@ cleaner = Cleaner(
     style=False,
     safe_attrs=(safe_attrs | set(["style"])),
     annoying_tags=False,
+    safe_attrs_only=False,
 )
 
 


### PR DESCRIPTION
* Disable `safe_attrs_only` for `sanitize_html()`. 
    * JavaScript based attributes are still sanitized. 