### PR TITLE
Hide token type in user settings

### DIFF
--- a/CTFd/themes/core/templates/settings.html
+++ b/CTFd/themes/core/templates/settings.html
@@ -94,7 +94,6 @@
 					<table class="table table-striped">
 						<thead>
 							<tr>
-								<td class="text-center"><b>Type</b></td>
 								<td class="text-center"><b>Created</b></td>
 								<td class="text-center"><b>Expiration</b></td>
 								<td class="text-center"><b>Delete</b></td>
@@ -103,7 +102,6 @@
 						<tbody>
 							{% for token in tokens %}
 							<tr>
-								<td>{{ token.type }}</td>
 								<td><span data-time="{{ token.created | isoformat }}"></span></td>
 								<td><span data-time="{{ token.expiration | isoformat }}"></span></td>
 								<td class="text-center">


### PR DESCRIPTION
* Works on #1891 
* Hides token type from user settings because it's currently unused