### PR TITLE
Match challenges and dynamic challenges

### DIFF
--- a/CTFd/themes/core/templates/challenge.html
+++ b/CTFd/themes/core/templates/challenge.html
@@ -96,13 +96,13 @@
 						<div class="row submit-row">
 							<div class="col-md-9 form-group">
 								{% block input %}
-									<input id="challenge-id" type="hidden" value="{{ challenge.id }}">
-									<input class="form-control" type="text" name="answer" id="submission-input" placeholder="Flag"/>
+									<input id="challenge-id" class="challenge-id" type="hidden" value="{{ challenge.id }}">
+									<input id="challenge-input" class="challenge-input" type="text" name="answer" placeholder="Flag"/>
 								{% endblock %}
 							</div>
 							<div class="col-md-3 form-group key-submit">
 								{% block submit %}
-								<button type="submit" id="submit-key" class="btn btn-md btn-outline-secondary float-right">
+								<button id="challenge-submit" class="challenge-submit" type="submit">
 									Submit
 								</button>
 								{% endblock %}


### PR DESCRIPTION
Both default challenge types overload the input block and submit block in the same way. This changes the default template to match these, so that other plugins don't have to overload it.

[/CTFd/plugins/challenges/assets/view.html](https://github.com/CTFd/CTFd/blob/12857797bbe6b7b9645e715138acee01db6e79e5/CTFd/plugins/challenges/assets/view.html)
[/CTFd/plugins/dynamic_challenges/assets/view.html](https://github.com/CTFd/CTFd/blob/12857797bbe6b7b9645e715138acee01db6e79e5/CTFd/plugins/dynamic_challenges/assets/view.html)

With this change, we could go the extra step of replacing both templates simply with `{% extends "challenge.html" %}`.

This also fixes an issue related to #1540, since the default template uses `submission-input` instead of `challenge-input` and `submit-key` instead of `challenge-submit`.