### PR TITLE
Fix issue where we are double processing config.ini items

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -263,4 +263,4 @@ class TestingConfig(ServerConfig):
 # Actually initialize ServerConfig to allow us to add more attributes on
 Config = ServerConfig()
 for k, v in config_ini.items("extra"):
-    setattr(Config, k, process_string_var(v))
+    setattr(Config, k, v)


### PR DESCRIPTION
* In some cases with numeric config items it appears that we can end up processing a string twice. This issue fixes it so that we only process the strings once at configparser load time with `before_get`