### PR TITLE
add: freeze ribbon to admin panel

### DIFF
--- a/CTFd/themes/admin/templates/base.html
+++ b/CTFd/themes/admin/templates/base.html
@@ -114,6 +114,15 @@
 	</nav>
 
 	<main role="main">
+		{% if get_config('freeze') %}
+		<div class="container-fluid bg-info text-center py-2">
+			<div class="row">
+				<div class="col-md-12 text-light">
+					Scoreboard freeze in effect
+				</div>
+			</div>
+		</div>
+		{% endif %}
 		{% if get_config('version_latest') %}
 		<div class="container-fluid bg-warning text-center py-3">
 			<div class="row">


### PR DESCRIPTION
This PR partially resolves #2283 . 

I've added a ribbon similar to the "A new CTFd version available" ribbon to the base template of the admin panel. I've aimed to show this information every time they view a page instead of just showing it only when admins view the scoreboard.