### PR TITLE
Set THEME_FALLBACK to default to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 **Themes**
 
-- CTFd now has the `THEME_FALLBACK` option enabled by default. THis allows users to provide incomplete themes. Missing theme files will be provided from the built-in core theme
+- CTFd now has the `THEME_FALLBACK` option enabled by default. This allows users to provide incomplete themes. Missing theme files will be provided from the built-in core theme
 - CTFd will now pass the title of a Page over to the template when rendering
 - No longer show the token type in user settings
 - Added `window.BETA_sortChallenges` to `/challenges` so that theme code can more easily define how to sort challenges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 **Themes**
 
+- CTFd now has the `THEME_FALLBACK` option enabled by default. THis allows users to provide incomplete themes. Missing theme files will be provided from the built-in core theme
 - CTFd will now pass the title of a Page over to the template when rendering
 - No longer show the token type in user settings
 - Added `window.BETA_sortChallenges` to `/challenges` so that theme code can more easily define how to sort challenges
@@ -61,6 +62,7 @@
 
 **Deployment**
 
+- The `THEME_FALLBACK` config is now set to true by default
 - Replace installation and usage of `mysqladmin` (specifically `mysqladmin ping`) with a custom Python script
 - Bump version of `pybluemonday` to 0.0.7 (fixes HTML sanitization bypasses and allows comments in HTML)
 - Bump `pydantic` from 1.5.1 to 1.6.2

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -145,7 +145,7 @@ REVERSE_PROXY =
 
 # THEME_FALLBACK
 # Specifies whether CTFd will fallback to the default "core" theme for missing pages/content. Useful for developing themes or using incomplete themes.
-# Defaults to false.
+# Defaults to true.
 THEME_FALLBACK =
 
 # TEMPLATES_AUTO_RELOAD

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -178,7 +178,7 @@ class ServerConfig(object):
 
     TEMPLATES_AUTO_RELOAD: bool = process_boolean_str(empty_str_cast(config_ini["optional"]["TEMPLATES_AUTO_RELOAD"], default=True))
 
-    THEME_FALLBACK: bool = process_boolean_str(empty_str_cast(config_ini["optional"]["THEME_FALLBACK"], default=False))
+    THEME_FALLBACK: bool = process_boolean_str(empty_str_cast(config_ini["optional"]["THEME_FALLBACK"], default=True))
 
     SQLALCHEMY_TRACK_MODIFICATIONS: bool = process_boolean_str(empty_str_cast(config_ini["optional"]["SQLALCHEMY_TRACK_MODIFICATIONS"], default=False))
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -152,7 +152,11 @@ def test_that_request_path_hijacking_works_properly():
 
 def test_theme_fallback_config():
     """Test that the `THEME_FALLBACK` config properly falls themes back to the core theme"""
-    app = create_ctfd()
+
+    class ThemeFallbackConfig(TestingConfig):
+        THEME_FALLBACK = False
+
+    app = create_ctfd(config=ThemeFallbackConfig)
     # Make an empty theme
     try:
         os.mkdir(os.path.join(app.root_path, "themes", "foo_fallback"))
@@ -161,6 +165,7 @@ def test_theme_fallback_config():
 
     # Without theme fallback, missing themes should disappear
     with app.app_context():
+        app.config["THEME_FALLBACK"] = False
         set_config("ctf_theme", "foo_fallback")
         assert app.config["THEME_FALLBACK"] == False
         with app.test_client() as client:
@@ -174,10 +179,7 @@ def test_theme_fallback_config():
                 pass
     destroy_ctfd(app)
 
-    class ThemeFallbackConfig(TestingConfig):
-        THEME_FALLBACK = True
-
-    app = create_ctfd(config=ThemeFallbackConfig)
+    app = create_ctfd()
     with app.app_context():
         set_config("ctf_theme", "foo_fallback")
         assert app.config["THEME_FALLBACK"] == True


### PR DESCRIPTION
* CTFd now has the `THEME_FALLBACK` option enabled by default. This allows users to provide incomplete themes. Missing theme files will be provided from the built-in core theme
* Closes #1967 