### PR TITLE
Moved attempt after CTF setting to settings tab

### DIFF
--- a/CTFd/constants/config.py
+++ b/CTFd/constants/config.py
@@ -11,6 +11,7 @@ class ConfigTypes(str, RawEnum):
     SCORE_VISIBILITY = "score_visibility"
     ACCOUNT_VISIBILITY = "account_visibility"
     REGISTRATION_VISIBILITY = "registration_visibility"
+    POST_CTF_VISIBILITY = "post_ctf_visibility"
 
 
 @JinjaEnum
@@ -45,6 +46,12 @@ class AccountVisibilityTypes(str, RawEnum):
 class RegistrationVisibilityTypes(str, RawEnum):
     PUBLIC = "public"
     PRIVATE = "private"
+
+
+@JinjaEnum
+class PostCTFVisibilityTypes(str, RawEnum):
+    ENABLED = "Enabled"
+    DISABLED = "Disabled"
 
 
 class _ConfigsWrapper:

--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -90,13 +90,23 @@
 		</div>
 
 		<div class="form-group">
-			<div class="form-check">
-				<label>
-					<input id="view_after_ctf" name="view_after_ctf" type="checkbox"
-						   {% if view_after_ctf %}checked{% endif %}>
-					Allow challenges to be viewed (no submissions are recorded) after the CTF End Time.
-				</label>
-			</div>
+			<label>
+				Post-CTF End Visibility<br>
+				<small class="form-text text-muted">
+					Control whether users can view challenges (no submissions are recorded) after the CTF End Time.
+				</small>
+			</label>
+			<select class="form-control custom-select" name="post_ctf_visibility">
+				<option value="Enabled" {% if post_ctf_visibility == 'Enabled' %}selected{% endif %}>
+					Enabled
+				</option>
+				<option value="Disabled" {% if post_ctf_visibility == 'Disabled' %}selected{% endif %}>
+					Disabled
+				</option>
+			</select>
+		</div>
+
+		<div class="form-group">
 			<div class="form-check">
 				<label>
 					<input id="paused" name="paused" type="checkbox" {% if paused %}checked{% endif %}>

--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -92,6 +92,13 @@
 		<div class="form-group">
 			<div class="form-check">
 				<label>
+					<input id="view_after_ctf" name="view_after_ctf" type="checkbox"
+						   {% if view_after_ctf %}checked{% endif %}>
+					Allow challenges to be viewed (no submissions are recorded) after the CTF End Time.
+				</label>
+			</div>
+			<div class="form-check">
+				<label>
 					<input id="paused" name="paused" type="checkbox" {% if paused %}checked{% endif %}>
 					Pause CTF<br>
 					<small>

--- a/CTFd/themes/admin/templates/configs/time.html
+++ b/CTFd/themes/admin/templates/configs/time.html
@@ -119,14 +119,6 @@
 							   max="59" type='number'>
 					</div>
 
-					<div class="form-check">
-						<label>
-							<input id="view_after_ctf" name="view_after_ctf" type="checkbox"
-								   {% if view_after_ctf %}checked{% endif %}>
-							Allow challenges to be viewed (no submissions are recorded) after the CTF End Time.
-						</label>
-					</div>
-
 					<div class="form-group col-md-12">
 						<label for="end-timezone">Timezone:</label>
 						<select class="form-control custom-select end-date" id="end-timezone">

--- a/CTFd/utils/dates/__init__.py
+++ b/CTFd/utils/dates/__init__.py
@@ -54,7 +54,9 @@ def ctf_ended():
 
 
 def view_after_ctf():
-    return get_config("view_after_ctf")
+    if get_config("post_ctf_visibility") == 'Enabled':
+        return True
+    return False
 
 
 def unix_time(dt):

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -12,6 +12,7 @@ from CTFd.constants.config import (
     AccountVisibilityTypes,
     ChallengeVisibilityTypes,
     ConfigTypes,
+    PostCTFVisibilityTypes,
     RegistrationVisibilityTypes,
     ScoreVisibilityTypes,
 )
@@ -191,6 +192,7 @@ def setup():
             )
             set_config(ConfigTypes.SCORE_VISIBILITY, ScoreVisibilityTypes.PUBLIC)
             set_config(ConfigTypes.ACCOUNT_VISIBILITY, AccountVisibilityTypes.PUBLIC)
+            set_config(ConfigTypes.POST_CTF_VISIBILITY, PostCTFVisibilityTypes.DISABLED)
 
             # Verify emails
             set_config("verify_emails", None)


### PR DESCRIPTION
Moved "Allow challenges to be viewed (no submissions are recorded) after the CTF End Time." checkbox setting from the time config panel to the settings config panel, to improve discoverability as per issue #2128.