### PR TITLE
Add nested UserSchema and TeamSchema to SubmissionSchema

### DIFF
--- a/CTFd/schemas/submissions.py
+++ b/CTFd/schemas/submissions.py
@@ -2,11 +2,15 @@ from marshmallow import fields
 
 from CTFd.models import Submissions, ma
 from CTFd.schemas.challenges import ChallengeSchema
+from CTFd.schemas.teams import TeamSchema
+from CTFd.schemas.users import UserSchema
 from CTFd.utils import string_types
 
 
 class SubmissionSchema(ma.ModelSchema):
-    challenge = fields.Nested(ChallengeSchema, only=["name", "category", "value"])
+    challenge = fields.Nested(ChallengeSchema, only=["id", "name", "category", "value"])
+    user = fields.Nested(UserSchema, only=["id", "name"])
+    team = fields.Nested(TeamSchema, only=["id", "name"])
 
     class Meta:
         model = Submissions


### PR DESCRIPTION
* Add nested UserSchema and TeamSchema to SubmissionSchema to allow easier access to a user/team name without issuing another query/API call
* Closes #2005 