### PR TITLE
Add autocomplete='off' to admin pages to fix Firefox caching checkboxes

### DIFF
--- a/CTFd/themes/admin/templates/challenges/challenges.html
+++ b/CTFd/themes/admin/templates/challenges/challenges.html
@@ -72,7 +72,7 @@
 					<tr>
 						<td class="d-block border-right border-bottom text-center" data-checkbox>
 							<div class="form-check">
-								<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+								<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 							</div>
 						</td>
 						<th class="sort-col text-center"><b>ID</b></th>
@@ -88,7 +88,7 @@
 						<tr data-href="{{ url_for('admin.challenges_detail', challenge_id=challenge.id) }}">
 							<td class="d-block border-right text-center" data-checkbox>
 								<div class="form-check">
-									<input type="checkbox" class="form-check-input" value="{{ challenge.id }}" data-challenge-id="{{ challenge.id }}">&nbsp;
+									<input type="checkbox" class="form-check-input" value="{{ challenge.id }}" autocomplete="off" data-challenge-id="{{ challenge.id }}">&nbsp;
 								</div>
 							</td>
 							<td class="text-center">{{ challenge.id }}</td>

--- a/CTFd/themes/admin/templates/notifications.html
+++ b/CTFd/themes/admin/templates/notifications.html
@@ -10,7 +10,7 @@
 		<div class="row">
 			<div class="col-md-12">
 				{% with form = Forms.notifications.NotificationForm() %}
-				<form method="POST" id="notifications_form">
+				<form method="POST" id="notifications_form" autocomplete="off">
 					<div class="form-group">
 						<b>{{ form.title.label }}</b>
 						{{ form.title(class="form-control") }}

--- a/CTFd/themes/admin/templates/pages.html
+++ b/CTFd/themes/admin/templates/pages.html
@@ -35,7 +35,7 @@
 				<tr>
 					<th class="border-right" data-checkbox>
 						<div class="form-check text-center">
-							<input type="checkbox" class="form-check-input" id="scoreboard-bulk-select" data-checkbox-all>&nbsp;
+							<input type="checkbox" class="form-check-input" id="pages-bulk-select" autocomplete="off" data-checkbox-all>&nbsp;
 						</div>
 					</th>
 					<th class="sort-col text-center"><b>Title</b></th>
@@ -50,7 +50,7 @@
 					<tr data-href="{{ url_for('admin.pages_detail', page_id=page.id) }}">
 						<td class="border-right" data-checkbox>
 							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" value="{{ page.id }}" data-page-id="{{ page.id }}">&nbsp;
+								<input type="checkbox" class="form-check-input" value="{{ page.id }}" data-page-id="{{ page.id }}" autocomplete="off">&nbsp;
 							</div>
 						</td>
 						<td class="page-title">

--- a/CTFd/themes/admin/templates/scoreboard/standings.html
+++ b/CTFd/themes/admin/templates/scoreboard/standings.html
@@ -3,7 +3,7 @@
 		<tr>
 			<th class="border-right" data-checkbox>
 				<div class="form-check text-center">
-					<input type="checkbox" class="form-check-input" id="scoreboard-bulk-select" data-checkbox-all>&nbsp;
+					<input type="checkbox" class="form-check-input" id="scoreboard-bulk-select" autocomplete="off" data-checkbox-all>&nbsp;
 				</div>
 			</th>
 			<th class="sort-col text-center"><b>Place</b></th>
@@ -17,7 +17,7 @@
 		<tr data-href="{{ generate_account_url(standing.account_id, admin=True) }}">
 			<td class="border-right text-center" data-checkbox>
 				<div class="form-check">
-					<input type="checkbox" class="form-check-input" value="{{ standing.account_id }}" data-account-id="{{ standing.account_id }}">&nbsp;
+					<input type="checkbox" class="form-check-input" value="{{ standing.account_id }}" data-account-id="{{ standing.account_id }}" autocomplete="off">&nbsp;
 				</div>
 			</td>
 			<td class="text-center" width="10%">{{ loop.index }}</td>

--- a/CTFd/themes/admin/templates/scoreboard/users.html
+++ b/CTFd/themes/admin/templates/scoreboard/users.html
@@ -3,7 +3,7 @@
 		<tr>
 			<th class="border-right" data-checkbox>
 				<div class="form-check text-center">
-					<input type="checkbox" class="form-check-input" id="scoreboard-bulk-select" data-checkbox-all>&nbsp;
+					<input type="checkbox" class="form-check-input" id="users-bulk-select" autocomplete="off" data-checkbox-all>&nbsp;
 				</div>
 			</th>
 			<th class="sort-col text-center"><b>Place</b></th>
@@ -17,7 +17,7 @@
 		<tr data-href="{{ url_for('admin.users_detail', user_id=standing.user_id) }}">
 			<td class="border-right text-center" data-checkbox>
 				<div class="form-check">
-					<input type="checkbox" class="form-check-input" value="{{ standing.user_id }}" data-user-id="{{ standing.user_id }}">&nbsp;
+					<input type="checkbox" class="form-check-input" value="{{ standing.user_id }}" autocomplete="off" data-user-id="{{ standing.user_id }}">&nbsp;
 				</div>
 			</td>
 			<td class="text-center" width="10%">{{ loop.index }}</td>

--- a/CTFd/themes/admin/templates/submissions.html
+++ b/CTFd/themes/admin/templates/submissions.html
@@ -63,7 +63,7 @@
 					<tr>
 						<th class="border-right" data-checkbox>
 							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+								<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 							</div>
 						</th>
 						<th class="text-center sort-col"><b>ID</b></th>
@@ -82,7 +82,7 @@
 					<tr>
 						<td class="border-right" data-checkbox>
 							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" value="{{ sub.id }}" data-submission-id="{{ sub.id }}">&nbsp;
+								<input type="checkbox" class="form-check-input" value="{{ sub.id }}" data-submission-id="{{ sub.id }}" autocomplete="off">&nbsp;
 							</div>
 						</td>
 						<td class="text-center" id="{{ sub.id }}">

--- a/CTFd/themes/admin/templates/teams/team.html
+++ b/CTFd/themes/admin/templates/teams/team.html
@@ -332,7 +332,7 @@
 							<tr>
 								<th class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+										<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 									</div>
 								</th>
 								<th class="sort-col text-center"><b>Challenge</b></th>
@@ -348,7 +348,8 @@
 							<tr class="chal-solve" data-href="{{ url_for("admin.challenges_detail", challenge_id=solve.challenge_id) }}">
 								<td class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" value="{{ solve.id }}" data-submission-id="{{ solve.id }}"
+										<input type="checkbox" class="form-check-input" value="{{ solve.id }}" autocomplete="off"
+										data-submission-id="{{ solve.id }}"
 										data-submission-type="{{ solve.type }}"
 										data-submission-challenge="{{ solve.challenge.name }}">&nbsp;
 									</div>
@@ -397,7 +398,7 @@
 							<tr>
 								<th class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+										<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 									</div>
 								</th>
 								<th class="sort-col text-center"><b>Challenge</b></th>
@@ -411,7 +412,8 @@
 							<tr class="chal-wrong" data-href="{{ url_for("admin.challenges_detail", challenge_id=fail.challenge_id) }}">
 								<td class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" value="{{ fail.id }}" data-submission-id="{{ fail.id }}"
+										<input type="checkbox" class="form-check-input" value="{{ fail.id }}" autocomplete="off"
+										data-submission-id="{{ fail.id }}"
 										data-submission-type="{{ fail.type }}"
 										data-submission-challenge="{{ fail.challenge.name }}">&nbsp;
 									</div>
@@ -458,7 +460,7 @@
 						<tr>
 							<th class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+									<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 								</div>
 							</th>
 							<th class="sort-col text-center"><b>Name</b></th>
@@ -475,7 +477,7 @@
 							<tr class="award-row">
 								<td class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" value="{{ award.id }}" data-award-id="{{ award.id }}" data-award-name="{{ award.name }}">&nbsp;
+										<input type="checkbox" class="form-check-input" value="{{ award.id }}" autocomplete="off" data-award-id="{{ award.id }}" data-award-name="{{ award.name }}">&nbsp;
 									</div>
 								</td>
 								<td class="text-center chal" id="{{ award.id }}">{{ award.name }}</td>
@@ -519,7 +521,7 @@
 						<tr>
 							<th class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+									<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 								</div>
 							</th>
 							<th class="sort-col text-center"><b>Challenge</b></th>
@@ -532,7 +534,7 @@
 						<tr class="chal-solve" data-href="{{ url_for("admin.challenges_detail", challenge_id=challenge.id) }}">
 							<td class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" value="{{ challenge.id }}" data-missing-challenge-id="{{ challenge.id }}"
+									<input type="checkbox" class="form-check-input" value="{{ challenge.id }}" autocomplete="off" data-missing-challenge-id="{{ challenge.id }}"
 									data-missing-challenge-name="{{ challenge.name }}">&nbsp;
 								</div>
 							</td>

--- a/CTFd/themes/admin/templates/teams/teams.html
+++ b/CTFd/themes/admin/templates/teams/teams.html
@@ -70,7 +70,7 @@
 					<tr>
 						<th class="border-right" data-checkbox>
 							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+								<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 							</div>
 						</th>
 						<th class="sort-col text-center"><b>ID</b></th>
@@ -85,7 +85,7 @@
 					<tr name="{{ team.id }}" data-href="{{ url_for('admin.teams_detail', team_id=team.id) }}">
 						<td class="border-right" data-checkbox>
 							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" value="{{ team.id }}" data-team-id="{{ team.id }}">&nbsp;
+								<input type="checkbox" class="form-check-input" value="{{ team.id }}" autocomplete="off" data-team-id="{{ team.id }}">&nbsp;
 							</div>
 						</td>
 						<td class="team-id text-center" value="{{ team.id }}">{{ team.id }}</td>

--- a/CTFd/themes/admin/templates/users/user.html
+++ b/CTFd/themes/admin/templates/users/user.html
@@ -218,7 +218,7 @@
 						<tr>
 							<th class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+									<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 								</div>
 							</th>
 							<th class="sort-col text-center"><b>Challenge</b></th>
@@ -233,7 +233,8 @@
 						<tr class="chal-solve" data-href="{{ url_for("admin.challenges_detail", challenge_id=solve.challenge_id) }}">
 							<td class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" value="{{ solve.id }}" data-submission-id="{{ solve.id }}"
+									<input type="checkbox" class="form-check-input" value="{{ solve.id }}" autocomplete="off" 
+									data-submission-id="{{ solve.id }}"
 									data-submission-type="{{ solve.type }}"
 									data-submission-challenge="{{ solve.challenge.name }}">&nbsp;
 								</div>
@@ -277,7 +278,7 @@
 							<tr>
 								<th class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+										<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 									</div>
 								</th>
 								<th class="sort-col text-center"><b>Challenge</b></th>
@@ -290,7 +291,8 @@
 							<tr class="chal-wrong" data-href="{{ url_for("admin.challenges_detail", challenge_id=fail.challenge_id) }}">
 								<td class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" value="{{ fail.id }}" data-submission-id="{{ fail.id }}"
+										<input type="checkbox" class="form-check-input" value="{{ fail.id }}" autocomplete="off"
+										data-submission-id="{{ fail.id }}"
 										data-submission-type="{{ fail.type }}"
 										data-submission-challenge="{{ fail.challenge.name }}">&nbsp;
 									</div>
@@ -334,7 +336,7 @@
 							<tr>
 								<th class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+										<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 									</div>
 								</th>
 								<th class="sort-col text-center"><b>Name</b></th>
@@ -350,7 +352,7 @@
 							<tr class="award-row">
 								<td class="border-right" data-checkbox>
 									<div class="form-check text-center">
-										<input type="checkbox" class="form-check-input" value="{{ award.id }}" data-award-id="{{ award.id }}" data-award-name="{{ award.name }}">&nbsp;
+										<input type="checkbox" class="form-check-input" value="{{ award.id }}" autocomplete="off" data-award-id="{{ award.id }}" data-award-name="{{ award.name }}">&nbsp;
 									</div>
 								</td>
 								<td class="text-center chal" id="{{ award.id }}">{{ award.name }}</td>
@@ -389,7 +391,7 @@
 						<tr>
 							<th class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" data-checkbox-all>&nbsp;
+									<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
 								</div>
 							</th>
 							<th class="sort-col text-center"><b>Challenge</b></th>
@@ -402,7 +404,7 @@
 						<tr class="chal-solve" data-href="{{ url_for("admin.challenges_detail", challenge_id=challenge.id) }}">
 							<td class="border-right" data-checkbox>
 								<div class="form-check text-center">
-									<input type="checkbox" class="form-check-input" value="{{ challenge.id }}" data-missing-challenge-id="{{ challenge.id }}"
+									<input type="checkbox" class="form-check-input" value="{{ challenge.id }}" autocomplete="off" data-missing-challenge-id="{{ challenge.id }}"
 									data-missing-challenge-name="{{ challenge.name }}">&nbsp;
 								</div>
 							</td>


### PR DESCRIPTION
* Add `autocomplete='off'` to admin pages to fix Firefox caching checkboxes