### PR TITLE
Add TIMEOUT environment variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+TIMEOUT=${TIMEOUT:-30}
 WORKERS=${WORKERS:-1}
 WORKER_CLASS=${WORKER_CLASS:-gevent}
 ACCESS_LOG=${ACCESS_LOG:--}
@@ -43,6 +44,7 @@ python manage.py db upgrade
 echo "Starting CTFd"
 exec gunicorn 'CTFd:create_app()' \
     --bind '0.0.0.0:8000' \
+    --timeout $TIMEOUT \
     --workers $WORKERS \
     --worker-tmp-dir "$WORKER_TEMP_DIR" \
     --worker-class "$WORKER_CLASS" \


### PR DESCRIPTION
Add support for a timeout variable for gunicorn
to prevent WORKER timeouts when importing a CTFd export on a
slow platform like a synology nas.