### PR TITLE
Mark 3.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.4.3 / 2022-03-07
+
+**Security**
+
+- Bump cmarkgfm to 0.8.0 to resolve CVE-2022-24724. Copied entry from 3.4.2 since 3.4.2 introduced a bug that prevented writing raw HTML.
+
+**General**
+
+- Fix issue where raw HTML would not be rendered in markdown
+
 # 3.4.2 / 2022-03-07
 
 **Security**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -29,7 +29,7 @@ from CTFd.utils.migrations import create_database, migrations, stamp_latest_revi
 from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 
-__version__ = "3.4.2"
+__version__ = "3.4.3"
 __channel__ = "oss"
 
 

--- a/CTFd/utils/__init__.py
+++ b/CTFd/utils/__init__.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 import cmarkgfm
+from cmarkgfm.cmark import Options
 from flask import current_app as app
 
 # isort:imports-firstparty
@@ -14,7 +15,9 @@ binary_type = bytes
 
 def markdown(md):
     return cmarkgfm.markdown_to_html_with_extensions(
-        md, extensions=["autolink", "table", "strikethrough"]
+        md,
+        extensions=["autolink", "table", "strikethrough"],
+        options=Options.CMARK_OPT_UNSAFE,
     )
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfd",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "CTFd is a Capture The Flag framework focusing on ease of use and customizability. It comes with everything you need to run a CTF and it's easy to customize with plugins and themes.",
   "main": "index.js",
   "directories": {

--- a/tests/utils/test_markdown.py
+++ b/tests/utils/test_markdown.py
@@ -1,0 +1,14 @@
+from pytest import mark
+
+from CTFd.utils import markdown
+
+
+def test_markdown():
+    """
+    Test that our markdown function renders properly
+    """
+    # Allow raw HTML / potentially unsafe HTML
+    assert (
+        markdown("<iframe src='https://example.com'></iframe>")
+        == "<iframe src='https://example.com'></iframe>"
+    )

--- a/tests/utils/test_markdown.py
+++ b/tests/utils/test_markdown.py
@@ -7,6 +7,6 @@ def test_markdown():
     """
     # Allow raw HTML / potentially unsafe HTML
     assert (
-        markdown("<iframe src='https://example.com'></iframe>")
+        markdown("<iframe src='https://example.com'></iframe>").strip()
         == "<iframe src='https://example.com'></iframe>"
     )

--- a/tests/utils/test_markdown.py
+++ b/tests/utils/test_markdown.py
@@ -1,5 +1,3 @@
-from pytest import mark
-
 from CTFd.utils import markdown
 
 


### PR DESCRIPTION
# 3.4.3 / 2022-03-07

**Security**

- Bump cmarkgfm to 0.8.0 to resolve CVE-2022-24724. Copied entry from 3.4.2 since 3.4.2 introduced a bug that prevented writing raw HTML.

**General**

- Fix issue where raw HTML would not be rendered in markdown