### PR TITLE
string error Update

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -285,6 +285,7 @@ def create_app(config="CTFd.config.Config"):
         from CTFd.api import api
         from CTFd.events import events
         from CTFd.errors import render_error
+        from CTFd.strings import string_error
 
         app.register_blueprint(views)
         app.register_blueprint(teams)


### PR DESCRIPTION
Since strings are not functions. In line 288, I added string_error because we are calling function () to the end of a function name. This error commonly occurs when you assign a variable called “str”, to use the str() function. Python interprets “str” as a string and you cannot use the str() function in your program