### PR TITLE
Clarify Score Visibility and Account Visibility

### DIFF
--- a/CTFd/scoreboard.py
+++ b/CTFd/scoreboard.py
@@ -2,7 +2,10 @@ from flask import Blueprint, render_template
 
 from CTFd.utils import config
 from CTFd.utils.config.visibility import scores_visible
-from CTFd.utils.decorators.visibility import check_score_visibility
+from CTFd.utils.decorators.visibility import (
+    check_account_visibility,
+    check_score_visibility,
+)
 from CTFd.utils.helpers import get_infos
 from CTFd.utils.scores import get_standings
 from CTFd.utils.user import is_admin
@@ -11,6 +14,7 @@ scoreboard = Blueprint("scoreboard", __name__)
 
 
 @scoreboard.route("/scoreboard")
+@check_account_visibility
 @check_score_visibility
 def listing():
     infos = get_infos()

--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -22,6 +22,26 @@
 
 		<div class="form-group">
 			<label>
+				Account Visibility<br>
+				<small class="form-text text-muted">
+					Control whether accounts (users &amp; teams) are shown to everyone, only to authenticated users, or only to admins
+				</small>
+			</label>
+			<select class="form-control custom-select" name="account_visibility">
+				<option value="public" {% if account_visibility == 'public' %}selected{% endif %}>
+					Public
+				</option>
+				<option value="private" {% if account_visibility == 'private' %}selected{% endif %}>
+					Private
+				</option>
+				<option value="admins" {% if account_visibility == 'admins' %}selected{% endif %}>
+					Admins Only
+				</option>
+			</select>
+		</div>
+
+		<div class="form-group">
+			<label>
 				Score Visibility<br>
 				<small class="form-text text-muted">
 					Control whether solves/score are shown to the public, to logged in users, hidden to all non-admins, or only shown to admins
@@ -42,30 +62,9 @@
 				</option>
 			</select>
 			<small class="form-text text-muted">
-				This setting should generally be the same as Account Visibility to avoid conflicts.
-			</small>
-		</div>
-
-		<div class="form-group">
-			<label>
-				Account Visibility<br>
-				<small class="form-text text-muted">
-					Control whether accounts (users &amp; teams) are shown to everyone, only to authenticated users, or only to admins
-				</small>
-			</label>
-			<select class="form-control custom-select" name="account_visibility">
-				<option value="public" {% if account_visibility == 'public' %}selected{% endif %}>
-					Public
-				</option>
-				<option value="private" {% if account_visibility == 'private' %}selected{% endif %}>
-					Private
-				</option>
-				<option value="admins" {% if account_visibility == 'admins' %}selected{% endif %}>
-					Admins Only
-				</option>
-			</select>
-			<small class="form-text text-muted">
-				This setting should generally be the same as Score Visibility to avoid conflicts.
+				Score Visibility is a subset of Account Visibility. 
+				This means that if accounts are visible to a user then score visibility will control whether they can see the score of that user. 
+				If accounts are not visibile then score visibility has no effect.
 			</small>
 		</div>
 

--- a/CTFd/themes/core/templates/components/navbar.html
+++ b/CTFd/themes/core/templates/components/navbar.html
@@ -30,7 +30,7 @@
                     {% endif %}
                 {% endif %}
 
-                {% if Configs.score_visibility != 'admins' %}
+                {% if Configs.score_visibility != 'admins' and Configs.account_visibility != 'admins' %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('scoreboard.listing') }}">Scoreboard</a>
                     </li>

--- a/CTFd/themes/core/templates/components/navbar.html
+++ b/CTFd/themes/core/templates/components/navbar.html
@@ -30,7 +30,7 @@
                     {% endif %}
                 {% endif %}
 
-                {% if Configs.score_visibility != 'admins' and Configs.account_visibility != 'admins' %}
+                {% if Configs.account_visibility != 'admins' and Configs.score_visibility != 'admins' %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('scoreboard.listing') }}">Scoreboard</a>
                     </li>


### PR DESCRIPTION
We need to make the discrepancy between score_visiblity and account_visibility clearer. 

I want to officially clarify score visibility as meaning: 

"If a user's account is visibile, do we then also show their score and solves?"

If you have account visibility but not score_visibility you should be able to see their account information but none of their score information. If you have score visibility but not account visibility you shouldn't be able to see anything. 

Score visibility should be seen as a subset of account visibility.

* Don't show `/scoreboard` if we do not have `account_visibility`

