### PR TITLE
Mark 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.3.0 / UNRELEASED
+# 3.3.0 / 2020-03-26
 
 **General**
 
@@ -25,8 +25,8 @@
 - Allow for one theme to reference and inherit from another theme through approaches like `{% extends "core/page.html" %}`
 - Allow for the automatic date rendering format to be overridden by specifying a `data-time-format` attribute.
 - Add styling for the `<blockquote>` element.
-- Change users/private.html, users/public.html to show awards before a user gets a solve
-- Change teams/private.html, teams/public.html to show awards before a team gets a solve
+- Change `users/private.html`, `users/public.html` to show awards before a user gets a solve
+- Change `teams/private.html`, `teams/public.html` to show awards before a team gets a solve
 - Change `colorHash` function to use HSL color values to avoid generating too light/dark colors
 - Fix an issue where hidden users couldn't see their graphing data on their private user page (`/user`)
 - Fix scoreboard table identifier to switch between User/Team depending on configured user mode
@@ -57,16 +57,16 @@
 - Require `pybluemonday` as pip dependency
 - Remove `lxml` and `html5lib` from pip dependencies
 - Bump `Jinja2` to 2.11.3
-- Bump pip-compile to 5.4.0
+- Bump `pip-tools` to 5.4.0
 
 **Miscellaneous**
 
-- Rewrite the HTML santiziation feature (controlled by `HTML_SANITIZATION`) to use the pybluemonday library instead of lxml/html5lib
+- Rewrite the HTML santiziation feature (controlled by `HTML_SANITIZATION`) to use the `pybluemonday` library instead of `lxml`/`html5lib`
   - Note that this feature is still in beta
 - Cache Docker builds more by copying and installing Python dependencies before copying CTFd
 - Change the default emails slightly and rework confirmation email page to make some recommendations clearer
 - Use `examplectf.com` as testing/development domain instead of `ctfd.io`
-- Fixes issue where user's name and email would not appear in logs properly
+- Fix issue where user's name and email would not appear in logs properly
 - Add more linting by also linting with `flake8-comprehensions` and `flake8-bugbear`
 - Add `.pyc` files and `__pycache__` to `.dockerignore`
 


### PR DESCRIPTION
# 3.3.0 / 2020-03-26

**General**

- Don't require a team for viewing challenges if Challenge visibility is set to public
- Add a `THEME_FALLBACK` config to help develop themes. See **Themes** section for details.

**API**

- Implement a faster `/api/v1/scoreboard` endpoint in Teams Mode
- Add the `solves` item to both `/api/v1/challenges` and `/api/v1/challenges/[challenge_id]` to more easily determine how many solves a challenge has
- Add the `solved_by_me` item to both `/api/v1/challenges` and `/api/v1/challenges/[challenge_id]` to more easily determine if the current account has solved the challenge
- Prevent admins from deleting themselves through `DELETE /api/v1/users/[user_id]`
- Add length checking to some sensitive fields in the Pages and Challenges schemas
- Fix issue where `PATCH /api/v1/users[user_id]` returned a list instead of a dict
- Fix exception that occured on demoting admins through `PATCH /api/v1/users[user_id]`
- Add `team_id` to `GET /api/v1/users` to determine if a user is already in a team
- Provide a more useful error message when using an expired token

**Themes**

- Add a `THEME_FALLBACK` config to help develop themes.
  - `THEME_FALLBACK` will configure CTFd to try to find missing theme files in the default built-in `core` theme.
  - This makes it easier to develop themes or use incomplete themes.
- Allow for one theme to reference and inherit from another theme through approaches like `{% extends "core/page.html" %}`
- Allow for the automatic date rendering format to be overridden by specifying a `data-time-format` attribute.
- Add styling for the `<blockquote>` element.
- Change `users/private.html`, `users/public.html` to show awards before a user gets a solve
- Change `teams/private.html`, `teams/public.html` to show awards before a team gets a solve
- Change `colorHash` function to use HSL color values to avoid generating too light/dark colors
- Fix an issue where hidden users couldn't see their graphing data on their private user page (`/user`)
- Fix scoreboard table identifier to switch between User/Team depending on configured user mode
- Switch the challenges page in core to use the new API information in `/api/v1/challenges` to mark solves and display solve counts
- Switch to using Bootstrap's scss in `core/main.scss` to allow using Bootstrap variables
- Consolidate Jinja error handlers into a single function and better handle issues where error templates can't be found

**Plugins**

- Set plugin migration version after successful migrations
- Fix issue where Page URLs injected into the navbar were relative instead of absolute

**Admin Panel**

- Add User standings as well as Teams standings to the admin scoreboard when in Teams Mode
- Add a UI for adding members to a team from the team's admin page
- Add ability for admins to disable public team creation
- Link directly to users who submitted something in the submissions page if the CTF is in Teams Mode
- Fix Challenge Requirements interface in Admin Panel to not allow empty/null requirements to be added
- Fixed an issue where config times (start, end, freeze times) could not be removed
- Fix an exception that occurred when demoting an Admin user
- Adds a temporary hack for re-enabling Javascript snippets in Flag editor templates. (See #1779)

**Deployment**

- Fix boolean configs from the `config.ini` optional section
- Install `python3-dev` instead of `python-dev` in apt
- Require `pybluemonday` as pip dependency
- Remove `lxml` and `html5lib` from pip dependencies
- Bump `Jinja2` to 2.11.3
- Bump `pip-tools` to 5.4.0

**Miscellaneous**

- Rewrite the HTML santiziation feature (controlled by `HTML_SANITIZATION`) to use the `pybluemonday` library instead of `lxml`/`html5lib`
  - Note that this feature is still in beta
- Cache Docker builds more by copying and installing Python dependencies before copying CTFd
- Change the default emails slightly and rework confirmation email page to make some recommendations clearer
- Use `examplectf.com` as testing/development domain instead of `ctfd.io`
- Fix issue where user's name and email would not appear in logs properly
- Add more linting by also linting with `flake8-comprehensions` and `flake8-bugbear`
- Add `.pyc` files and `__pycache__` to `.dockerignore`