### PR TITLE
Fix Docker Compose restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   nginx:
     image: nginx:1.17
+    restart: always
     volumes:
       - ./conf/nginx/http.conf:/etc/nginx/nginx.conf
     ports:


### PR DESCRIPTION
Hi,

The restart policy for nginx is different than the rest of the challenges. Because the default restart policy is `no`, this causes `nginx` to not restart automatically (like after a reboot), while other challenges do. 