### PR TITLE
Mark 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.4.2 / 2022-03-07
+
+**Security**
+
+- Bump cmarkgfm to 0.8.0 to resolve CVE-2022-24724
+
+**General**
+
+- Fix issue where unauthed users couldn't download challenge files after CTF end but viewing after CTF was enabled
+
 # 3.4.1 / 2022-02-19
 
 **General**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -29,7 +29,7 @@ from CTFd.utils.migrations import create_database, migrations, stamp_latest_revi
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 
-__version__ = "3.4.1"
+__version__ = "3.4.2"
 __channel__ = "oss"
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
# 3.4.2 / 2022-03-07

**Security**

- Bump cmarkgfm to 0.8.0 to resolve CVE-2022-24724

**General**

- Fix issue where unauthed users couldn't download challenge files after CTF end but viewing after CTF was enabled