### PR TITLE
No longer set "filesystem" as UPLOAD_PROVIDER in config.ini

### DIFF
--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -106,7 +106,7 @@ MAILGUN_BASE_URL =
 # UPLOAD_PROVIDER
 # Specifies the service that CTFd should use to store files.
 # Can be set to filesystem or s3
-UPLOAD_PROVIDER = filesystem
+UPLOAD_PROVIDER =
 
 # UPLOAD_FOLDER
 # The location where files are uploaded under the filesystem uploader.


### PR DESCRIPTION
Setting `filesystem` here actually prevent the config to be overwritten by an environment variable. This prevent stateless setup such as running CTFd from the official docker image.

This is not a breaking change since the `UPLOAD_PROVIDER` config already has `filesystem` as fallback in `CTFd/config.py` and `CTFd/utils/uploads/__init__.py`.

PS: I've used Github to create the patch and it automatically added a new line at the end of the file, I haven't removed it as it is best practise anyway. 