### PR TITLE
Speed up docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /opt/CTFd
+COPY requirements.txt /opt/CTFd/
 
 RUN pip install -r requirements.txt --no-cache-dir
+
+COPY . /opt/CTFd
+
 # hadolint ignore=SC2086
 RUN for d in CTFd/plugins/*; do \
         if [ -f "$d/requirements.txt" ]; then \


### PR DESCRIPTION
This change first copies and sets up the python requirement file and only then copies the rest of the working directly.

This change can speed up docker rebuilds in a dev or CI environment as code changes that do not impact requirements.txt will not force redownloading all the python dependencies.