### PR TITLE
1580 fix hidden admin scores

### DIFF
--- a/CTFd/scoreboard.py
+++ b/CTFd/scoreboard.py
@@ -2,9 +2,11 @@ from flask import Blueprint, render_template
 
 from CTFd.cache import cache, make_cache_key
 from CTFd.utils import config
+from CTFd.utils.config.visibility import scores_visible
 from CTFd.utils.decorators.visibility import check_score_visibility
 from CTFd.utils.helpers import get_infos
 from CTFd.utils.scores import get_standings
+from CTFd.utils.user import is_admin
 
 scoreboard = Blueprint("scoreboard", __name__)
 
@@ -17,6 +19,9 @@ def listing():
 
     if config.is_scoreboard_frozen():
         infos.append("Scoreboard has been frozen")
+
+    if is_admin() is True and scores_visible() is False:
+        infos.append("Scores are not currently visible to users")
 
     standings = get_standings()
     return render_template("scoreboard.html", standings=standings, infos=infos)

--- a/CTFd/utils/decorators/visibility.py
+++ b/CTFd/utils/decorators/visibility.py
@@ -30,10 +30,18 @@ def check_score_visibility(f):
                     return redirect(url_for("auth.login", next=request.full_path))
 
         elif v == ScoreVisibilityTypes.HIDDEN:
-            return (
-                render_template("errors/403.html", error="Scores are currently hidden"),
-                403,
-            )
+            if is_admin():
+                return f(*args, **kwargs)
+            else:
+                if request.content_type == "application/json":
+                    abort(403)
+                else:
+                    return (
+                        render_template(
+                            "errors/403.html", error="Scores are currently hidden"
+                        ),
+                        403,
+                    )
 
         elif v == ScoreVisibilityTypes.ADMINS:
             if is_admin():

--- a/tests/admin/test_scoreboard.py
+++ b/tests/admin/test_scoreboard.py
@@ -23,23 +23,23 @@ def test_admins_can_see_scores_with_hidden_scores():
         set_config("score_visibility", "hidden")
 
         # Users can see their own data
-        r = user.get("/api/v1/users/me/fails")
+        r = user.get("/api/v1/users/me/fails", json="")
         assert r.status_code == 200
-        r = user.get("/api/v1/users/me/solves")
+        r = user.get("/api/v1/users/me/solves", json="")
         assert r.status_code == 200
 
         # Users cannot see public data
-        r = user.get("/api/v1/users/2/solves")
+        r = user.get("/api/v1/users/2/solves", json="")
         assert r.status_code == 403
-        r = user.get("/api/v1/users/2/fails")
+        r = user.get("/api/v1/users/2/fails", json="")
         assert r.status_code == 403
         r = user.get("/scoreboard")
         assert r.status_code == 403
-        r = user.get("/api/v1/scoreboard")
+        r = user.get("/api/v1/scoreboard", json="")
         assert r.status_code == 403
 
         # Admins can see user data
-        r = admin.get("/api/v1/users/2/fails")
+        r = admin.get("/api/v1/users/2/fails", json="")
         assert r.status_code != 403
 
         # Admins can see the scoreboard
@@ -48,7 +48,7 @@ def test_admins_can_see_scores_with_hidden_scores():
         assert "Scores are not currently visible to users" in r.get_data(as_text=True)
 
         # Admins can see the scoreboard
-        r = admin.get("/api/v1/scoreboard")
+        r = admin.get("/api/v1/scoreboard", json="")
         assert r.status_code != 403
 
     destroy_ctfd(app)

--- a/tests/admin/test_scoreboard.py
+++ b/tests/admin/test_scoreboard.py
@@ -1,0 +1,54 @@
+from CTFd.models import Users
+from CTFd.utils import set_config
+from tests.helpers import (
+    create_ctfd,
+    destroy_ctfd,
+    login_as_user,
+    register_user,
+    simulate_user_activity,
+)
+
+
+def test_admins_can_see_scores_with_hidden_scores():
+    """Test that admins can see user scores when Score Visibility is set to hidden"""
+    app = create_ctfd()
+    with app.app_context():
+        register_user(app)
+        user = Users.query.filter_by(id=2).first()
+        simulate_user_activity(app.db, user=user)
+
+        admin = login_as_user(app, name="admin", password="password")
+        user = login_as_user(app)
+
+        set_config("score_visibility", "hidden")
+
+        # Users can see their own data
+        r = user.get("/api/v1/users/me/fails")
+        assert r.status_code == 200
+        r = user.get("/api/v1/users/me/solves")
+        assert r.status_code == 200
+
+        # Users cannot see public data
+        r = user.get("/api/v1/users/2/solves")
+        assert r.status_code == 403
+        r = user.get("/api/v1/users/2/fails")
+        assert r.status_code == 403
+        r = user.get("/scoreboard")
+        assert r.status_code == 403
+        r = user.get("/api/v1/scoreboard")
+        assert r.status_code == 403
+
+        # Admins can see user data
+        r = admin.get("/api/v1/users/2/fails")
+        assert r.status_code != 403
+
+        # Admins can see the scoreboard
+        r = admin.get("/scoreboard")
+        assert r.status_code != 403
+        assert "Scores are not currently visible to users" in r.get_data(as_text=True)
+
+        # Admins can see the scoreboard
+        r = admin.get("/api/v1/scoreboard")
+        assert r.status_code != 403
+
+    destroy_ctfd(app)


### PR DESCRIPTION
* Fix issue where admins could not see user graphs/api data if score visibility was set to hidden
* Closes #1580 