### PR TITLE
Remove psycopg2 dep and only use psycopg2-binary

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -4,8 +4,7 @@ pytest-randomly==3.4.0
 coverage==5.1
 flake8==3.8.2
 freezegun==0.3.15
-psycopg2==2.7.5
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.6
 codecov==2.1.7
 moto==1.3.14
 bandit==1.6.2


### PR DESCRIPTION
* Remove `psycopg2` dep and only use `psycopg2-binary`
* Update `psycopg2-binary` to 2.8.6