### PR TITLE
Ignore node_modules in any subdirectory for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,6 @@ CTFd/uploads/**/*
 .gitignore
 .prettierignore
 .travis.yml
-node_modules
+**/node_modules
 **/*.pyc
 **/__pycache__


### PR DESCRIPTION
- Make `node_modules` in `.dockerignore` recursive to not add any `node_modules` folders into the build context