### PR TITLE
[closes #1781] reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-slim-buster AS cache
 
 COPY . /opt/CTFd
-RUN find /opt/CTFd -name requirements.txt -exec cat {} \; > /opt/requirements.txt
+RUN find /opt/CTFd -not -name "requirements.txt" -type f -delete
 
 FROM python:3.7-slim-buster
 WORKDIR /opt/CTFd
@@ -14,9 +14,16 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=cache /opt/requirements.txt /opt/requirements.txt
+COPY --from=cache /opt/CTFd /opt/CTFd
 
-RUN pip install -r /opt/requirements.txt --no-cache-dir
+RUN pip install -r requirements.txt --no-cache-dir
+
+# hadolint ignore=SC2086
+RUN for d in CTFd/plugins/*; do \
+        if [ -f "$d/requirements.txt" ]; then \
+            pip install -r $d/requirements.txt --no-cache-dir; \
+        fi; \
+    done;
 
 COPY . /opt/CTFd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM python:3.7-slim-buster AS cache
+
+COPY . /opt/CTFd
+RUN find /opt/CTFd -name requirements.txt -exec cat {} \; > /opt/requirements.txt
+
 FROM python:3.7-slim-buster
 WORKDIR /opt/CTFd
 RUN mkdir -p /opt/CTFd /var/log/CTFd /var/uploads
@@ -5,27 +10,15 @@ RUN mkdir -p /opt/CTFd /var/log/CTFd /var/uploads
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential \
         default-mysql-client \
-        python3-dev \
-        libffi-dev \
-        libssl-dev \
-        git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /opt/CTFd/
+COPY --from=cache /opt/requirements.txt /opt/requirements.txt
 
-RUN pip install -r requirements.txt --no-cache-dir
+RUN pip install -r /opt/requirements.txt --no-cache-dir
 
 COPY . /opt/CTFd
-
-# hadolint ignore=SC2086
-RUN for d in CTFd/plugins/*; do \
-        if [ -f "$d/requirements.txt" ]; then \
-            pip install -r $d/requirements.txt --no-cache-dir; \
-        fi; \
-    done;
 
 RUN adduser \
     --disabled-login \


### PR DESCRIPTION
1. caches plugin requirements.txt for faster re-building
2. removes dev headers and git for they are only required for the alpine base image