### PR TITLE
Bump gevent version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gunicorn==20.0.4
 dataset==1.3.1
 cmarkgfm==0.4.2
 redis==3.5.2
-gevent==20.5.2
+gevent==20.9.0
 python-dotenv==0.13.0
 flask-restx==0.2.0
 flask-marshmallow==0.10.1


### PR DESCRIPTION
The gevent version 20.5.2 is not compatible with greenlet generating a Runtime error and not letting the CTFd start. 

This PR fixes Issue #1667 
This was fixed by gevent version bump.The version 20.9.0 works fine.