### PR TITLE
Add pyc and pycache files to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,5 @@ CTFd/uploads/**/*
 .prettierignore
 .travis.yml
 node_modules
+**/*.pyc
+**/__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Use `examplectf.com` as testing/development domain instead of `ctfd.io`
 - Fixes issue where user's name and email would not appear in logs properly
 - Add more linting by also linting with `flake8-comprehensions` and `flake8-bugbear`
+- Add `.pyc` files and `__pycache__` to `.dockerignore`
 
 # 3.2.1 / 2020-12-09
 


### PR DESCRIPTION
- Add `.pyc` files and `__pycache__` to `.dockerignore`