### PR TITLE
Updated vagrant with slightly newer guest os

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_IMG = "generic/ubuntu1810"
+# BOX_IMG = "generic/ubuntu1810" # Working  
+# BOX_IMG = "ubuntu/bionic64" # psycopg2 problem
+# BOX_IMG = "generic/ubuntu2004" # ssh problem
+BOX_IMG = "generic/ubuntu1804"
 
 # Install tmux, virtualenv, and mariadb-server to support development
 $preProvision= <<SCRIPT


### PR DESCRIPTION
On first clone and run, many errors were reported with software dependencies and base os defaulted to python2.
After many hours of testing, I was able to get ctfd to work with this base os and python3 default.