### PR TITLE
Add a lower parameter to the plugin upgrade() function to help importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
 - Don't run `db.create_all()` as much during plugin upgrade or during imports
   - By avoiding this we can let alembic and migrations do more of the table creation work but this means that plugins specifically opt into `app.db.create_all()` and will not implicitly get it through `upgrade()`.
   - This means plugins that run `upgrade()` without a migrations folder (no idea who would do this really) will need to upgrade their code.
+- The plugin `upgrade()` function now accepts a `lower` parameter which specifies what lower revision should be used to start from.
+  - This is used to support plugin migrations during import so that we can import data directly at the point that the import was taken from
+  - `lower="current"` means to use the current revision and `lower=None` would mean to use the absolute base revision (e.g. plugin's first installation)
 
 **Admin Panel**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - The plugin `upgrade()` function now accepts a `lower` parameter which specifies what lower revision should be used to start from.
   - This is used to support plugin migrations during import so that we can import data directly at the point that the import was taken from
   - `lower="current"` means to use the current revision and `lower=None` would mean to use the absolute base revision (e.g. plugin's first installation)
+  - By default this doesn't change `upgrade()` behavior
 
 **Admin Panel**
 

--- a/CTFd/plugins/migrations.py
+++ b/CTFd/plugins/migrations.py
@@ -56,7 +56,7 @@ def upgrade(plugin_name=None, revision=None, lower="current"):
     # Choose base revision for plugin upgrade
     # "current" points to the current plugin version stored in config
     # None represents the absolute base layer (e.g. first installation)
-    if lower is "current":
+    if lower == "current":
         lower = get_config(plugin_name + "_alembic_version")
 
     # Do we upgrade to head or to a specific revision

--- a/CTFd/plugins/migrations.py
+++ b/CTFd/plugins/migrations.py
@@ -23,7 +23,7 @@ def current(plugin_name=None):
     return get_config(plugin_name + "_alembic_version")
 
 
-def upgrade(plugin_name=None, revision=None):
+def upgrade(plugin_name=None, revision=None, lower="current"):
     database_url = current_app.config.get("SQLALCHEMY_DATABASE_URI")
     if database_url.startswith("sqlite"):
         current_app.db.create_all()
@@ -53,8 +53,11 @@ def upgrade(plugin_name=None, revision=None):
     config.set_main_option("version_locations", migrations_path)
     script = ScriptDirectory.from_config(config)
 
-    # get current revision for plugin
-    lower = get_config(plugin_name + "_alembic_version")
+    # Choose base revision for plugin upgrade
+    # "current" points to the current plugin version stored in config
+    # None represents the absolute base layer (e.g. first installation)
+    if lower is "current":
+        lower = get_config(plugin_name + "_alembic_version")
 
     # Do we upgrade to head or to a specific revision
     if revision is None:

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -306,7 +306,7 @@ def import_ctf(backup, erase=True):
     plugins = get_plugin_names()
     for plugin in plugins:
         revision = plugin_current(plugin_name=plugin)
-        plugin_upgrade(plugin_name=plugin, revision=revision)
+        plugin_upgrade(plugin_name=plugin, revision=revision, lower=None)
 
     # Insert data for plugin tables
     insertion(members)


### PR DESCRIPTION
- The plugin `upgrade()` function now accepts a `lower` parameter which specifies what lower revision should be used to start from.
  - This is used to support plugin migrations during import so that we can import data directly at the point that the import was taken from
  - `lower="current"` means to use the current revision and `lower=None` would mean to use the absolute base revision (e.g. plugin's first installation)
  - By default this doesn't change `upgrade()` behavior