### PR TITLE
Fix remove db from connection string

### DIFF
--- a/ping.py
+++ b/ping.py
@@ -17,7 +17,7 @@ if url.drivername.startswith("sqlite"):
 
 # Null out the database so raw_connection doesnt error if it doesnt exist
 # CTFd will create the database if it doesnt exist
-url = url.set(database=None)
+url = url._replace(database=None)
 
 # Wait for the database server to be available
 engine = create_engine(url)


### PR DESCRIPTION
Problem: when starting CTFd with an empty database the ping check will fail, complaining that the database does not exist. Calling `set` with parameter value `None` does not actually remove the value from the connection string. 

Solution: Rewrite as explained in the `set` method documentation.

Excerpt from the documentation:

```
Values are used if they are non-None.  To set a value to ``None``
        explicitly, use the :meth:`_engine.URL._replace` method adapted
        from ``namedtuple``.
```