### PR TITLE
Clean up the aesthetics for the 'Pause CTF' and 'View After CTF' configs

### DIFF
--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -89,13 +89,16 @@
 		</div>
 
 		<div class="form-group">
-			<div class="form-check">
+			<label>
+				Pause<br>
+				<small class="form-text text-muted">
+					Prevent users from submitting answers until unpaused. Challenges can still be viewed.
+				</small>
+			</label>
+			<div class="form-check pl-0">
 				<label>
 					<input id="paused" name="paused" type="checkbox" {% if paused %}checked{% endif %}>
 					Pause CTF<br>
-					<small>
-						Prevent users from submitting answers until unpaused. Challenges can still be viewed.
-					</small>
 				</label>
 			</div>
 		</div>

--- a/CTFd/themes/admin/templates/configs/time.html
+++ b/CTFd/themes/admin/templates/configs/time.html
@@ -119,12 +119,17 @@
 							   max="59" type='number'>
 					</div>
 
-					<div class="form-check">
-						<label>
-							<input id="view_after_ctf" name="view_after_ctf" type="checkbox"
-								   {% if view_after_ctf %}checked{% endif %}>
-							Allow challenges to be viewed (no submissions are recorded) after the CTF End Time.
-						</label>
+					<div class="form-group col-md-12">
+						<div class="form-check pl-0">
+							<label>
+								<input id="view_after_ctf" name="view_after_ctf" type="checkbox" {% if view_after_ctf %}checked{% endif %}>
+								View After CTF
+								<small class="form-text text-muted">
+									Allows challenges to be viewed after the End Time, however no new submissions will be recorded.<br>
+									For participants to be able to submit after End Time but not alter the scoreboard, configure Freeze Time to be your End Time.
+								</small>
+							</label>
+						</div>
 					</div>
 
 					<div class="form-group col-md-12">


### PR DESCRIPTION
* Clean up the aesthetics for the 'Pause CTF' and 'View After CTF' configs
* Closes #2128 

I could not come up with a better place to put either of these configurations but I decided to clean up the content overall. I think they are okay where they are but if we get more time related configurations we can group them all together into one section. For now I think this is fine. 