### PR TITLE
Add individual REDIS_* options, as an alternative to REDIS_URL

### DIFF
--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -59,11 +59,40 @@ DATABASE_PORT =
 DATABASE_NAME =
 
 # REDIS_URL
-# The URL to connect to a Redis server. If not specified, CTFd will use the .data folder as a filesystem cache
+# The URL to connect to a Redis server. If neither this setting nor `REDIS_HOST` is specified,
+# CTFd will use the .data folder as a filesystem cache.
 #
 # e.g. redis://user:password@localhost:6379
 # http://pythonhosted.org/Flask-Caching/#configuring-flask-caching
 REDIS_URL =
+
+# REDIS_HOST
+# The hostname of the Redis server to connect to.
+# If `REDIS_URL` is set, this setting will have no effect.
+#
+# This option, along with the other `REDIS_*` options, are an alternative to specifying all connection details in the single `REDIS_URL`.
+# If neither this setting nor `REDIS_URL` is specified, CTFd will use the .data folder as a filesystem cache.
+REDIS_HOST =
+
+# REDIS_PROTOCOL
+# The protocol used to access the Redis server, if `REDIS_HOST` is set. Defaults to `redis`.
+REDIS_PROTOCOL =
+
+# REDIS_USER
+# The username used to access the Redis server, if `REDIS_HOST` is set.
+REDIS_USER =
+
+# REDIS_PASSWORD
+# The password used to access the Redis server, if `REDIS_HOST` is set.
+REDIS_PASSWORD =
+
+# REDIS_PORT
+# The port used to access the Redis server, if `REDIS_HOST` is set.
+REDIS_PORT =
+
+# REDIS_DB
+# The index of the Redis database to access, if `REDIS_HOST` is set.
+REDIS_DB =
 
 [security]
 # SESSION_COOKIE_HTTPONLY

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -76,6 +76,8 @@ REDIS_HOST =
 
 # REDIS_PROTOCOL
 # The protocol used to access the Redis server, if `REDIS_HOST` is set. Defaults to `redis`.
+#
+# Note that the `unix` protocol is not supported here; use `REDIS_URL` instead.
 REDIS_PROTOCOL =
 
 # REDIS_USER

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -103,8 +103,25 @@ class ServerConfig(object):
 
     REDIS_URL: str = empty_str_cast(config_ini["server"]["REDIS_URL"])
 
+    REDIS_HOST: str = empty_str_cast(config_ini["server"]["REDIS_HOST"])
+    REDIS_PROTOCOL: str = empty_str_cast(config_ini["server"]["REDIS_PROTOCOL"]) or "redis"
+    REDIS_USER: str = empty_str_cast(config_ini["server"]["REDIS_USER"])
+    REDIS_PASSWORD: str = empty_str_cast(config_ini["server"]["REDIS_PASSWORD"])
+    REDIS_PORT: int = empty_str_cast(config_ini["server"]["REDIS_PORT"]) or 6379
+    REDIS_DB: int = empty_str_cast(config_ini["server"]["REDIS_DB"]) or 0
+
+    if REDIS_URL or REDIS_HOST is None:
+        CACHE_REDIS_URL = REDIS_URL
+    else:
+        # construct URL from individual variables
+        CACHE_REDIS_URL = f"{REDIS_PROTOCOL}://"
+        if REDIS_USER:
+            CACHE_REDIS_URL += REDIS_USER
+        if REDIS_PASSWORD:
+            CACHE_REDIS_URL += f":{REDIS_PASSWORD}"
+        CACHE_REDIS_URL += f"@{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
+
     SQLALCHEMY_DATABASE_URI = DATABASE_URL
-    CACHE_REDIS_URL = REDIS_URL
     if CACHE_REDIS_URL:
         CACHE_TYPE: str = "redis"
     else:


### PR DESCRIPTION
Expanding on #2237, this PR adds the following config settings:

- `REDIS_PROTOCOL`: Protocol to access Redis server with (either `redis` or `rediss`)
- `REDIS_USER`: Username to access Redis server with
- `REDIS_PASSWORD`: Password to access Redis server with
- `REDIS_HOST`: Hostname of the Redis server to access
- `REDIS_PORT`: Port of the Redis server to access
- `REDIS_DB`: Numeric ID of the database to access

As with my previous PR, `REDIS_URL` takes precedence over any of these new settings.

As far as I can tell, redis-py doesn't provide a helper similar to SQLAlchemy's URL class, so I used string concatenation to build the connection URL.

Unfortunately, connecting to a Unix Domain Socket with these settings is not supported, as the URL structure is very different.