### PR TITLE
Added /opt/CTFD to chown path (line 47) to correct permissions error …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN useradd \
     -u 1001 \
     ctfd \
     && mkdir -p /var/log/CTFd /var/uploads \
-    && chown -R 1001:1001 /var/log/CTFd /var/uploads \
+    && chown -R 1001:1001 /var/log/CTFd /var/uploads /opt/CTFd \
     && chmod +x /opt/CTFd/docker-entrypoint.sh
 
 COPY --chown=1001:1001 --from=build /opt/venv /opt/venv


### PR DESCRIPTION
In reference to issue #2298 where the the path for the CTFd package was missing from the chown statement.  Fix submitted by @killuak11
