### PR TITLE
Add response headers to `/api/v1/users/me`

### DIFF
--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -280,19 +280,25 @@ class UserPrivate(Resource):
     @users_namespace.doc(
         description="Endpoint to get the User object for the current user",
         responses={
-            200: ("Success", "UserDetailedSuccessResponse"),
             400: (
                 "An error occured processing the provided or stored data",
                 "APISimpleErrorResponse",
             ),
         },
     )
+    @users_namespace.response(200, "Success", "UserDetailedSuccessResponse", headers={
+        "X-CTFd-ID": "User ID",
+        "X-CTFd-Type": "User Type",
+    })
     def get(self):
         user = get_current_user()
         response = UserSchema("self").dump(user).data
         response["place"] = user.place
         response["score"] = user.score
-        return {"success": True, "data": response}
+        return {"success": True, "data": response}, 200, {
+            "X-CTFd-ID": user.id,
+            "X-CTFd-Type": user.type,
+        }
 
     @authed_only
     @users_namespace.doc(

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -290,7 +290,10 @@ class UserPrivate(Resource):
         200,
         "Success",
         "UserDetailedSuccessResponse",
-        headers={"X-CTFd-ID": "User ID", "X-CTFd-Type": "User Type",},
+        headers={
+            "X-CTFd-ID": "User ID",
+            "X-CTFd-Type": "User Type",
+        },
     )
     def get(self):
         user = get_current_user()
@@ -300,7 +303,10 @@ class UserPrivate(Resource):
         return (
             {"success": True, "data": response},
             200,
-            {"X-CTFd-ID": user.id, "X-CTFd-Type": user.type,},
+            {
+                "X-CTFd-ID": user.id,
+                "X-CTFd-Type": user.type,
+            },
         )
 
     @authed_only

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -290,10 +290,7 @@ class UserPrivate(Resource):
         200,
         "Success",
         "UserDetailedSuccessResponse",
-        headers={
-            "X-CTFd-ID": "User ID",
-            "X-CTFd-Type": "User Type",
-        },
+        headers={"X-CTFd-ID": "User ID", "X-CTFd-Type": "User Type",},
     )
     def get(self):
         user = get_current_user()
@@ -303,10 +300,7 @@ class UserPrivate(Resource):
         return (
             {"success": True, "data": response},
             200,
-            {
-                "X-CTFd-ID": user.id,
-                "X-CTFd-Type": user.type,
-            },
+            {"X-CTFd-ID": user.id, "X-CTFd-Type": user.type,},
         )
 
     @authed_only

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -286,19 +286,28 @@ class UserPrivate(Resource):
             ),
         },
     )
-    @users_namespace.response(200, "Success", "UserDetailedSuccessResponse", headers={
-        "X-CTFd-ID": "User ID",
-        "X-CTFd-Type": "User Type",
-    })
+    @users_namespace.response(
+        200,
+        "Success",
+        "UserDetailedSuccessResponse",
+        headers={
+            "X-CTFd-ID": "User ID",
+            "X-CTFd-Type": "User Type",
+        },
+    )
     def get(self):
         user = get_current_user()
         response = UserSchema("self").dump(user).data
         response["place"] = user.place
         response["score"] = user.score
-        return {"success": True, "data": response}, 200, {
-            "X-CTFd-ID": user.id,
-            "X-CTFd-Type": user.type,
-        }
+        return (
+            {"success": True, "data": response},
+            200,
+            {
+                "X-CTFd-ID": user.id,
+                "X-CTFd-Type": user.type,
+            },
+        )
 
     @authed_only
     @users_namespace.doc(


### PR DESCRIPTION
Adds X-CTFd-ID and X-CTFd-Type response headers to the `/api/v1/users/me` endpoint.
This allows you to use CTFd to manage sessions along with nginx's [auth_request](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) module to make reverse proxied applications aware of the user's identity.
```
location /secretapp/ {
    auth_request /auth;                
    auth_request_set $id $upstream_http_x_ctfd_id;      
    auth_request_set $type $upstream_http_x_ctfd_type;      
    proxy_set_header X-User-ID $id;
    proxy_set_header X-User-Type $type;
    proxy_pass protected_app_backend;
}

location = /auth {
    proxy_pass http://ctfd/api/v1/users/me;
    proxy_pass_request_body off;
    proxy_set_header Content-Length "";
    proxy_set_header X-Original-URI $request_uri;
}
```