### PR TITLE
Fix for hidden users seeing their graphing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Allow for the automatic date rendering format to be overridden by specifying a `data-time-format` attribute.
 - Add styling for the `<blockquote>` element.
 - Change `colorHash` function to use HSL color values to avoid generating too light/dark colors
+- Fix an issue where hidden users couldn't see their graphing data on their private user page (`/user`)
 - Fix scoreboard table identifier to switch between User/Team depending on configured user mode
 - Switch the challenges page in core to use the new API information in `/api/v1/challenges` to mark solves and display solve counts
 - Switch to using Bootstrap's scss in `core/main.scss` to allow using Bootstrap variables

--- a/CTFd/themes/core/templates/users/private.html
+++ b/CTFd/themes/core/templates/users/private.html
@@ -166,7 +166,7 @@
 			'type': 'user',
 			'id': user.id,
 			'name': user.name,
-			'account_id': 'me' if user.id == id else user.id,
+			'account_id': 'me' if user.id == Session.id else user.id,
 		} | tojson }};
 	</script>
 	<script defer src="{{ url_for('views.themes', path='js/echarts.bundle.js') }}"></script>

--- a/CTFd/themes/core/templates/users/public.html
+++ b/CTFd/themes/core/templates/users/public.html
@@ -166,7 +166,7 @@
 			'type': 'user',
 			'id': user.id,
 			'name': user.name,
-			'account_id': 'me' if user.id == id else user.id,
+			'account_id': 'me' if user.id == Session.id else user.id,
 		} | tojson }};
 	</script>
 	<script defer src="{{ url_for('views.themes', path='js/echarts.bundle.js') }}"></script>


### PR DESCRIPTION
* Fix an issue where hidden users couldn't see their graphing data on their private user page (i.e. `/user`)