### PR TITLE
Hidden admin team by default

### DIFF
--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -278,7 +278,7 @@ def new():
         if errors:
             return render_template("teams/new_team.html", errors=errors), 403
 
-        team = Teams(name=teamname, password=passphrase, captain_id=user.id)
+        team = Teams(name=teamname, password=passphrase, captain_id=user.id, hidden=user.type=='admin')
 
         if website:
             team.website = website


### PR DESCRIPTION
When an Admin creates a team through the normal Team Creation flow that team should be defaulted to Hidden
Fix issue #2144