### PR TITLE
Enable gzip for nginx

### DIFF
--- a/conf/nginx/http.conf
+++ b/conf/nginx/http.conf
@@ -14,7 +14,7 @@ http {
   }
 
   server {
-  
+
     listen 80;
 
     gzip on;

--- a/conf/nginx/http.conf
+++ b/conf/nginx/http.conf
@@ -14,6 +14,8 @@ http {
   }
 
   server {
+  
+    gzip on;
 
     listen 80;
 

--- a/conf/nginx/http.conf
+++ b/conf/nginx/http.conf
@@ -15,9 +15,9 @@ http {
 
   server {
   
-    gzip on;
-
     listen 80;
+
+    gzip on;
 
     client_max_body_size 4G;
 


### PR DESCRIPTION
This enables gzip for nginx.
Without gzip, our scoreboard takes 5 mb and with gzip, ~100kb.