### PR TITLE
Provide direct link to the challenge page. Closes issue #1905

### DIFF
--- a/CTFd/themes/admin/templates/challenges/challenge.html
+++ b/CTFd/themes/admin/templates/challenges/challenge.html
@@ -25,6 +25,10 @@
 					<i class="btn-fa fas fa-file-alt fa-2x px-2" data-toggle="tooltip" data-placement="top"
 					   title="Preview Challenge"></i>
 				</a>
+				<a class="no-decoration" href="{{url_for('challenges.listing')}}#{{challenge.name}}-{{challenge.id}}" target="_blank">
+					<i class="btn-fa fas fa-link fa-2x px-2" data-toggle="tooltip" data-placement="top"
+					   title="Link to Challenge"></i>
+				</a>
 				<a class="no-decoration" href="{{ url_for('admin.submissions_listing', submission_type='correct', field='challenge_id', q=challenge.id) }}">
 					<i class="btn-fa fas fa-tasks fa-2x px-2" data-toggle="tooltip" data-placement="top"
 					   title="Correct Submissions"></i>

--- a/CTFd/themes/admin/templates/challenges/challenge.html
+++ b/CTFd/themes/admin/templates/challenges/challenge.html
@@ -25,10 +25,13 @@
 					<i class="btn-fa fas fa-file-alt fa-2x px-2" data-toggle="tooltip" data-placement="top"
 					   title="Preview Challenge"></i>
 				</a>
-				<a class="no-decoration" href="{{url_for('challenges.listing')}}#{{challenge.name}}-{{challenge.id}}" target="_blank">
+				{% if challenge.state == 'visible' %}
+				<a class="no-decoration" href="{{url_for('challenges.listing')}}#{{challenge.name | safe}}-{{challenge.id}}" target="_blank">
 					<i class="btn-fa fas fa-link fa-2x px-2" data-toggle="tooltip" data-placement="top"
 					   title="Link to Challenge"></i>
 				</a>
+				{% else %}
+				{% endif %}
 				<a class="no-decoration" href="{{ url_for('admin.submissions_listing', submission_type='correct', field='challenge_id', q=challenge.id) }}">
 					<i class="btn-fa fas fa-tasks fa-2x px-2" data-toggle="tooltip" data-placement="top"
 					   title="Correct Submissions"></i>

--- a/CTFd/themes/admin/templates/challenges/challenge.html
+++ b/CTFd/themes/admin/templates/challenges/challenge.html
@@ -26,7 +26,7 @@
 					   title="Preview Challenge"></i>
 				</a>
 				{% if challenge.state == 'visible' %}
-				<a class="no-decoration" href="{{url_for('challenges.listing')}}#{{challenge.name | safe}}-{{challenge.id}}" target="_blank">
+				<a class="no-decoration" href="{{url_for('challenges.listing')}}#{{challenge.name | urlencode}}-{{challenge.id}}" target="_blank">
 					<i class="btn-fa fas fa-link fa-2x px-2" data-toggle="tooltip" data-placement="top"
 					   title="Link to Challenge"></i>
 				</a>


### PR DESCRIPTION
- Create an icon in the admin panel for linking to a the challenge on the challenge page
- Use urlencode to reduce script placement inside of the url, although only internal users like admins can create challenges so the attack vector is not that important