### PR TITLE
Mark 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Fix an issue where admins couldn't see challenges which had requirements in the add requirements interface
 
+# 3.3.1 / 2021-07-15
+
+**Security**
+
+- Fixes an issue where users could join teams without knowing the team password or having a team invite
+
 # 3.3.0 / 2021-03-26
 
 **General**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -29,7 +29,7 @@ from CTFd.utils.migrations import create_database, migrations, stamp_latest_revi
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 __channel__ = "oss"
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
# 3.3.1 / 2021-07-15

**Security**

- Fixes an issue where users could join teams without knowing the team password or having a team invite