### PR TITLE
Fixes double loading of plugins through serve.py

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -40,4 +40,4 @@ if args.profile:
     toolbar.init_app(app)
     print(" * Flask profiling running at http://127.0.0.1:4000/flask-profiler/")
 
-app.run(debug=True, threaded=True, host="127.0.0.1", port=args.port)
+app.run(debug=True, threaded=True, host="127.0.0.1", port=args.port, use_reloader=False)


### PR DESCRIPTION
This change resolves #361 by disabling the reloader, loading the plugins twice when running the app through serve.py.
Signed-off-by : Souvik Mondal <tukaiemondal1@gmail.com>