### PR TITLE
GeoIp bugfix

### DIFF
--- a/CTFd/utils/countries/geoip.py
+++ b/CTFd/utils/countries/geoip.py
@@ -8,8 +8,8 @@ IP_ADDR_LOOKUP = maxminddb.open_database(
 
 
 def lookup_ip_address(addr):
-    response = IP_ADDR_LOOKUP.get(addr)
     try:
+        response = IP_ADDR_LOOKUP.get(addr)
         return response["country"]["iso_code"]
-    except KeyError:
+    except (KeyError, ValueError):
         return None


### PR DESCRIPTION
Added error handling in case `IP_ADDR_LOOKUP.get(addr)` fails. I'm not entirely sure what caused this issue in my installation, but it manifested as an empty string being passed in as addr. the exception that was raised caused admins to not be able to manage any users.