### PR TITLE
Use binaries in PATH in npm run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "test": "tests"
   },
   "scripts": {
-    "dev": "node_modules/webpack-cli/bin/cli.js -w --mode=development",
-    "build": "node_modules/webpack-cli/bin/cli.js --mode=development; node_modules/webpack-cli/bin/cli.js --mode=production",
-    "verify": "node_modules/webpack-cli/bin/cli.js --mode=development --display=errors-only; node_modules/webpack-cli/bin/cli.js --mode=production --display=errors-only; git diff --quiet --exit-code",
+    "dev": "webpack-cli -w --mode=development",
+    "build": "webpack-cli --mode=development; webpack-cli --mode=production",
+    "verify": "webpack-cli --mode=development --display=errors-only; webpack-cli --mode=production --display=errors-only; git diff --quiet --exit-code",
     "clean": "rm -rf CTFd/themes/core/static/css/* CTFd/themes/core/static/js/* CTFd/themes/admin/static/css/* CTFd/themes/admin/static/js/*",
-    "lint": "node_modules/.bin/eslint CTFd/themes/core/assets/ CTFd/themes/admin/assets/"
+    "lint": "eslint CTFd/themes/core/assets/ CTFd/themes/admin/assets/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running software installed via NPM, `node_modules/.bin` is in PATH, so we can just omit most of the path.