### PR TITLE
Allow `/healthcheck` endpoint to bypass setup 

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -198,7 +198,7 @@ def init_request_processors(app):
                 "views.integrations",
                 "views.themes",
                 "views.files",
-                "views.healthcheck"
+                "views.healthcheck",
             ):
                 return
             else:

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -198,6 +198,7 @@ def init_request_processors(app):
                 "views.integrations",
                 "views.themes",
                 "views.files",
+                "views.healthcheck"
             ):
                 return
             else:


### PR DESCRIPTION
This PR fixes #2214 by adding a `/healthcheck` endpoint to the application.

Tested and working

<img width="659" alt="image" src="https://user-images.githubusercontent.com/41597815/199964515-bb380b5b-9ddb-41a9-b303-a8786cdde69f.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/41597815/199964693-d1a09b15-f65e-4804-af3f-2c545eed55bb.png">

```text
172.17.0.1 - - [04/Nov/2022:11:43:02 +0000] "GET /themes/core/static/js/pages/setup.min.js?d=67acada5 HTTP/1.1" 200 0 "http://0.0.0.0:8000/setup" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:02 +0000] "GET /events HTTP/1.1" 302 219 "http://0.0.0.0:8000/setup" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:02 +0000] "GET /themes/core/static/img/favicon.ico?d=67acada5 HTTP/1.1" 200 0 "http://0.0.0.0:8000/setup" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:02 +0000] "GET /setup HTTP/1.1" 200 15195 "http://0.0.0.0:8000/setup" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:07 +0000] "GET /themes/core/static/img/favicon.ico?d=67acada5 HTTP/1.1" 200 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:07 +0000] "GET /healthcheck HTTP/1.1" 200 2 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:08 +0000] "GET /favicon.ico HTTP/1.1" 302 219 "http://0.0.0.0:8000/healthcheck" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:08 +0000] "GET /setup HTTP/1.1" 200 15192 "http://0.0.0.0:8000/healthcheck" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:12 +0000] "GET /healthcheck HTTP/1.1" 200 2 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:12 +0000] "GET /favicon.ico HTTP/1.1" 302 219 "http://0.0.0.0:8000/healthcheck" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
172.17.0.1 - - [04/Nov/2022:11:43:12 +0000] "GET /setup HTTP/1.1" 200 15195 "http://0.0.0.0:8000/healthcheck" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"


```