### PR TITLE
validate value type is string before using strip

### DIFF
--- a/CTFd/schemas/teams.py
+++ b/CTFd/schemas/teams.py
@@ -264,10 +264,13 @@ class TeamSchema(ma.ModelSchema):
                     field_id=field.id, team_id=current_team.id
                 ).first()
 
-                if field.required is True and value.strip() == "":
-                    raise ValidationError(
-                        f"Field '{field.name}' is required", field_names=["fields"]
-                    )
+                if field.required is True:
+                    if isinstance(value, str):
+                        if value.strip() == "":
+                            raise ValidationError(
+                                f"Field '{field.name}' is required",
+                                field_names=["fields"],
+                            )
 
                 if field.editable is False and entry is not None:
                     raise ValidationError(

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -255,7 +255,7 @@ class UserSchema(ma.ModelSchema):
                         if value.strip() == "":
                             raise ValidationError(
                                 f"Field '{field.name}' is required",
-                                field_names=["fields"]
+                                field_names=["fields"],
                             )
 
                 if field.editable is False and entry is not None:

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -250,10 +250,12 @@ class UserSchema(ma.ModelSchema):
                     field_id=field.id, user_id=current_user.id
                 ).first()
 
-                if field.required is True and value.strip() == "":
-                    raise ValidationError(
-                        f"Field '{field.name}' is required", field_names=["fields"]
-                    )
+                if field.required is True:
+                    if isinstance(value, str):
+                        if value.strip() == "":
+                            raise ValidationError(
+                                f"Field '{field.name}' is required", field_names=["fields"]
+                            )
 
                 if field.editable is False and entry is not None:
                     raise ValidationError(

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -254,7 +254,8 @@ class UserSchema(ma.ModelSchema):
                     if isinstance(value, str):
                         if value.strip() == "":
                             raise ValidationError(
-                                f"Field '{field.name}' is required", field_names=["fields"]
+                                f"Field '{field.name}' is required",
+                                field_names=["fields"]
                             )
 
                 if field.editable is False and entry is not None:


### PR DESCRIPTION
When a checkbox field that is required and editable is created after user has created account. Existing users are unable to update their profile as an internal server error is produced.

The internal server error is due to the required field being a boolean and .strip() is invoked on a boolean with causes an error.

The fix is to validate the type of value to be string before checking if the field is empty.