### PR TITLE
Added info for challenges page Admins Only mode

### DIFF
--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -10,7 +10,7 @@ from CTFd.utils.decorators import (
 )
 from CTFd.utils.decorators.visibility import check_challenge_visibility
 from CTFd.utils.helpers import get_errors, get_infos
-from CTFd.utils.user import authed, get_current_team
+from CTFd.utils.user import authed, is_admin, get_current_team
 
 challenges = Blueprint("challenges", __name__)
 
@@ -33,6 +33,12 @@ def listing():
     infos = get_infos()
     errors = get_errors()
 
+    if (
+        Configs.challenge_visibility == ChallengeVisibilityTypes.ADMINS
+        and is_admin() is True
+    ):
+        infos.append(f"Challenges are set to Admins Only mode")
+    
     if ctf_started() is False:
         errors.append(f"{Configs.ctf_name} has not started yet")
 

--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -10,7 +10,7 @@ from CTFd.utils.decorators import (
 )
 from CTFd.utils.decorators.visibility import check_challenge_visibility
 from CTFd.utils.helpers import get_errors, get_infos
-from CTFd.utils.user import authed, is_admin, get_current_team
+from CTFd.utils.user import authed, get_current_team,  is_admin
 
 challenges = Blueprint("challenges", __name__)
 
@@ -37,7 +37,7 @@ def listing():
         Configs.challenge_visibility == ChallengeVisibilityTypes.ADMINS
         and is_admin() is True
     ):
-        infos.append(f"Challenges are set to Admins Only mode")
+        infos.append("Challenges are set to Admins Only mode")
     
     if ctf_started() is False:
         errors.append(f"{Configs.ctf_name} has not started yet")

--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -10,7 +10,7 @@ from CTFd.utils.decorators import (
 )
 from CTFd.utils.decorators.visibility import check_challenge_visibility
 from CTFd.utils.helpers import get_errors, get_infos
-from CTFd.utils.user import authed, get_current_team,  is_admin
+from CTFd.utils.user import authed, get_current_team
 
 challenges = Blueprint("challenges", __name__)
 
@@ -33,12 +33,9 @@ def listing():
     infos = get_infos()
     errors = get_errors()
 
-    if (
-        Configs.challenge_visibility == ChallengeVisibilityTypes.ADMINS
-        and is_admin() is True
-    ):
-        infos.append("Challenges are set to Admins Only mode")
-    
+    if Configs.challenge_visibility == ChallengeVisibilityTypes.ADMINS:
+        infos.append("Challenge Visibility is set to Admins Only")
+
     if ctf_started() is False:
         errors.append(f"{Configs.ctf_name} has not started yet")
 

--- a/CTFd/utils/decorators/visibility.py
+++ b/CTFd/utils/decorators/visibility.py
@@ -73,7 +73,13 @@ def check_challenge_visibility(f):
                 return f(*args, **kwargs)
             else:
                 if authed():
-                    abort(403)
+                    if request.content_type == "application/json":
+                        abort(403)
+                    else:
+                        abort(
+                            403,
+                            description="Challenge Visibility is set to Admins Only",
+                        )
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))
 


### PR DESCRIPTION
Added info stating "Challenges are set to Admins Only mode" for admins in relevant case so they don't forget as per issue https://github.com/CTFd/CTFd/issues/2137.