### PR TITLE
1471 teams.members doesn't respect hidden/banned

### DIFF
--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -118,6 +118,10 @@ class BaseChallenge(object):
         data = request.form or request.get_json()
         submission = data["submission"].strip()
         flags = Flags.query.filter_by(challenge_id=challenge.id).all()
+
+        if submission.strip() == "":
+            return False, "Flag cannot be blank strings"
+
         for flag in flags:
             try:
                 if get_flag_class(flag.type).compare(flag, submission):

--- a/CTFd/themes/core/templates/teams/public.html
+++ b/CTFd/themes/core/templates/teams/public.html
@@ -75,14 +75,16 @@
 					</thead>
 					<tbody>
 					{% for member in team.members %}
-						<tr>
-							<td>
-								<a href="{{ url_for('users.public', user_id=member.id) }}">
-									{{ member.name }}
-								</a>
-							</td>
-							<td>{{ member.score }}</td>
-						</tr>
+						{% if member.hidden != 1 and member.banned != 1 %}
+							<tr>
+								<td>
+									<a href="{{ url_for('users.public', user_id=member.id) }}">
+										{{ member.name }}
+									</a>
+								</td>
+								<td>{{ member.score }}</td>
+							</tr>
+						{% endif %}
 					{% endfor %}
 					</tbody>
 				</table>


### PR DESCRIPTION
In team.members list on public.html, it seems that it will show that the team members that have been hidden or banned and I notice that could be an issue. So I added validation on teams public.html file that will check if the team.members have hidden or banned status set to 1, it will not display the member name on the list.