### PR TITLE
Bump CTFd dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,15 +8,15 @@ Flask-Script==2.0.6
 SQLAlchemy==1.3.17
 SQLAlchemy-Utils==0.36.6
 passlib==1.7.4
-bcrypt==3.2.2
+bcrypt==4.0.1
 itsdangerous==1.1.0
-requests==2.27.1
+requests==2.28.1
 PyMySQL==0.9.3
 gunicorn==20.1.0
 dataset==1.3.1
 cmarkgfm==0.8.0
 redis==3.5.2
-gevent==21.12.0
+gevent==22.10.2
 python-dotenv==0.13.0
 flask-restx==0.5.1
 flask-marshmallow==0.10.1
@@ -25,7 +25,7 @@ boto3==1.13.9
 marshmallow==2.20.2
 pydantic==1.6.2
 WTForms==2.3.1
-python-geoacumen-city==2022.5.15
+python-geoacumen-city==2022.11.15
 maxminddb==1.5.4
 tenacity==6.2.0
 pybluemonday==0.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ aniso8601==8.0.0
     # via flask-restx
 attrs==20.3.0
     # via jsonschema
-bcrypt==3.2.2
+bcrypt==4.0.1
     # via -r requirements.in
 boto3==1.13.9
     # via -r requirements.in
@@ -24,7 +24,6 @@ certifi==2020.11.8
     # via requests
 cffi==1.15.0
     # via
-    #   bcrypt
     #   cmarkgfm
     #   pybluemonday
 charset-normalizer==2.0.12
@@ -60,9 +59,9 @@ flask-sqlalchemy==2.4.3
     # via
     #   -r requirements.in
     #   flask-migrate
-gevent==21.12.0
+gevent==22.10.2
     # via -r requirements.in
-greenlet==1.1.2
+greenlet==2.0.1
     # via gevent
 gunicorn==20.1.0
     # via -r requirements.in
@@ -120,13 +119,13 @@ python-dotenv==0.13.0
     # via -r requirements.in
 python-editor==1.0.4
     # via alembic
-python-geoacumen-city==2022.5.15
+python-geoacumen-city==2022.11.15
     # via -r requirements.in
 pytz==2020.4
     # via flask-restx
 redis==3.5.2
     # via -r requirements.in
-requests==2.27.1
+requests==2.28.1
     # via -r requirements.in
 s3transfer==0.3.3
     # via boto3


### PR DESCRIPTION
Bump bcrypt, gevent, greenlet, python-geoacumen-city, requests.

There are probably more dependencies that need to be updated.

The update is important because new versions of gevent and greenlet support musl.
In the future I will create another docker image based on alpine.
Alpine uses musl.