### PR TITLE
POC documentation generation

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -3,10 +3,11 @@ import os
 import sys
 import weakref
 from distutils.version import StrictVersion
+from apiflask import APIFlask
 
 import jinja2
-from flask import Flask, Request
-from flask.helpers import safe_join
+from flask import Request
+from werkzeug.security import safe_join
 from flask_babel import Babel
 from flask_migrate import upgrade
 from jinja2 import FileSystemLoader
@@ -45,7 +46,7 @@ class CTFdRequest(Request):
         self.path = self.script_root + self.path
 
 
-class CTFdFlask(Flask):
+class CTFdFlask(APIFlask):
     def __init__(self, *args, **kwargs):
         """Overriden Jinja constructor setting a custom jinja_environment"""
         self.jinja_environment = SandboxedBaseEnvironment
@@ -57,7 +58,7 @@ class CTFdFlask(Flask):
 
         # Create generally unique run identifier
         self.run_id = sha256(str(self.start_time))[0:8]
-        Flask.__init__(self, *args, **kwargs)
+        APIFlask.__init__(self, *args, **kwargs)
 
     def create_jinja_environment(self):
         """Overridden jinja environment constructor"""
@@ -156,7 +157,11 @@ def run_upgrade():
 
 
 def create_app(config="CTFd.config.Config"):
-    app = CTFdFlask(__name__)
+    app = CTFdFlask(__name__, docs_path=None)
+    app.config['SWAGGER_UI_CSS'] = 'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.11.1/swagger-ui.min.css'
+    app.config['SWAGGER_UI_BUNDLE_JS'] = 'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.11.1/swagger-ui-bundle.min.js'
+    app.config['SWAGGER_UI_STANDALONE_PRESET_JS'] = 'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.11.1/swagger-ui-standalone-preset.min.js'
+
     with app.app_context():
         app.config.from_object(config)
 
@@ -189,17 +194,7 @@ def create_app(config="CTFd.config.Config"):
         # Use a choice loader to find the first match from our list of loaders
         app.jinja_loader = jinja2.ChoiceLoader(loaders)
 
-        from CTFd.models import (  # noqa: F401
-            Challenges,
-            Fails,
-            Files,
-            Flags,
-            Solves,
-            Tags,
-            Teams,
-            Tracking,
-            db,
-        )
+        from CTFd.models import db
 
         url = create_database()
 
@@ -239,13 +234,15 @@ def create_app(config="CTFd.config.Config"):
             # Allows migrations to happen properly
             upgrade()
 
-        from CTFd.models import ma
 
-        ma.init_app(app)
-
+        
         app.db = db
         app.VERSION = __version__
         app.CHANNEL = __channel__
+
+        # In order to integrate with Flask-SQLAlchemy, this extension must be initialized *after* flask_sqlalchemy.SQLAlchemy.
+        # https://github.com/marshmallow-code/flask-marshmallow/issues/74
+        from CTFd.schemas import ma
 
         from CTFd.cache import cache
 

--- a/CTFd/api/__init__.py
+++ b/CTFd/api/__init__.py
@@ -1,73 +1,74 @@
-from flask import Blueprint, current_app
-from flask_restx import Api
+from flask import current_app
+# from flask_restx import Api
+from apiflask import APIBlueprint as Blueprint
 
-from CTFd.api.v1.awards import awards_namespace
-from CTFd.api.v1.challenges import challenges_namespace
-from CTFd.api.v1.comments import comments_namespace
-from CTFd.api.v1.config import configs_namespace
-from CTFd.api.v1.files import files_namespace
-from CTFd.api.v1.flags import flags_namespace
-from CTFd.api.v1.hints import hints_namespace
-from CTFd.api.v1.notifications import notifications_namespace
-from CTFd.api.v1.pages import pages_namespace
-from CTFd.api.v1.schemas import (
-    APIDetailedSuccessResponse,
-    APISimpleErrorResponse,
-    APISimpleSuccessResponse,
-)
-from CTFd.api.v1.scoreboard import scoreboard_namespace
-from CTFd.api.v1.statistics import statistics_namespace
-from CTFd.api.v1.submissions import submissions_namespace
-from CTFd.api.v1.tags import tags_namespace
-from CTFd.api.v1.teams import teams_namespace
-from CTFd.api.v1.tokens import tokens_namespace
-from CTFd.api.v1.topics import topics_namespace
-from CTFd.api.v1.unlocks import unlocks_namespace
-from CTFd.api.v1.users import users_namespace
+# from CTFd.api.v1.awards import awards_namespace
+from CTFd.api.v1.challenges import challenges_blueprint
+# from CTFd.api.v1.comments import comments_namespace
+# from CTFd.api.v1.config import configs_namespace
+# from CTFd.api.v1.files import files_namespace
+# from CTFd.api.v1.flags import flags_namespace
+# from CTFd.api.v1.hints import hints_namespace
+# from CTFd.api.v1.notifications import notifications_namespace
+# from CTFd.api.v1.pages import pages_namespace
+# from CTFd.api.v1.schemas import (
+#     APIDetailedSuccessResponse,
+#     APISimpleErrorResponse,
+#     APISimpleSuccessResponse,
+# )
+# from CTFd.api.v1.scoreboard import scoreboard_namespace
+# from CTFd.api.v1.statistics import statistics_namespace
+# from CTFd.api.v1.submissions import submissions_namespace
+# from CTFd.api.v1.tags import tags_namespace
+# from CTFd.api.v1.teams import teams_namespace
+# from CTFd.api.v1.tokens import tokens_namespace
+# from CTFd.api.v1.topics import topics_namespace
+# from CTFd.api.v1.unlocks import unlocks_namespace
+# from CTFd.api.v1.users import users_namespace
 
 api = Blueprint("api", __name__, url_prefix="/api/v1")
-CTFd_API_v1 = Api(
-    api,
-    version="v1",
-    doc=current_app.config.get("SWAGGER_UI_ENDPOINT"),
-    authorizations={
-        "AccessToken": {
-            "type": "apiKey",
-            "in": "header",
-            "name": "Authorization",
-            "description": "Generate access token in the settings page of your user account.",
-        },
-        "ContentType": {
-            "type": "apiKey",
-            "in": "header",
-            "name": "Content-Type",
-            "description": "Must be set to `application/json`",
-        },
-    },
-    security=["AccessToken", "ContentType"],
-)
+# CTFd_API_v1 = Api(
+#     api,
+#     version="v1",
+#     doc=current_app.config.get("SWAGGER_UI_ENDPOINT"),
+#     authorizations={
+#         "AccessToken": {
+#             "type": "apiKey",
+#             "in": "header",
+#             "name": "Authorization",
+#             "description": "Generate access token in the settings page of your user account.",
+#         },
+#         "ContentType": {
+#             "type": "apiKey",
+#             "in": "header",
+#             "name": "Content-Type",
+#             "description": "Must be set to `application/json`",
+#         },
+#     },
+#     security=["AccessToken", "ContentType"],
+# )
 
-CTFd_API_v1.schema_model("APISimpleErrorResponse", APISimpleErrorResponse.schema())
-CTFd_API_v1.schema_model(
-    "APIDetailedSuccessResponse", APIDetailedSuccessResponse.schema()
-)
-CTFd_API_v1.schema_model("APISimpleSuccessResponse", APISimpleSuccessResponse.schema())
+# CTFd_API_v1.schema_model("APISimpleErrorResponse", APISimpleErrorResponse.schema())
+# CTFd_API_v1.schema_model(
+#     "APIDetailedSuccessResponse", APIDetailedSuccessResponse.schema()
+# )
+# CTFd_API_v1.schema_model("APISimpleSuccessResponse", APISimpleSuccessResponse.schema())
 
-CTFd_API_v1.add_namespace(challenges_namespace, "/challenges")
-CTFd_API_v1.add_namespace(tags_namespace, "/tags")
-CTFd_API_v1.add_namespace(topics_namespace, "/topics")
-CTFd_API_v1.add_namespace(awards_namespace, "/awards")
-CTFd_API_v1.add_namespace(hints_namespace, "/hints")
-CTFd_API_v1.add_namespace(flags_namespace, "/flags")
-CTFd_API_v1.add_namespace(submissions_namespace, "/submissions")
-CTFd_API_v1.add_namespace(scoreboard_namespace, "/scoreboard")
-CTFd_API_v1.add_namespace(teams_namespace, "/teams")
-CTFd_API_v1.add_namespace(users_namespace, "/users")
-CTFd_API_v1.add_namespace(statistics_namespace, "/statistics")
-CTFd_API_v1.add_namespace(files_namespace, "/files")
-CTFd_API_v1.add_namespace(notifications_namespace, "/notifications")
-CTFd_API_v1.add_namespace(configs_namespace, "/configs")
-CTFd_API_v1.add_namespace(pages_namespace, "/pages")
-CTFd_API_v1.add_namespace(unlocks_namespace, "/unlocks")
-CTFd_API_v1.add_namespace(tokens_namespace, "/tokens")
-CTFd_API_v1.add_namespace(comments_namespace, "/comments")
+api.register_blueprint(challenges_blueprint)
+# CTFd_API_v1.add_namespace(tags_namespace, "/tags")
+# CTFd_API_v1.add_namespace(topics_namespace, "/topics")
+# CTFd_API_v1.add_namespace(awards_namespace, "/awards")
+# CTFd_API_v1.add_namespace(hints_namespace, "/hints")
+# CTFd_API_v1.add_namespace(flags_namespace, "/flags")
+# CTFd_API_v1.add_namespace(submissions_namespace, "/submissions")
+# CTFd_API_v1.add_namespace(scoreboard_namespace, "/scoreboard")
+# CTFd_API_v1.add_namespace(teams_namespace, "/teams")
+# CTFd_API_v1.add_namespace(users_namespace, "/users")
+# CTFd_API_v1.add_namespace(statistics_namespace, "/statistics")
+# CTFd_API_v1.add_namespace(files_namespace, "/files")
+# CTFd_API_v1.add_namespace(notifications_namespace, "/notifications")
+# CTFd_API_v1.add_namespace(configs_namespace, "/configs")
+# CTFd_API_v1.add_namespace(pages_namespace, "/pages")
+# CTFd_API_v1.add_namespace(unlocks_namespace, "/unlocks")
+# CTFd_API_v1.add_namespace(tokens_namespace, "/tokens")
+# CTFd_API_v1.add_namespace(comments_namespace, "/comments")

--- a/CTFd/api/v1/helpers/request.py
+++ b/CTFd/api/v1/helpers/request.py
@@ -34,9 +34,9 @@ def validate_args(spec, location):
     def decorator(func):
         # Inject parameters information into the Flask-Restx apidoc attribute.
         # Not really a good solution. See https://github.com/CTFd/CTFd/issues/1504
-        apidoc = getattr(func, "__apidoc__", {"params": {}})
-        apidoc["params"].update(props)
-        func.__apidoc__ = apidoc
+        # apidoc = getattr(func, "__apidoc__", {"params": {}})
+        # apidoc["params"].update(props)
+        # func.__apidoc__ = apidoc
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -1,7 +1,5 @@
 import datetime
 from collections import defaultdict
-
-from flask_marshmallow import Marshmallow
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -10,8 +8,6 @@ from sqlalchemy.orm import column_property, validates
 from CTFd.cache import cache
 
 db = SQLAlchemy()
-ma = Marshmallow()
-
 
 def get_class_by_tablename(tablename):
     """Return class reference mapped to table.

--- a/CTFd/schemas/__init__.py
+++ b/CTFd/schemas/__init__.py
@@ -1,0 +1,4 @@
+from flask_marshmallow import Marshmallow
+from flask import current_app as app
+
+ma = Marshmallow(app)

--- a/CTFd/schemas/awards.py
+++ b/CTFd/schemas/awards.py
@@ -1,12 +1,15 @@
-from CTFd.models import Awards, ma
+from CTFd.models import Awards
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class AwardSchema(ma.ModelSchema):
+class AwardSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Awards
         include_fk = True
         dump_only = ("id", "date")
+        load_instance = True
 
     views = {
         "admin": [

--- a/CTFd/schemas/challenges.py
+++ b/CTFd/schemas/challenges.py
@@ -2,8 +2,8 @@ from marshmallow import validate
 from marshmallow.exceptions import ValidationError
 from marshmallow_sqlalchemy import field_for
 
-from CTFd.models import Challenges, ma
-
+from CTFd.models import Challenges
+from CTFd.schemas import ma
 
 class ChallengeRequirementsValidator(validate.Validator):
     default_message = "Error parsing challenge requirements"
@@ -24,12 +24,14 @@ class ChallengeRequirementsValidator(validate.Validator):
         return value
 
 
-class ChallengeSchema(ma.ModelSchema):
+class ChallengeSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Challenges
         include_fk = True
-        dump_only = ("id",)
+        # dump_only = ("id",)
+        load_instance = True
 
+    id = field_for(Challenges, "id", dump_only=True)
     name = field_for(
         Challenges,
         "name",

--- a/CTFd/schemas/comments.py
+++ b/CTFd/schemas/comments.py
@@ -1,14 +1,17 @@
 from marshmallow import fields
 
-from CTFd.models import Comments, ma
+from CTFd.models import Comments
+from CTFd.schemas import ma
+
 from CTFd.schemas.users import UserSchema
 
 
-class CommentSchema(ma.ModelSchema):
+class CommentSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Comments
         include_fk = True
         dump_only = ("id", "date", "html", "author", "author_id", "type")
+        load_instance = True
 
     author = fields.Nested(UserSchema(only=("name",)))
     html = fields.String()

--- a/CTFd/schemas/config.py
+++ b/CTFd/schemas/config.py
@@ -2,7 +2,9 @@ from marshmallow import fields
 from marshmallow.exceptions import ValidationError
 from marshmallow_sqlalchemy import field_for
 
-from CTFd.models import Configs, ma
+from CTFd.models import Configs
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
@@ -23,11 +25,12 @@ class ConfigValueField(fields.Field):
             return value
 
 
-class ConfigSchema(ma.ModelSchema):
+class ConfigSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Configs
         include_fk = True
         dump_only = ("id",)
+        load_instance = True
 
     views = {"admin": ["id", "key", "value"]}
     key = field_for(Configs, "key", required=True)

--- a/CTFd/schemas/fields.py
+++ b/CTFd/schemas/fields.py
@@ -1,16 +1,17 @@
 from marshmallow import fields
 
-from CTFd.models import Fields, TeamFieldEntries, UserFieldEntries, db, ma
+from CTFd.models import Fields, TeamFieldEntries, UserFieldEntries, db
+from CTFd.schemas import ma
 
 
-class FieldSchema(ma.ModelSchema):
+class FieldSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Fields
         include_fk = True
         dump_only = ("id",)
 
 
-class UserFieldEntriesSchema(ma.ModelSchema):
+class UserFieldEntriesSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = UserFieldEntries
         sqla_session = db.session
@@ -18,13 +19,14 @@ class UserFieldEntriesSchema(ma.ModelSchema):
         load_only = ("id",)
         exclude = ("field", "user", "user_id")
         dump_only = ("user_id", "name", "description", "type")
+        load_instance = True
 
-    name = fields.Nested(FieldSchema, only=("name"), attribute="field")
-    description = fields.Nested(FieldSchema, only=("description"), attribute="field")
-    type = fields.Nested(FieldSchema, only=("field_type"), attribute="field")
+    name = fields.Nested(FieldSchema, only=("name",), attribute="field")
+    description = fields.Nested(FieldSchema, only=("description",), attribute="field")
+    type = fields.Nested(FieldSchema, only=("field_type",), attribute="field")
 
 
-class TeamFieldEntriesSchema(ma.ModelSchema):
+class TeamFieldEntriesSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = TeamFieldEntries
         sqla_session = db.session
@@ -33,6 +35,6 @@ class TeamFieldEntriesSchema(ma.ModelSchema):
         exclude = ("field", "team", "team_id")
         dump_only = ("team_id", "name", "description", "type")
 
-    name = fields.Nested(FieldSchema, only=("name"), attribute="field")
-    description = fields.Nested(FieldSchema, only=("description"), attribute="field")
-    type = fields.Nested(FieldSchema, only=("field_type"), attribute="field")
+    name = fields.Nested(FieldSchema, only=("name",), attribute="field")
+    description = fields.Nested(FieldSchema, only=("description",), attribute="field")
+    type = fields.Nested(FieldSchema, only=("field_type",), attribute="field")

--- a/CTFd/schemas/files.py
+++ b/CTFd/schemas/files.py
@@ -1,12 +1,15 @@
-from CTFd.models import Files, ma
+from CTFd.models import Files
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class FileSchema(ma.ModelSchema):
+class FileSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Files
         include_fk = True
         dump_only = ("id", "type", "location")
+        load_instance = True
 
     def __init__(self, view=None, *args, **kwargs):
         if view:

--- a/CTFd/schemas/flags.py
+++ b/CTFd/schemas/flags.py
@@ -1,12 +1,15 @@
-from CTFd.models import Flags, ma
+from CTFd.models import Flags
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class FlagSchema(ma.ModelSchema):
+class FlagSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Flags
         include_fk = True
         dump_only = ("id",)
+        load_instance = True
 
     def __init__(self, view=None, *args, **kwargs):
         if view:

--- a/CTFd/schemas/hints.py
+++ b/CTFd/schemas/hints.py
@@ -1,12 +1,15 @@
-from CTFd.models import Hints, ma
+from CTFd.models import Hints
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class HintSchema(ma.ModelSchema):
+class HintSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Hints
         include_fk = True
         dump_only = ("id", "type", "html")
+        load_instance = True
 
     views = {
         "locked": ["id", "type", "challenge", "challenge_id", "cost"],

--- a/CTFd/schemas/notifications.py
+++ b/CTFd/schemas/notifications.py
@@ -1,14 +1,17 @@
 from marshmallow import fields
 
-from CTFd.models import Notifications, ma
+from CTFd.models import Notifications
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class NotificationSchema(ma.ModelSchema):
+class NotificationSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Notifications
         include_fk = True
         dump_only = ("id", "date", "html")
+        load_instance = True
 
     # Used to force the schema to include the html property from the model
     html = fields.Str()

--- a/CTFd/schemas/pages.py
+++ b/CTFd/schemas/pages.py
@@ -1,15 +1,18 @@
 from marshmallow import pre_load, validate
 from marshmallow_sqlalchemy import field_for
 
-from CTFd.models import Pages, ma
+from CTFd.models import Pages
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class PageSchema(ma.ModelSchema):
+class PageSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Pages
         include_fk = True
         dump_only = ("id",)
+        load_instance = True
 
     title = field_for(
         Pages,

--- a/CTFd/schemas/submissions.py
+++ b/CTFd/schemas/submissions.py
@@ -1,13 +1,15 @@
 from marshmallow import fields
 
-from CTFd.models import Submissions, ma
+from CTFd.models import Submissions
+from CTFd.schemas import ma
+
 from CTFd.schemas.challenges import ChallengeSchema
 from CTFd.schemas.teams import TeamSchema
 from CTFd.schemas.users import UserSchema
 from CTFd.utils import string_types
 
 
-class SubmissionSchema(ma.ModelSchema):
+class SubmissionSchema(ma.SQLAlchemyAutoSchema):
     challenge = fields.Nested(ChallengeSchema, only=["id", "name", "category", "value"])
     user = fields.Nested(UserSchema, only=["id", "name"])
     team = fields.Nested(TeamSchema, only=["id", "name"])
@@ -16,6 +18,7 @@ class SubmissionSchema(ma.ModelSchema):
         model = Submissions
         include_fk = True
         dump_only = ("id",)
+        load_instance = True
 
     views = {
         "admin": [

--- a/CTFd/schemas/tags.py
+++ b/CTFd/schemas/tags.py
@@ -1,12 +1,15 @@
-from CTFd.models import Tags, ma
+from CTFd.models import Tags
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class TagSchema(ma.ModelSchema):
+class TagSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Tags
         include_fk = True
         dump_only = ("id",)
+        load_instance = True
 
     views = {"admin": ["id", "challenge", "value"], "user": ["value"]}
 

--- a/CTFd/schemas/teams.py
+++ b/CTFd/schemas/teams.py
@@ -3,7 +3,8 @@ from marshmallow.fields import Nested
 from marshmallow_sqlalchemy import field_for
 from sqlalchemy.orm import load_only
 
-from CTFd.models import TeamFieldEntries, TeamFields, Teams, Users, ma
+from CTFd.models import TeamFieldEntries, TeamFields, Teams, Users
+from CTFd.schemas import ma
 from CTFd.schemas.fields import TeamFieldEntriesSchema
 from CTFd.utils import get_config, string_types
 from CTFd.utils.crypto import verify_password
@@ -11,12 +12,13 @@ from CTFd.utils.user import get_current_team, get_current_user, is_admin
 from CTFd.utils.validators import validate_country_code
 
 
-class TeamSchema(ma.ModelSchema):
+class TeamSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Teams
         include_fk = True
         dump_only = ("id", "oauth_id", "created", "members")
         load_only = ("password",)
+        load_instance = True
 
     name = field_for(
         Teams,
@@ -31,7 +33,7 @@ class TeamSchema(ma.ModelSchema):
         Teams,
         "email",
         allow_none=False,
-        validate=validate.Email("Emails must be a properly formatted email address"),
+        validate=validate.Email(error="Emails must be a properly formatted email address"),
     )
     password = field_for(Teams, "password", required=True, allow_none=False)
     website = field_for(

--- a/CTFd/schemas/tokens.py
+++ b/CTFd/schemas/tokens.py
@@ -1,12 +1,15 @@
-from CTFd.models import Tokens, ma
+from CTFd.models import Tokens
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class TokenSchema(ma.ModelSchema):
+class TokenSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Tokens
         include_fk = True
         dump_only = ("id", "expiration", "type")
+        load_instance = True
 
     views = {
         "admin": [

--- a/CTFd/schemas/topics.py
+++ b/CTFd/schemas/topics.py
@@ -1,12 +1,15 @@
-from CTFd.models import ChallengeTopics, Topics, ma
+from CTFd.models import ChallengeTopics, Topics
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class TopicSchema(ma.ModelSchema):
+class TopicSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Topics
         include_fk = True
         dump_only = ("id",)
+        load_instance = True
 
     views = {"admin": ["id", "value"]}
 
@@ -20,7 +23,7 @@ class TopicSchema(ma.ModelSchema):
         super(TopicSchema, self).__init__(*args, **kwargs)
 
 
-class ChallengeTopicSchema(ma.ModelSchema):
+class ChallengeTopicSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = ChallengeTopics
         include_fk = True

--- a/CTFd/schemas/unlocks.py
+++ b/CTFd/schemas/unlocks.py
@@ -1,12 +1,15 @@
-from CTFd.models import Unlocks, ma
+from CTFd.models import Unlocks
+from CTFd.schemas import ma
+
 from CTFd.utils import string_types
 
 
-class UnlockSchema(ma.ModelSchema):
+class UnlockSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Unlocks
         include_fk = True
         dump_only = ("id", "date")
+        load_instance = True
 
     views = {
         "admin": ["user_id", "target", "team_id", "date", "type", "id"],

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -3,7 +3,9 @@ from marshmallow.fields import Nested
 from marshmallow_sqlalchemy import field_for
 from sqlalchemy.orm import load_only
 
-from CTFd.models import UserFieldEntries, UserFields, Users, ma
+from CTFd.models import UserFieldEntries, UserFields, Users
+from CTFd.schemas import ma
+
 from CTFd.schemas.fields import UserFieldEntriesSchema
 from CTFd.utils import get_config, string_types
 from CTFd.utils.crypto import verify_password
@@ -12,12 +14,13 @@ from CTFd.utils.user import get_current_user, is_admin
 from CTFd.utils.validators import validate_country_code, validate_language
 
 
-class UserSchema(ma.ModelSchema):
+class UserSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Users
         include_fk = True
         dump_only = ("id", "oauth_id", "created", "team_id")
         load_only = ("password",)
+        load_instance = True
 
     name = field_for(
         Users,
@@ -33,7 +36,7 @@ class UserSchema(ma.ModelSchema):
         "email",
         allow_none=False,
         validate=[
-            validate.Email("Emails must be a properly formatted email address"),
+            validate.Email(error="Emails must be a properly formatted email address"),
             validate.Length(min=1, max=128, error="Emails must not be empty"),
         ],
     )

--- a/CTFd/utils/config/pages.py
+++ b/CTFd/utils/config/pages.py
@@ -57,7 +57,7 @@ def build_markdown(md, sanitize=False):
     return html
 
 
-@cache.memoize()
+# @cache.memoize()
 def get_pages():
     db_pages = Pages.query.filter(
         Pages.route != "index", Pages.draft.isnot(True), Pages.hidden.isnot(True)
@@ -65,7 +65,7 @@ def get_pages():
     return db_pages
 
 
-@cache.memoize()
+# @cache.memoize()
 def get_page(route):
     page = db.session.execute(
         Pages.__table__.select()
@@ -74,6 +74,7 @@ def get_page(route):
     ).fetchone()
     if page:
         # Convert the row into a transient ORM object so this change isn't commited accidentally
-        p = Pages(**page)
+        p = Pages(**page._mapping)
+
         return p
     return None

--- a/CTFd/utils/helpers/__init__.py
+++ b/CTFd/utils/helpers/__init__.py
@@ -40,7 +40,7 @@ def env_asset_url_default(endpoint, values):
         static_asset = path.endswith(".js") or path.endswith(".css")
         direct_access = ".dev" in path or ".min" in path
         if static_asset and not direct_access:
-            env = values.get("env", current_app.env)
+            env = values.get("env", os.environ["FLASK_ENV"])
             mode = ".dev" if env == "development" else ".min"
             base, ext = os.path.splitext(path)
             values["path"] = base + mode + ext

--- a/CTFd/utils/sessions/__init__.py
+++ b/CTFd/utils/sessions/__init__.py
@@ -64,7 +64,7 @@ class CachingSessionInterface(SessionInterface):
         self.permanent = permanent
 
     def open_session(self, app, request):
-        sid = request.cookies.get(app.session_cookie_name)
+        sid = request.cookies.get(app.config["SESSION_COOKIE_NAME"])
         if not sid:
             sid = self._generate_sid()
             return self.session_class(sid=sid, permanent=self.permanent)
@@ -96,7 +96,7 @@ class CachingSessionInterface(SessionInterface):
             if session.modified:
                 cache.delete(self.key_prefix + session.sid)
                 response.delete_cookie(
-                    app.session_cookie_name, domain=domain, path=path
+                    app.config["SESSION_COOKIE_NAME"], domain=domain, path=path
                 )
             return
 
@@ -122,7 +122,7 @@ class CachingSessionInterface(SessionInterface):
                 session_id = session.sid
 
             response.set_cookie(
-                app.session_cookie_name,
+                app.config["SESSION_COOKIE_NAME"],
                 session_id,
                 expires=expires,
                 httponly=httponly,

--- a/CTFd/utils/updates/__init__.py
+++ b/CTFd/utils/updates/__init__.py
@@ -43,7 +43,7 @@ def update_check(force=False):
                 "current": app.VERSION,
                 "python_version_raw": sys.hexversion,
                 "python_version": python_version(),
-                "db_driver": db.session.bind.dialect.name,
+                "db_driver": db.session.get_bind().dialect.name,
                 "challenge_count": Challenges.query.count(),
                 "user_mode": get_config("user_mode"),
                 "user_count": Users.query.count(),

--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 import boto3
 from botocore.client import Config
 from flask import current_app, redirect, send_file
-from flask.helpers import safe_join
+from werkzeug.security import safe_join
 from freezegun import freeze_time
 from werkzeug.utils import secure_filename
 

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -10,10 +10,12 @@ from flask import (
     send_file,
     session,
     url_for,
+    render_template_string
 )
-from flask.helpers import safe_join
+from werkzeug.security import safe_join
 from jinja2.exceptions import TemplateNotFound
 from sqlalchemy.exc import IntegrityError
+from apiflask.ui_templates import swagger_ui_template
 
 from CTFd.cache import cache
 from CTFd.constants.config import (
@@ -359,6 +361,15 @@ def settings():
         errors=errors,
     )
 
+@views.route("/docs")
+def docs():
+    return render_template_string(
+        swagger_ui_template,
+        title='CTFd API Documentation',
+        version='v0.0.1',
+        oauth2_redirect_path=None,
+        config=app.config
+    )
 
 @views.route("/", defaults={"route": "index"})
 @views.route("/<path:route>")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 #
 #    ./scripts/pip-compile.sh
 #
-alembic==1.4.3
+alembic==1.11.1
+APIFlask==1.3.1
     # via
     #   dataset
     #   flask-migrate
@@ -37,7 +38,7 @@ cffi==1.15.0
     #   pybluemonday
 charset-normalizer==2.0.12
     # via requests
-click==7.1.2
+click==8.1.4
     # via flask
 cmarkgfm==2022.10.27
     # via -r requirements.in
@@ -47,7 +48,7 @@ dataset==1.5.2
     # via -r requirements.in
 docutils==0.15.2
     # via botocore
-flask==2.0.3
+Flask==2.3.2
     # via
     #   -r requirements.in
     #   flask-babel
@@ -61,7 +62,7 @@ flask-babel==2.0.0
     # via -r requirements.in
 flask-caching==2.0.2
     # via -r requirements.in
-flask-marshmallow==0.10.1
+flask-marshmallow==0.15.0
     # via -r requirements.in
 flask-migrate==2.5.3
     # via -r requirements.in
@@ -69,7 +70,7 @@ flask-restx==1.1.0
     # via -r requirements.in
 flask-script==2.0.6
     # via -r requirements.in
-flask-sqlalchemy==2.5.1
+Flask-SQLAlchemy==3.0.5
     # via
     #   -r requirements.in
     #   flask-migrate
@@ -104,12 +105,12 @@ markupsafe==2.1.3
     #   jinja2
     #   mako
     #   wtforms
-marshmallow==2.20.2
+marshmallow==3.19.0
     # via
     #   -r requirements.in
     #   flask-marshmallow
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==0.17.0
+marshmallow-sqlalchemy==0.29.0
     # via -r requirements.in
 maxminddb==1.5.4
     # via
@@ -170,7 +171,7 @@ urllib3==1.25.11
     # via
     #   botocore
     #   requests
-werkzeug==2.1.2
+Werkzeug==2.3.6
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
As per #1504, you were interested in exploring an alternative documentation generation method. I have a POC up for converting a single challenges endpoint using [APIFlask](https://apiflask.com/api-docs/).

<img width="1072" alt="CleanShot 2023-07-08 at 19 53 12@2x" src="https://github.com/CTFd/CTFd/assets/13869303/84ff5d27-62c1-494d-aa0f-79043f716378">

I upgraded Flask + dependencies while I was doing this.

The new syntax for decorating an endpoint is:

```python3
    @admins_only
    @challenges_blueprint.doc(description="Endpoint to create a Challenge object")
    @challenges_blueprint.input(ChallengeSchema, location="json_or_form")
    @challenges_blueprint.output(ChallengeDetailedSuccessResponse, 200, description="Success")
    @challenges_blueprint.output(APISimpleErrorResponse, 400, description="An error occured processing the provided or stored data")
    def post(self, data):
         # data is of type ChallengeSchema already!
  ```
  
  I think this has a few benefits:

-   It should be quick to reuse the existing schema validators for endpoints
-  Don't need to do Schema validation inside of each method first, `APIFlask` does it for you, and emits a 400 error.
-  Don't need to describe schemas twice (once for docs based on pydantic, once for marshmallow), just describe once in marshmallow.
