### PR TITLE
Fix issues with backup importing

### DIFF
--- a/CTFd/themes/admin/templates/import.html
+++ b/CTFd/themes/admin/templates/import.html
@@ -21,19 +21,18 @@
 			<p>
 				<b>Import Error:</b> {{ import_error }}
 			</p>
+			<div class="alert alert-danger" role="alert">
+				An error occurred during the import. Please try again. 
+			</div>
 			{% else %}
 			<p>
 				<b>Current Status:</b> {{ import_status }}
 			</p>
-			{% endif %}
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-md-6 offset-md-3">
 			<div class="alert alert-secondary" role="alert">
 				Page will redirect upon completion. Refresh page to get latest status.<br>
 				Page will automatically refresh every 5 seconds.
 			</div>
+			{% endif %}
 		</div>
 	</div>
 </div>

--- a/CTFd/themes/admin/templates/import.html
+++ b/CTFd/themes/admin/templates/import.html
@@ -28,23 +28,32 @@
 			{% endif %}
 		</div>
 	</div>
+	<div class="row">
+		<div class="col-md-6 offset-md-3">
+			<div class="alert alert-secondary" role="alert">
+				Page will redirect upon completion. Refresh page to get latest status.<br>
+				Page will automatically refresh every 5 seconds.
+			</div>
+		</div>
+	</div>
 </div>
 {% endblock %}
 
 {% block scripts %}
 <script>
+	// Reload every 5 seconds to poll import status
+	setTimeout(function(){
+		window.location.reload();
+	}, 5000);
+	
 	let start_time = "{{ start_time | tojson }}";
 	let end_time = "{{ end_time | tojson }}";
 	let start = document.getElementById("start-time");
 	start.innerText = new Date(parseInt(start_time) * 1000);
-	let end = document.getElementById("end-time");
-	end.innerText = new Date(parseInt(end_time) * 1000);
 	
-	// Reload every 5 seconds to poll import status
-	if (!end_time) {
-		setTimeout(function(){
-			window.location.reload();
-		}, 5000);
+	if (end_time !== "null") {
+		let end = document.getElementById("end-time");
+		end.innerText = new Date(parseInt(end_time) * 1000);
 	}
 </script>
 {% endblock %}

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -2,11 +2,10 @@ import datetime
 import json
 import os
 import re
-import subprocess
+import subprocess  # nosec B404
 import sys
 import tempfile
 import zipfile
-from importlib.resources import path
 from io import BytesIO
 from pathlib import Path
 
@@ -420,6 +419,6 @@ def background_import_ctf(backup):
     backup.save(f.name)
     python = sys.executable  # Get path of Python interpreter
     manage_py = Path(app.root_path).parent / "manage.py"  # Path to manage.py
-    subprocess.Popen(
+    subprocess.Popen(  # nosec B603
         [python, manage_py, "import_ctf", "--delete_import_on_finish", f.name]
     )

--- a/CTFd/utils/exports/__init__.py
+++ b/CTFd/utils/exports/__init__.py
@@ -25,6 +25,7 @@ from CTFd.plugins.migrations import current as plugin_current
 from CTFd.plugins.migrations import upgrade as plugin_upgrade
 from CTFd.utils import get_app_config, set_config, string_types
 from CTFd.utils.dates import unix_time
+from CTFd.utils.exports.databases import is_database_mariadb
 from CTFd.utils.exports.freeze import freeze_export
 from CTFd.utils.migrations import (
     create_database,
@@ -96,6 +97,10 @@ def import_ctf(backup, erase=True):
         cache.set(key="import_status", value=val, timeout=cache_timeout)
         print(val)
 
+    # Reset import cache keys and don't print these values
+    cache.set(key="import_error", value=None, timeout=cache_timeout)
+    cache.set(key="import_status", value=None, timeout=cache_timeout)
+
     if not zipfile.is_zipfile(backup):
         set_error("zipfile.BadZipfile: zipfile is invalid")
         raise zipfile.BadZipfile
@@ -166,6 +171,7 @@ def import_ctf(backup, erase=True):
     sqlite = get_app_config("SQLALCHEMY_DATABASE_URI").startswith("sqlite")
     postgres = get_app_config("SQLALCHEMY_DATABASE_URI").startswith("postgres")
     mysql = get_app_config("SQLALCHEMY_DATABASE_URI").startswith("mysql")
+    mariadb = is_database_mariadb()
 
     if erase:
         set_status("erasing")
@@ -306,6 +312,23 @@ def import_ctf(backup, erase=True):
                             requirements = entry.get("requirements")
                             if requirements and isinstance(requirements, string_types):
                                 entry["requirements"] = json.loads(requirements)
+
+                        # From v3.1.0 to v3.5.0 FieldEntries could have been varying levels of JSON'ified strings.
+                        # For example "\"test\"" vs "test". This results in issues with importing backups between
+                        # databases. Specifically between MySQL and MariaDB. Because CTFd standardizes against MySQL
+                        # we need to have an edge case here.
+                        if member == "db/field_entries.json":
+                            value = entry.get("value")
+                            if value:
+                                try:
+                                    # Attempt to convert anything to its original Python value
+                                    entry["value"] = str(json.loads(value))
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+                                finally:
+                                    # Dump the value into JSON if its mariadb or skip the conversion if not mariadb
+                                    if mariadb:
+                                        entry["value"] = json.dumps(entry["value"])
 
                         try:
                             table.insert(entry)

--- a/CTFd/utils/exports/databases.py
+++ b/CTFd/utils/exports/databases.py
@@ -1,0 +1,10 @@
+from CTFd.models import db
+
+
+def is_database_mariadb():
+    try:
+        result = db.session.execute("SELECT version()").fetchone()[0]
+        mariadb = "mariadb" in result.lower()
+    except:
+        mariadb = False
+    return mariadb

--- a/CTFd/utils/exports/databases.py
+++ b/CTFd/utils/exports/databases.py
@@ -1,5 +1,6 @@
-from CTFd.models import db
 from sqlalchemy.exc import OperationalError
+
+from CTFd.models import db
 
 
 def is_database_mariadb():

--- a/CTFd/utils/exports/databases.py
+++ b/CTFd/utils/exports/databases.py
@@ -1,10 +1,11 @@
 from CTFd.models import db
+from sqlalchemy.exc import OperationalError
 
 
 def is_database_mariadb():
     try:
         result = db.session.execute("SELECT version()").fetchone()[0]
         mariadb = "mariadb" in result.lower()
-    except:
+    except OperationalError:
         mariadb = False
     return mariadb

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,8 @@
 import datetime
 import shutil
 
+from pathlib import Path
+
 from flask_migrate import MigrateCommand
 from flask_script import Manager
 
@@ -71,9 +73,13 @@ def export_ctf(path=None):
 
 
 @manager.command
-def import_ctf(path):
+def import_ctf(path, delete_import_on_finish=False):
     with app.app_context():
         import_ctf_util(path)
+
+    if delete_import_on_finish:
+        print(f"Deleting {path}")
+        Path(path).unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Closes #2087 
* Use `python manage.py import_ctf` instead of a new Process to import backups from the Admin Panel. 
    * This avoids a number of issues with gevent and webserver forking/threading models. 
* Add `--delete_import_on_finish` to `python manage.py import_ctf`
* Fix issue where `field_entries` table could not be imported when moving between MySQL and MariaDB