### PR TITLE
Notifications improvements

### DIFF
--- a/CTFd/utils/events/__init__.py
+++ b/CTFd/utils/events/__init__.py
@@ -40,8 +40,8 @@ class EventManager(object):
     def __init__(self):
         self.clients = {}
 
-    def publish(self, data, type=None, channel="ctf"):
-        event = ServerSentEvent(data, type=type)
+    def publish(self, data, type=None, id=id, channel="ctf"):
+        event = ServerSentEvent(data, type=type, id=id)
         message = event.to_dict()
         for client in list(self.clients.values()):
             client[channel].put(message)
@@ -56,14 +56,14 @@ class EventManager(object):
         try:
             # Immediately yield a ping event to force Response headers to be set
             # or else some reverse proxies will incorrectly buffer SSE
-            yield ServerSentEvent(data="", type="ping")
+            yield ServerSentEvent(data="ping", type="ping")
             while True:
                 try:
                     with Timeout(5):
                         message = q[channel].get()
                         yield ServerSentEvent(**message)
                 except Timeout:
-                    yield ServerSentEvent(data="", type="ping")
+                    yield ServerSentEvent(data="ping", type="ping")
         finally:
             del self.clients[id(q)]
             del q
@@ -75,8 +75,8 @@ class RedisEventManager(EventManager):
         self.client = cache.cache._write_client
         self.clients = {}
 
-    def publish(self, data, type=None, channel="ctf"):
-        event = ServerSentEvent(data, type=type)
+    def publish(self, data, type=None, id=None, channel="ctf"):
+        event = ServerSentEvent(data, type=type, id=id)
         message = json.dumps(event.to_dict())
         return self.client.publish(message=message, channel=channel)
 
@@ -107,14 +107,14 @@ class RedisEventManager(EventManager):
         try:
             # Immediately yield a ping event to force Response headers to be set
             # or else some reverse proxies will incorrectly buffer SSE
-            yield ServerSentEvent(data="", type="ping")
+            yield ServerSentEvent(data="ping", type="ping")
             while True:
                 try:
                     with Timeout(5):
                         message = q[channel].get()
                         yield ServerSentEvent(**message)
                 except Timeout:
-                    yield ServerSentEvent(data="", type="ping")
+                    yield ServerSentEvent(data="ping", type="ping")
         finally:
             del self.clients[id(q)]
             del q

--- a/CTFd/utils/events/__init__.py
+++ b/CTFd/utils/events/__init__.py
@@ -40,7 +40,7 @@ class EventManager(object):
     def __init__(self):
         self.clients = {}
 
-    def publish(self, data, type=None, id=id, channel="ctf"):
+    def publish(self, data, type=None, id=None, channel="ctf"):
         event = ServerSentEvent(data, type=type, id=id)
         message = event.to_dict()
         for client in list(self.clients.values()):

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -36,7 +36,7 @@ def test_event_manager_subscription():
         events = event_manager.subscribe()
         message = next(events)
         assert isinstance(message, ServerSentEvent)
-        assert message.to_dict() == {"data": "", "type": "ping"}
+        assert message.to_dict() == {"data": "ping", "type": "ping"}
         assert message.__str__().startswith("event:ping")
         assert len(event_manager.clients) == 1
 
@@ -146,7 +146,7 @@ def test_redis_event_manager_subscription():
                 events = event_manager.subscribe()
                 message = next(events)
                 assert isinstance(message, ServerSentEvent)
-                assert message.to_dict() == {"data": "", "type": "ping"}
+                assert message.to_dict() == {"data": "ping", "type": "ping"}
                 assert message.__str__().startswith("event:ping")
 
                 message = next(events)


### PR DESCRIPTION
* Improve event `ping`s to actually include data so that they show up in devtools
* Improve Event publishers to take an `id` parameter that is sent to the browser
* Add a `since_id` parameter to `GET /api/v1/notifications` to get Notifications that have happened since a specific ID
* Add `HEAD /api/v1/notifications` to get a count of notifications that have happened. This also includes a `since_id` parameter to allow for a notification cursor. 