### PR TITLE
Add the optional rsa dependency to pymysql

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ passlib==1.7.4
 bcrypt==4.0.1
 itsdangerous==1.1.0
 requests==2.28.1
-PyMySQL==0.9.3
+PyMySQL[rsa]==0.9.3
 gunicorn==20.1.0
 dataset==1.3.1
 cmarkgfm==2022.10.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ certifi==2022.12.7
 cffi==1.15.0
     # via
     #   cmarkgfm
+    #   cryptography
     #   pybluemonday
 charset-normalizer==2.0.12
     # via requests
@@ -36,6 +37,8 @@ click==7.1.2
     # via flask
 cmarkgfm==2022.10.27
     # via -r requirements.in
+cryptography==40.0.2
+    # via pymysql
 dataset==1.3.1
     # via -r requirements.in
 docutils==0.15.2
@@ -117,7 +120,7 @@ pycparser==2.20
     # via cffi
 pydantic==1.6.2
     # via -r requirements.in
-pymysql==0.9.3
+pymysql[rsa]==0.9.3
     # via -r requirements.in
 pyrsistent==0.17.3
     # via jsonschema


### PR DESCRIPTION
This dependency is required to allow compatibility with MySQL instances that enforce specific authentication protocols. This is often the case with managed databases for some public cloud providers. PyMySQL documentation: https://pymysql.readthedocs.io/en/latest/user/installation.html .

Tested on OVHcloud public cloud through the [404 CTF](https://www.404ctf.fr) .