### PR TITLE
3.0.0b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 3.0.0b3 / 2020-07-22
+
+**General**
+
+- Render Hint content on the server side and provide it in the Hint API response
+  - In a sense this would deprecate the `content` field but it's left in for backwards compatability
+
+**API**
+
+- Add `html` item for `GET /api/v1/hints/[hint_id]` which contains the rendered HTML of the Hint content
+- Remove `content` from `GET /api/v1/hints`
+
+**Admin Panel**
+
+- Fix an issue where an admin couldn't submit more than once on a challenge preview
+- Fix an issue where the theme settings editor wouldn't load if the theme settings JSON was malformed
+
+**Miscellaneous**
+
+- Fix an issue where email sending would be broken if the CTF name contained a colon
+
 # 3.0.0b2 / 2020-07-19
 
 **General**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -26,7 +26,7 @@ from CTFd.utils.migrations import create_database, migrations, stamp_latest_revi
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 
-__version__ = "3.0.0b2"
+__version__ = "3.0.0b3"
 
 
 class CTFdRequest(Request):

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Currently CTFd master contains an alpha version of the next major CTFd release. 
   - Forgot password support
 - Automatic competition starting and ending
 - Team management, hiding, and banning
-- Customize everything using the [plugin](https://github.com/CTFd/CTFd/wiki/Plugins) and [theme](https://github.com/CTFd/CTFd/tree/master/CTFd/themes) interfaces
+- Customize everything using the [plugin](https://docs.ctfd.io/docs/plugins/) and [theme](https://docs.ctfd.io/docs/themes/) interfaces
 - Importing and Exporting of CTF data for archival
 - And a lot more...
 
@@ -58,7 +58,7 @@ Or you can use Docker Compose with the following command from the source reposit
 
 `docker-compose up`
 
-Check out the [wiki](https://github.com/CTFd/CTFd/wiki) for [deployment options](https://github.com/CTFd/CTFd/wiki/Basic-Deployment) and the [Getting Started](https://github.com/CTFd/CTFd/wiki/Getting-Started) guide
+Check out the [CTFd docs](https://docs.ctfd.io/) for [deployment options](https://docs.ctfd.io/docs/deployment/) and the [Getting Started](https://github.com/CTFd/CTFd/wiki/Getting-Started) guide
 
 ## Live Demo
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "3.0.0b2",
+  "version": "3.0.0b3",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
# 3.0.0b3 / 2020-07-22

**General**

- Render Hint content on the server side and provide it in the Hint API response
  - In a sense this would deprecate the `content` field but it's left in for backwards compatability

**API**

- Add `html` item for `GET /api/v1/hints/[hint_id]` which contains the rendered HTML of the Hint content
- Remove `content` from `GET /api/v1/hints`

**Admin Panel**

- Fix an issue where an admin couldn't submit more than once on a challenge preview
- Fix an issue where the theme settings editor wouldn't load if the theme settings JSON was malformed

**Miscellaneous**

- Fix an issue where email sending would be broken if the CTF name contained a colon