### PR TITLE
Improve speed of the ChallengeSolves API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- Improved speed of the `/api/v1/challenges/[challenge_id]/solves` endpoint
+
 # 3.4.0 / 2021-08-11
 
 **General**

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -769,8 +769,7 @@ class ChallengeSolves(Resource):
         # query for the attribute directly and it's unknown what the
         # affects of changing the relationship lazy attribute would be
         solves = (
-            Solves.query
-            .add_columns(Model.name.label("account_name"))
+            Solves.query.add_columns(Model.name.label("account_name"))
             .join(Model, Solves.account_id == Model.id)
             .filter(
                 Solves.challenge_id == challenge_id,

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -788,6 +788,7 @@ class ChallengeSolves(Resource):
                 solves = solves.filter(Solves.date < dt)
 
         for solve in solves:
+            # Seperate out the account name and the Solve object from the SQLAlchemy tuple
             solve, account_name = solve
             response.append(
                 {

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import List
 
 from flask import abort, render_template, request, url_for
@@ -764,7 +763,7 @@ class ChallengeSolves(Resource):
 
         Model = get_model()
 
-        # Note that we specifically query for the Solves.account.name 
+        # Note that we specifically query for the Solves.account.name
         # attribute here because it is faster than having SQLAlchemy
         # query for the attribute directly and it's unknown what the
         # affects of changing the relationship lazy attribute would be

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import List
 
 from flask import abort, render_template, request, url_for
@@ -778,6 +779,13 @@ class ChallengeSolves(Resource):
             )
             .order_by(Solves.date.asc())
         )
+
+        freeze = get_config("freeze")
+        if freeze:
+            preview = request.args.get("preview")
+            if (is_admin() is False) or (is_admin() is True and preview):
+                dt = datetime.datetime.utcfromtimestamp(freeze)
+                solves = solves.filter(Solves.date < dt)
 
         for solve in solves:
             solve, account_name = solve


### PR DESCRIPTION
* Improve speed of the ChallengeSolves API (`/api/v1/challenges/[challenge_id]/solves`) endpoint

From time testing there is a significant improvement:

Before:

```
690 ms ± 47.5 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
684 ms ± 45.1 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
712 ms ± 79 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
761 ms ± 108 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
```

After:

```
125 ms ± 25.6 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
115 ms ± 7.94 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
127 ms ± 17.6 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
133 ms ± 27.2 ms per loop (mean ± std. dev. of 10 runs, 3 loops each)
```

We should consider the potential performance gains vs risks of making all relationships use joined loading instead of select lazy loading. 
