### PR TITLE
Add support for experimental image based on Alpine Linux

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,58 @@
+FROM python:3.9-alpine as build
+
+WORKDIR /opt/CTFd
+
+RUN apk add --no-cache \
+        gcc \
+        musl-dev \
+        openssl-dev \
+        build-base \
+        libffi-dev \
+        git \
+    && python -m venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY . /opt/CTFd
+
+RUN pip install --no-cache-dir -r requirements.txt \
+    && for d in CTFd/plugins/*; do \
+        if [ -f "$d/requirements.txt" ]; then \
+            pip install --no-cache-dir -r "$d/requirements.txt";\
+        fi; \
+    done;
+
+
+FROM python:3.9-alpine as release
+
+WORKDIR /opt/CTFd
+
+RUN apk add --no-cache \
+        libffi \
+        libssl1.1 \
+        bash
+
+COPY --chown=1001:1001 . /opt/CTFd
+
+RUN mkdir -p /var/log/CTFd /var/uploads \
+    && chown -R 1001:1001 /var/log/CTFd /var/uploads \
+    && chmod +x /opt/CTFd/docker-entrypoint.sh
+
+RUN adduser \
+    -D \
+    -u 1001 \
+    -g "" \
+    -H \
+    -s /bin/bash \
+    ctfd \
+    && mkdir -p /var/log/CTFd /var/uploads \
+    && chown -R 1001:1001 /var/log/CTFd /var/uploads \
+    && chmod +x /opt/CTFd/docker-entrypoint.sh
+
+
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+USER 1001
+EXPOSE 8000
+ENTRYPOINT ["/opt/CTFd/docker-entrypoint.sh"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -50,7 +50,7 @@ RUN adduser \
     && chmod +x /opt/CTFd/docker-entrypoint.sh
 
 
-COPY --from=build /opt/venv /opt/venv
+COPY --chown=1001:1001 --from=build /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 USER 1001


### PR DESCRIPTION
- [X] Image build correctly
- [X] All modules for python install correctly
- [ ] Error detected on pybluemonday on runtime.
```
Traceback (most recent call last):
  File "/opt/CTFd/ping.py", line 10, in <module>
    from CTFd.config import Config
  File "/opt/CTFd/CTFd/__init__.py", line 19, in <module>
    from CTFd.plugins import init_plugins
  File "/opt/CTFd/CTFd/plugins/__init__.py", line 9, in <module>
    from CTFd.utils.config.pages import get_pages
  File "/opt/CTFd/CTFd/utils/config/pages.py", line 8, in <module>
    from CTFd.utils.security.sanitize import sanitize_html
  File "/opt/CTFd/CTFd/utils/security/sanitize.py", line 1, in <module>
    from pybluemonday import UGCPolicy
  File "/opt/venv/lib/python3.9/site-packages/pybluemonday/__init__.py", line 5, in <module>
    from pybluemonday.bluemonday import ffi, lib
ImportError: Error relocating /opt/venv/lib/python3.9/site-packages/pybluemonday/bluemonday.cpython-39-x86_64-linux-gnu.so: free: initial-exec TLS resolves to dynamic definition in /opt/venv/lib/python3.9/site-packages/pybluemonday/bluemonday.cpython-39-x86_64-linux-gnu.so
```
Probably it's this error.
(https://github.com/golang/go/issues/54805)

After I have time, I will open Issue on (https://github.com/ColdHeat/pybluemonday) for track this problem.