### PR TITLE
Sort challenges by id

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -227,7 +227,9 @@ class ChallengeList(Resource):
                 and_(Challenges.state != "hidden", Challenges.state != "locked")
             )
         chal_q = (
-            chal_q.filter_by(**query_args).filter(*filters).order_by(Challenges.value)
+            chal_q.filter_by(**query_args)
+            .filter(*filters)
+            .order_by(Challenges.value, Challenges.id)
         )
 
         # Iterate through the list of challenges, adding to the object which


### PR DESCRIPTION
When you go over 256 (?) challenges, the sorting of everything gets chaotic. Before that threshold, everything seems to be implicitly secondarily sorted by id (probably just an artifact of the database internals). A nice and simple fix is to just sort everything by id explicitly as a secondary sorting key. For most users, this should not have any effect. For the (probably rare) users that go over this 256 barrier, this will make things function as expected.