### PR TITLE
Redirect users to team creation before event start

### DIFF
--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -29,8 +29,11 @@ def during_ctf_time_only(f):
                     error = "{} has ended".format(config.ctf_name())
                     abort(403, description=error)
             if ctf_started() is False:
-                error = "{} has not started yet".format(config.ctf_name())
-                abort(403, description=error)
+                if is_teams_mode() and get_current_team() is None:
+                    return redirect(url_for("teams.private", next=request.full_path))
+                else:
+                    error = "{} has not started yet".format(config.ctf_name())
+                    abort(403, description=error)
 
     return during_ctf_time_only_wrapper
 


### PR DESCRIPTION
This change redirects users to the team creation page if they access a during_ctf_time_only page before the CTF starts. This results in a better experience since users can start assembling their team immediately.