### PR TITLE
Docker-compose now always uses stable nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         internal:
 
   nginx:
-    image: nginx:1.17
+    image: nginx:stable
     restart: always
     volumes:
       - ./conf/nginx/http.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
As discussed in #2086, this PR changes the docker-compose file to automatically uses the latest version of Nginx instead of a pinned version.