### PR TITLE
Mark 3.0.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 3.0.0b2 / 2020-07-19
+
+**General**
+
+- Make HTML Sanitization an optional setting that's configurable via `HTML_SANITIZATION` in config.ini
+- Allow HTML comments through sanitization
+- Allow Bootstrap data attributes through sanitization
+
+**Admin Panel**
+
+- Fix an unclickable label in the Challenge creation interface
+
+**Plugins**
+
+- Fix bug preventing deleting alternative challenge types
+
+**Miscellaneous**
+
+- Switch to using Github Actions for testing and linting
+
 # 3.0.0b1 / 2020-07-15
 
 **General**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -26,7 +26,7 @@ from CTFd.utils.migrations import create_database, migrations, stamp_latest_revi
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 
-__version__ = "3.0.0b1"
+__version__ = "3.0.0b2"
 
 
 class CTFdRequest(Request):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "3.0.0b1",
+  "version": "3.0.0b2",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
# 3.0.0b2 / 2020-07-19

**General**

- Make HTML Sanitization an optional setting that's configurable via `HTML_SANITIZATION` in config.ini
- Allow HTML comments through sanitization
- Allow Bootstrap data attributes through sanitization

**Admin Panel**

- Fix an unclickable label in the Challenge creation interface

**Plugins**

- Fix bug preventing deleting alternative challenge types

**Miscellaneous**

- Switch to using Github Actions for testing and linting