### PR TITLE
Option to not wait for the datababase on Docker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,18 @@ ACCESS_LOG=${ACCESS_LOG:--}
 ERROR_LOG=${ERROR_LOG:--}
 WORKER_TEMP_DIR=${WORKER_TEMP_DIR:-/dev/shm}
 SECRET_KEY=${SECRET_KEY:-}
+CHECK_DB=${CHECK_DB:-true}
+
+while [[ $# -gt 0 ]]
+do
+  case "$1" in
+    "--no-check-db") CHECK_DB=false;;
+    *)
+      echo "Unknown flag: $1"
+      exit 1
+  esac
+  shift
+done
 
 # Check that a .ctfd_secret_key file or SECRET_KEY envvar is set
 if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
@@ -18,8 +30,11 @@ if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
     fi
 fi
 
-# Ensures that the database is available
-python ping.py
+if [[ "$CHECK_DB" = "true" ]]
+then
+  # Ensures that the database is available
+  python ping.py
+fi
 
 # Initialize database
 python manage.py db upgrade


### PR DESCRIPTION
## Why

While the `ping.py` script is useful in most scenario, it can be bothersome when troubleshooting database issues in complex, container based environments, especially because it will not print out the actual exception when the database is ready but the connection fails for another reason. Additionally, such environments, like Kubernetes, may offer better alternative, like running the `ping.py` in a dedicated init container.

For those reasons, it might often be useful to not run `ping.py` when the CTFd container starts up. This pull request adds options to disable it.

## How

- An environment variable, `CHECK_DB`, which can be set to `false` to disable `ping.py`.
- A flag, `--no-check-db`, which can be passed as an argument to `docker-entrypoint.sh`, to achieve the same result (takes precedence).