### PR TITLE
Added filters for notifications for users/teams

### DIFF
--- a/CTFd/events/__init__.py
+++ b/CTFd/events/__init__.py
@@ -1,7 +1,9 @@
 from flask import Blueprint, Response, current_app, stream_with_context
 
-from CTFd.utils import get_app_config
+from CTFd.utils import get_app_config, get_config
+from CTFd.utils.modes import TEAMS_MODE
 from CTFd.utils.decorators import authed_only, ratelimit
+from CTFd.utils.user import get_current_user, get_current_team
 
 events = Blueprint("events", __name__)
 
@@ -13,6 +15,19 @@ def subscribe():
     @stream_with_context
     def gen():
         for event in current_app.events_manager.subscribe():
+            # Filter notifications based on user and team ID
+            if event.type == "notification":
+                if (
+                    event.data["user"] is not None
+                    and event.data["user"] != get_current_user().id
+                ):
+                    continue
+                if get_config("user_mode") == TEAMS_MODE:
+                    if (
+                        event.data["team"] is not None
+                        and event.data["team"] != get_current_team().id
+                    ):
+                        continue
             yield str(event)
 
     enabled = get_app_config("SERVER_SENT_EVENTS")


### PR DESCRIPTION
I'm unsure whether this was an planned/abandoned feature, however I've added the ability to filter notifications by user/team ID. The information was already in the `Notification` database model, but appeared to be unused. As some background, I'd like to use this feature to allow per-user notifications. I'm developing a plugin to integrate a Kubernetes cluster with CTFd to develop active challenges, and notifying users when their deployments are being reset or shutdown would be a nice feature.

As it stands, I simply added filtering for both events and notifications which removes notifications not destined for the current user/team (depending on if teams are enabled). I did not add any UI mention of this (e.g. in the admin panel notifications dialog), however the ability to create notifications tagged for a user or team existed implicitly in the notifications API, because any of the properties of the `Notification` model could be specified in the post request. The UI side is not my forte, and the these modifications don't break or change any existing functionality that I'm aware of, so I left the old notification creation page unchanged.

Summary/explanation of changes per file:

- `CTFd/api/v1/notifications.py` - modified the `get` handler to insert extra filters on SQLAlchemy query to filter out user and team IDs if present. Also checks for current user mode.
- `CTFd/events/__init__.py` - based what I read in the notifications API post handler, this is how async notifications are sent to the users. Here, I intercepted the notification in the generator and applied similar logic to the above to ignore events not applicable to our current user.
- `CTFd/views.py` - Similar to the notifications API `get` handler. Added the same filters to SQLAlchemy query to remove non-applicable notifications.

If I misunderstood the purpose of the fields in the `Notifications` model, please let me know. I tested locally and was able to receive notifications destined for my user, and was unable to see notifications destined for other users, and was still able to see notifications destined for all users. 