### PR TITLE
`delete` space

### DIFF
--- a/CTFd/themes/core/templates/settings.html
+++ b/CTFd/themes/core/templates/settings.html
@@ -1,4 +1,4 @@
- {% extends "base.html" %}
+{% extends "base.html" %}
 
 {% block stylesheets %}
 {% endblock %}


### PR DESCRIPTION
There was a blank space.