### PR TITLE
Fix team template syntax for core-beta theme

### DIFF
--- a/CTFd/themes/core-beta/templates/teams/private.html
+++ b/CTFd/themes/core-beta/templates/teams/private.html
@@ -171,7 +171,7 @@
                   {% trans %}Share this link with your team members for them to join your team{% endtrans %}
                 </small>
                 <small class="form-text text-muted">
-                  {% trans %}Invite links can be re-used and expire after 1 day{% trans %}
+                  {% trans %}Invite links can be re-used and expire after 1 day{% endtrans %}
                 </small>
               </div>
             </form>


### PR DESCRIPTION
A small fix for the core-beta theme template of "team" page that prevented it from rendering.