### PR TITLE
Add a way to access the challenge plugin class from the Challenges model

### DIFF
--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -122,6 +122,12 @@ class Challenges(db.Model):
 
         return markup(build_markdown(self.description))
 
+    @property
+    def plugin_class(self):
+        from CTFd.plugins.challenges import get_chal_class
+
+        return get_chal_class(self.type)
+
     def __init__(self, *args, **kwargs):
         super(Challenges, self).__init__(**kwargs)
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from CTFd.models import Challenges
 from CTFd.plugins import (
     bypass_csrf_protection,
     get_admin_plugin_menu_bar,
@@ -14,7 +15,13 @@ from CTFd.plugins import (
     register_plugin_script,
     register_user_page_menu_bar,
 )
-from tests.helpers import create_ctfd, destroy_ctfd, login_as_user, setup_ctfd
+from tests.helpers import (
+    create_ctfd,
+    destroy_ctfd,
+    gen_challenge,
+    login_as_user,
+    setup_ctfd,
+)
 
 
 def test_register_plugin_asset():
@@ -203,4 +210,18 @@ def test_bypass_csrf_protection():
             output = r.get_data(as_text=True)
             assert r.status_code == 200
             assert output == "Success"
+    destroy_ctfd(app)
+
+
+def test_challenges_model_access_plugin_class():
+    """
+    Test that the Challenges model can access its plugin class
+    """
+    app = create_ctfd()
+
+    with app.app_context():
+        from CTFd.plugins.challenges import get_chal_class
+
+        chal = gen_challenge(app.db)
+        assert chal.plugin_class == get_chal_class("standard")
     destroy_ctfd(app)

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from CTFd.models import Challenges
 from CTFd.plugins import (
     bypass_csrf_protection,
     get_admin_plugin_menu_bar,


### PR DESCRIPTION
* Add a way to access the challenge plugin class from the Challenges model
   * Allows templates to access the plugin class more easily
   * Allows plugins to access the plugin class without having to load the class explicitly
* Closes #1879 