### PR TITLE
SMTP TLS/SSL Labels to Match Thunderbird

### DIFF
--- a/CTFd/themes/admin/templates/configs/email.html
+++ b/CTFd/themes/admin/templates/configs/email.html
@@ -221,13 +221,13 @@
 				<div class="form-check">
 					<label>
 						<input id="mail_ssl" name="mail_ssl" type="checkbox" {% if mail_ssl %}checked{% endif %}>
-						SSL
+						TLS/SSL
 					</label>
 				</div>
 				<div class="form-check">
 					<label>
 						<input id="mail_tls" name="mail_tls" type="checkbox" {% if mail_tls %}checked{% endif %}>
-						TLS
+						STARTTLS
 					</label>
 				</div>
 			</div>

--- a/CTFd/themes/admin/templates/configs/email.html
+++ b/CTFd/themes/admin/templates/configs/email.html
@@ -224,13 +224,13 @@
 				<div class="form-check">
 					<label>
 						<input id="mail_ssl" name="mail_ssl" type="checkbox" {% if mail_ssl %}checked{% endif %}>
-						SSL
+						TLS/SSL
 					</label>
 				</div>
 				<div class="form-check">
 					<label>
 						<input id="mail_tls" name="mail_tls" type="checkbox" {% if mail_tls %}checked{% endif %}>
-						TLS
+						STARTTLS
 					</label>
 				</div>
 			</div>

--- a/CTFd/themes/admin/templates/configs/email.html
+++ b/CTFd/themes/admin/templates/configs/email.html
@@ -133,6 +133,9 @@
 		<h5>Email Server</h5>
 		<small class="form-text text-muted">
 			Change the email server used by CTFd to send email
+			<a class="float-right" href="https://docs.ctfd.io/docs/settings/emails#email-server" target="_blank">
+				<i class="far fa-question-circle pr-2"></i>
+			</a>
 		</small>
 		<ul class="nav nav-tabs my-3" role="tablist">
 			<li class="nav-item active">
@@ -221,13 +224,13 @@
 				<div class="form-check">
 					<label>
 						<input id="mail_ssl" name="mail_ssl" type="checkbox" {% if mail_ssl %}checked{% endif %}>
-						TLS/SSL
+						SSL
 					</label>
 				</div>
 				<div class="form-check">
 					<label>
 						<input id="mail_tls" name="mail_tls" type="checkbox" {% if mail_tls %}checked{% endif %}>
-						STARTTLS
+						TLS
 					</label>
 				</div>
 			</div>


### PR DESCRIPTION
Replaced TLS and SSL checkbox text to match the
defaults used by Mozilla Thunderbird to eliminate confusion when configuring SMTP.

https://github.com/CTFd/CTFd/issues/2292