### PR TITLE
Fix requirements for Python 3.7 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ cffi==1.14.3              # via bcrypt, cmarkgfm
 chardet==3.0.4            # via requests
 click==7.1.2              # via flask
 cmarkgfm==0.4.2           # via -r requirements.in
-dataclasses==0.8          # via pydantic
 dataset==1.3.1            # via -r requirements.in
 docutils==0.15.2          # via botocore
 flask-caching==1.8.0      # via -r requirements.in


### PR DESCRIPTION
* Build `requirements.txt` on Python 3.7 to fix an issue with installing dataclasses. 
* Closes #1729 

I tested that this works in Python 3.6, 3.7, and 3.8. A useful project would be to add installing deps to Github Actions. 
I'll subscribe to https://github.com/ericvsmith/dataclasses/pull/161 since this is IMO a bug in dataclasses. 