### PR TITLE
Add support for custom S3 regions in S3 uploader

### DIFF
--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -129,6 +129,10 @@ AWS_S3_BUCKET =
 # A URL pointing to a custom S3 implementation. Only used under the s3 uploader.
 AWS_S3_ENDPOINT_URL =
 
+# AWS_S3_REGION
+# The aws region that hosts your bucket. Only used in the s3 uploader.
+AWS_S3_REGION =
+
 [logs]
 # LOG_FOLDER
 # The location where logs are written. These are the logs for CTFd key submissions, registrations, and logins. The default location is the CTFd/logs folder.

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -174,6 +174,8 @@ class ServerConfig(object):
 
         AWS_S3_ENDPOINT_URL: str = empty_str_cast(config_ini["uploads"]["AWS_S3_ENDPOINT_URL"])
 
+        AWS_S3_REGION: str = empty_str_cast(config_ini["uploads"]["AWS_S3_REGION"])
+
     # === OPTIONAL ===
     REVERSE_PROXY: Union[str, bool] = empty_str_cast(config_ini["optional"]["REVERSE_PROXY"], default=False)
 

--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -85,12 +85,14 @@ class S3Uploader(BaseUploader):
         access_key = get_app_config("AWS_ACCESS_KEY_ID")
         secret_key = get_app_config("AWS_SECRET_ACCESS_KEY")
         endpoint = get_app_config("AWS_S3_ENDPOINT_URL")
+        region = get_app_config("AWS_S3_REGION")
         client = boto3.client(
             "s3",
             config=Config(signature_version="s3v4"),
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
             endpoint_url=endpoint,
+            region_name=region,
         )
         return client
 

--- a/tests/utils/test_uploaders.py
+++ b/tests/utils/test_uploaders.py
@@ -10,8 +10,10 @@ from tests.helpers import create_ctfd, destroy_ctfd
 
 @mock_s3
 def test_s3_uploader():
-    conn = boto3.resource("s3", region_name="us-east-1")
-    conn.create_bucket(Bucket="bucket")
+    conn = boto3.resource("s3", region_name="test-region")
+    conn.create_bucket(
+        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "test-region"}
+    )
 
     app = create_ctfd()
     with app.app_context():
@@ -19,6 +21,7 @@ def test_s3_uploader():
         app.config["AWS_ACCESS_KEY_ID"] = "AKIAIOSFODNN7EXAMPLE"
         app.config["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         app.config["AWS_S3_BUCKET"] = "bucket"
+        app.config["AWS_S3_REGION"] = "test-region"
 
         uploader = S3Uploader()
 
@@ -34,8 +37,10 @@ def test_s3_uploader():
 
 @mock_s3
 def test_s3_sync():
-    conn = boto3.resource("s3", region_name="us-east-1")
-    conn.create_bucket(Bucket="bucket")
+    conn = boto3.resource("s3", region_name="test-region")
+    conn.create_bucket(
+        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "test-region"}
+    )
 
     app = create_ctfd()
     with app.app_context():
@@ -43,6 +48,7 @@ def test_s3_sync():
         app.config["AWS_ACCESS_KEY_ID"] = "AKIAIOSFODNN7EXAMPLE"
         app.config["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         app.config["AWS_S3_BUCKET"] = "bucket"
+        app.config["AWS_S3_REGION"] = "test-region"
 
         uploader = S3Uploader()
         uploader.sync()


### PR DESCRIPTION
This is a fix for https://github.com/CTFd/CTFd/issues/2115 .

**Changes summary:**
- Adds a `AWS_S3_REGION` configuration key in `config.ini` and `config.py`.
- Passes the corresponding value as the S3 region when creating the boto3 client for the S3 uploader. Boto3 will default to `us-est-1` the value is `None`, conserving the current behavior if the configuration key is not set.
- Includes a test region in unit tests.

Credits to @mh4ckt3mh4ckt1c4s for the discovery of the issue and a first version of the fix.