### PR TITLE
Prevent race conditions on /healthcheck

### DIFF
--- a/CTFd/utils/health/__init__.py
+++ b/CTFd/utils/health/__init__.py
@@ -1,4 +1,4 @@
-from time import monotonic_ns
+from time import time
 
 from flask import current_app
 from sqlalchemy_utils import database_exists
@@ -13,6 +13,7 @@ def check_database():
 
 @timed_lru_cache(timeout=30)
 def check_config():
-    value = monotonic_ns()
-    cache.set("healthcheck", value)
-    return cache.get("healthcheck") == value
+    key = "healthcheck"
+    value = round(time() / 5) * 5
+    cache.set(key, value)
+    return cache.get(key) == value


### PR DESCRIPTION
In a high availability deployment scenario, two clients may make a request on /healthcheck at the exact same time, which can lead to check_config returning False if the second requests changes the 'healthcheck' cache key before the first one has had time to fetch the value it had set.

A solution to counter this is to ensure different keys are used for each healthcheck.