### PR TITLE
Add validation for blank flag submission on BaseChallenge class

### DIFF
--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -118,6 +118,10 @@ class BaseChallenge(object):
         data = request.form or request.get_json()
         submission = data["submission"].strip()
         flags = Flags.query.filter_by(challenge_id=challenge.id).all()
+
+        if submission.strip() == "":
+            return False, "Flag cannot be blank strings"
+
         for flag in flags:
             try:
                 if get_flag_class(flag.type).compare(flag, submission):


### PR DESCRIPTION
I notice that the attempt function in BaseChallenge class was used to for submitting flag. So I add validation that checked if the input is blank, it will return false and error message "Flag cannot be blank strings"