### PR TITLE
Add a new upload provider for Azure Blob Storage

### DIFF
--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -170,7 +170,7 @@ MAIL_PROVIDER =
 [uploads]
 # UPLOAD_PROVIDER
 # Specifies the service that CTFd should use to store files.
-# Can be set to filesystem or s3
+# Can be set to filesystem or s3 or azure
 UPLOAD_PROVIDER =
 
 # UPLOAD_FOLDER
@@ -197,6 +197,25 @@ AWS_S3_ENDPOINT_URL =
 # AWS_S3_REGION
 # The aws region that hosts your bucket. Only used in the s3 uploader.
 AWS_S3_REGION =
+
+# AZURE_STORAGE_ACCOUNT_NAME
+# The storage account name to authenticate to the Azure container, also to generate the shared access signature.
+AZURE_STORAGE_ACCOUNT_NAME =
+
+# AZURE_STORAGE_ACCESS_KEY
+# The account key, also called shared key or access key, to authenticate to the Azure container, also to generate the shared access signature.
+AZURE_STORAGE_ACCESS_KEY =
+
+# AZURE_STORAGE_CONTAINER
+# The name of the container that the blob is in, blob container is like an S3 bucket as the framework for retention of objects.
+AZURE_STORAGE_CONTAINER =
+
+# AZURE_STORAGE_ENDPOINT
+# The URL to the blob storage account. Required if you are using customized url (which means the url is not in this format <storage_account_name>.blob.core.windows.net)
+# This is optional if the `AZURE_STORAGE_ACCOUNT_NAME` is set.
+# e.g. https://<storage-account-name>.blob.core.windows.net (Standard endpoints)
+# e.g. https://<storage-account-name>.z[00-99].blob.storage.azure.net (Azure DNS zone endpoints)
+AZURE_STORAGE_ENDPOINT =
 
 [logs]
 # LOG_FOLDER

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -209,6 +209,14 @@ class ServerConfig(object):
         AWS_S3_ENDPOINT_URL: str = empty_str_cast(config_ini["uploads"]["AWS_S3_ENDPOINT_URL"])
 
         AWS_S3_REGION: str = empty_str_cast(config_ini["uploads"]["AWS_S3_REGION"])
+    elif UPLOAD_PROVIDER == "azure":
+        AZURE_STORAGE_ACCOUNT_NAME: str = empty_str_cast(config_ini["uploads"]["AZURE_STORAGE_ACCOUNT_NAME"])
+
+        AZURE_STORAGE_ACCESS_KEY: str = empty_str_cast(config_ini["uploads"]["AZURE_STORAGE_ACCESS_KEY"])
+
+        AZURE_STORAGE_CONTAINER: str = empty_str_cast(config_ini["uploads"]["AZURE_STORAGE_CONTAINER"])
+
+        AZURE_STORAGE_ENDPOINT: str = empty_str_cast(config_ini["uploads"]["AZURE_STORAGE_ENDPOINT"])
 
     # === OPTIONAL ===
     REVERSE_PROXY: Union[str, bool] = empty_str_cast(config_ini["optional"]["REVERSE_PROXY"], default=False)

--- a/CTFd/utils/uploads/__init__.py
+++ b/CTFd/utils/uploads/__init__.py
@@ -2,9 +2,9 @@ import shutil
 
 from CTFd.models import ChallengeFiles, Files, PageFiles, db
 from CTFd.utils import get_app_config
-from CTFd.utils.uploads.uploaders import FilesystemUploader, S3Uploader
+from CTFd.utils.uploads.uploaders import FilesystemUploader, S3Uploader, AzureBlobStorageAdapter
 
-UPLOADERS = {"filesystem": FilesystemUploader, "s3": S3Uploader}
+UPLOADERS = {"filesystem": FilesystemUploader, "s3": S3Uploader, "azure": AzureBlobStorageAdapter}
 
 
 def get_uploader():

--- a/requirements.in
+++ b/requirements.in
@@ -30,3 +30,4 @@ maxminddb==1.5.4
 tenacity==6.2.0
 pybluemonday==0.0.9
 freezegun==1.2.2
+azure-storage-blob==12.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ aniso8601==8.0.0
     # via flask-restx
 attrs==20.3.0
     # via jsonschema
+azure-storage-blob==12.15.0
+    # via -r requirements.in
 bcrypt==4.0.1
     # via -r requirements.in
 boto3==1.13.9


### PR DESCRIPTION
|Related issue|
|---|
| #2265|

## Description
Azure Blob is the Microsoft equivalent to Amazon’s S3-based object storage services. Within that, a “blob” is like a bucket as the framework for retention of objects. You can upload, download, list, move and carry out other commands in Azure Blobs using Azure Storage client library which is available for multiple languages that include .Net, Java, Node.js, Python, PHP and Ruby.

**Blob storage offers three types of resources:**

* The storage account
* A container in the storage account
* A blob in the container

The following diagram shows the relationship between these resources:

![image](https://user-images.githubusercontent.com/31898849/221697426-cf14e681-fbad-4e6d-bd02-055e5bfd0682.png)

## Configuration options

`AZURE_STORAGE_ACCOUNT_NAME` : The storage account name to authenticate to the Azure container.
`AZURE_STORAGE_ACCESS_KEY` : The account key, also called shared key or access key.
`AZURE_STORAGE_CONTAINER` : The name of the container that the blob is in, blob container is like an S3 bucket.
`AZURE_STORAGE_ENDPOINT` : The URL to the blob storage account.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Each of the features listed below passed all tests without any errors.
- [x] Upload files.
- [x] Download files.
- [x] Delete files.
- [x] Store files (CTF import).
- [x] Sync the blob storage with local storage (CTF export).
