### PR TITLE
Add individual DATABASE_* options, as an alternative to DATABASE_URL

### DIFF
--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -26,9 +26,37 @@ SECRET_KEY =
 # The URI that specifies the username, password, hostname, port, and database of the server
 # used to hold the CTFd database.
 #
-# If a database URL is not specified, CTFd will automatically create a SQLite database for you to use
+# If neither this setting nor `DATABASE_HOST` is specified, CTFd will automatically create a SQLite database for you to use
 # e.g. mysql+pymysql://root:<YOUR_PASSWORD_HERE>@localhost/ctfd
 DATABASE_URL =
+
+# DATABASE_HOST
+# The hostname of the database server used to hold the CTFd database.
+# If `DATABASE_URL` is set, this setting will have no effect.
+#
+# This option, along with the other `DATABASE_*` options, are an alternative to specifying all connection details in the single `DATABASE_URL`.
+# If neither this setting nor `DATABASE_URL` is specified, CTFd will automatically create a SQLite database for you to use.
+DATABASE_HOST =
+
+# DATABASE_PROTOCOL
+# The protocol used to access the database server, if `DATABASE_HOST` is set. Defaults to `mysql+pymysql`.
+DATABASE_PROTOCOL =
+
+# DATABASE_USER
+# The username used to access the database server, if `DATABASE_HOST` is set. Defaults to `ctfd`.
+DATABASE_USER =
+
+# DATABASE_PASSWORD
+# The password used to access the database server, if `DATABASE_HOST` is set.
+DATABASE_PASSWORD =
+
+# DATABASE_PORT
+# The port used to access the database server, if `DATABASE_HOST` is set.
+DATABASE_PORT =
+
+# DATABASE_NAME
+# The name of the database to access on the database server, if `DATABASE_HOST` is set. Defaults to `ctfd`.
+DATABASE_NAME =
 
 # REDIS_URL
 # The URL to connect to a Redis server. If not specified, CTFd will use the .data folder as a filesystem cache

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -3,6 +3,8 @@ import os
 from distutils.util import strtobool
 from typing import Union
 
+from sqlalchemy.engine.url import URL
+
 
 class EnvInterpolation(configparser.BasicInterpolation):
     """Interpolation which expands environment variables in values."""
@@ -83,8 +85,21 @@ class ServerConfig(object):
     SECRET_KEY: str = empty_str_cast(config_ini["server"]["SECRET_KEY"]) \
         or gen_secret_key()
 
-    DATABASE_URL: str = empty_str_cast(config_ini["server"]["DATABASE_URL"]) \
-        or f"sqlite:///{os.path.dirname(os.path.abspath(__file__))}/ctfd.db"
+    DATABASE_URL: str = empty_str_cast(config_ini["server"]["DATABASE_URL"])
+    if not DATABASE_URL:
+        if empty_str_cast(config_ini["server"]["DATABASE_HOST"]) is not None:
+            # construct URL from individual variables
+            DATABASE_URL = str(URL(
+                drivername=empty_str_cast(config_ini["server"]["DATABASE_PROTOCOL"]) or "mysql+pymysql",
+                username=empty_str_cast(config_ini["server"]["DATABASE_USER"]) or "ctfd",
+                password=empty_str_cast(config_ini["server"]["DATABASE_PASSWORD"]),
+                host=empty_str_cast(config_ini["server"]["DATABASE_HOST"]),
+                port=empty_str_cast(config_ini["server"]["DATABASE_PORT"]),
+                database=empty_str_cast(config_ini["server"]["DATABASE_NAME"]) or "ctfd",
+            ))
+        else:
+            # default to local SQLite DB
+            DATABASE_URL = f"sqlite:///{os.path.dirname(os.path.abspath(__file__))}/ctfd.db"
 
     REDIS_URL: str = empty_str_cast(config_ini["server"]["REDIS_URL"])
 


### PR DESCRIPTION
## Description / Motivation

This PR is meant to resolve issue #2231 by adding the following config settings:
- `DATABASE_PROTOCOL`: SQLAlchemy DB protocol (+ driver, optionally)
- `DATABASE_USER`: Username to access DB server with
- `DATABASE_PASSWORD`: Password to access DB server with
- `DATABASE_HOST`: Hostname of the DB server to access
- `DATABASE_PORT`: Port of the DB server to access
- `DATABASE_NAME`: Name of the database to use

As explained in the linked issue, these new settings are meant as an alternative to the monolithic `DATABASE_URL` setting, to allow each individual component to be controlled separately via environment variables.  
One of the main use cases is in cloud deployments, where it's common to treat the database credentials as opaque secrets, and store the rest of the connection details in plaintext.

## Implementation details

As I've implemented it, SQLite databases aren't really supported (`DATABASE_HOST` is required to use these settings), but I also don't see the use case for someone using these new settings with a SQLite DB, as opposed to `DATABASE_URL`.

If specified, `DATABASE_URL` takes full precedence over any of these new settings, as per ColdHeat's request in #2231.

I just used the setting names from the linked issue, and tried to use reasonable defaults for undefined settings.
I've also used the URL class from SQLAlchemy in order to build the URL - hopefully that's not an issue. I tried writing a  version using string concatenation, but it was both harder to understand and came with some annoying limitations (ex. if someone changed the DB type, the default port wouldn't match up).

One last note: I'm not sure if the intent of the linked issue was to add `REDIS_*` settings as well; if that's the case, I can either add that into this PR, or make a second PR similar to this one for those settings.