### PR TITLE
Add email whitelist wildcard

### DIFF
--- a/CTFd/forms/config.py
+++ b/CTFd/forms/config.py
@@ -31,7 +31,7 @@ class ResetInstanceForm(BaseForm):
 class AccountSettingsForm(BaseForm):
     domain_whitelist = StringField(
         "Account Email Whitelist",
-        description="Comma-seperated email domains which users can register under (e.g. ctfd.io, *.example.com, *.edu)",
+        description="Comma-seperated email domains which users can register under (e.g. ctfd.io, example.com, *.example.com)",
     )
     team_creation = SelectField(
         "Team Creation",

--- a/CTFd/forms/config.py
+++ b/CTFd/forms/config.py
@@ -31,7 +31,7 @@ class ResetInstanceForm(BaseForm):
 class AccountSettingsForm(BaseForm):
     domain_whitelist = StringField(
         "Account Email Whitelist",
-        description="Comma-seperated email domains which users can register under (e.g. ctfd.io, gmail.com, yahoo.com)",
+        description="Comma-seperated email domains which users can register under (e.g. ctfd.io, *.example.com, *.edu)",
     )
     team_creation = SelectField(
         "Team Creation",

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -139,6 +139,14 @@ def check_email_is_whitelisted(email_address):
     domain_whitelist = get_config("domain_whitelist")
     if domain_whitelist:
         domain_whitelist = [d.strip() for d in domain_whitelist.split(",")]
-        if domain not in domain_whitelist:
-            return False
-    return True
+
+        for allowed_domain in domain_whitelist:
+            if allowed_domain.startswith("*"):
+                # Handle wildcard domain case
+                suffix = allowed_domain[1:]  # Remove the "*" prefix
+                if domain.endswith(suffix):
+                    return True
+            elif domain == allowed_domain:
+                return True
+
+    return False

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -137,15 +137,21 @@ def user_created_notification(addr, name, password):
 def check_email_is_whitelisted(email_address):
     local_id, _, domain = email_address.partition("@")
     domain_whitelist = get_config("domain_whitelist")
+
     if domain_whitelist:
         domain_whitelist = [d.strip() for d in domain_whitelist.split(",")]
 
         for allowed_domain in domain_whitelist:
-            if allowed_domain.startswith("*"):
+            if allowed_domain.startswith("*."):
+                # domains should never container the "*" char
+                if "*" in domain:
+                    return False
+
                 # Handle wildcard domain case
                 suffix = allowed_domain[1:]  # Remove the "*" prefix
                 if domain.endswith(suffix):
                     return True
+
             elif domain == allowed_domain:
                 return True
 

--- a/CTFd/utils/email/__init__.py
+++ b/CTFd/utils/email/__init__.py
@@ -149,4 +149,8 @@ def check_email_is_whitelisted(email_address):
             elif domain == allowed_domain:
                 return True
 
-    return False
+        # whitelist is specified but the email doesn't match any domains
+        return False
+
+    # whitelist is not specified - allow all emails
+    return True

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -305,7 +305,6 @@ def test_email_whitelist():
             ("john.doe@uni.edu.de", True),
             ("john.doe@cs.uni.edu.de", True),
             ("john.doe@mail.cs.uni.edu.de", True),
-
             ("john.doe@gmail.com", False),
             ("john.doe@ample.com", False),
             ("john.doe@example1.com", False),

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -6,10 +6,10 @@ from freezegun import freeze_time
 
 from CTFd.utils import get_config, set_config
 from CTFd.utils.email import (
+    check_email_is_whitelisted,
     sendmail,
     successful_registration_notification,
     verify_email_address,
-    check_email_is_whitelisted
 )
 from tests.helpers import create_ctfd, destroy_ctfd
 
@@ -248,23 +248,22 @@ def test_email_whitelist():
         set_config("domain_whitelist", "example.com, uni.acme.com, *.edu, *.edu.de")
 
         test_cases = [
-            ('john.doe@example.com', True),
-            ('john.doe@uni.acme.com', True),
-            ('john.doe@uni.edu', True),
-            ('john.doe@cs.uni.edu', True),
-            ('john.doe@mail.cs.uni.edu', True),
-            ('john.doe@uni.edu.de', True),
-            ('john.doe@cs.uni.edu.de', True),
-            ('john.doe@mail.cs.uni.edu.de', True),
-
-            ('john.doe@gmail.com', False),
-            ('john.doe@example1.com', False),
-            ('john.doe@1example.com', False),
-            ('john.doe@ext.example.com', False),
-            ('john.doe@cs.acme.com', False),
-            ('john.doe@edu.com', False),
-            ('john.doe@mail.uni.acme.com', False),
-            ('john.doe@edu', False),
+            ("john.doe@example.com", True),
+            ("john.doe@uni.acme.com", True),
+            ("john.doe@uni.edu", True),
+            ("john.doe@cs.uni.edu", True),
+            ("john.doe@mail.cs.uni.edu", True),
+            ("john.doe@uni.edu.de", True),
+            ("john.doe@cs.uni.edu.de", True),
+            ("john.doe@mail.cs.uni.edu.de", True),
+            ("john.doe@gmail.com", False),
+            ("john.doe@example1.com", False),
+            ("john.doe@1example.com", False),
+            ("john.doe@ext.example.com", False),
+            ("john.doe@cs.acme.com", False),
+            ("john.doe@edu.com", False),
+            ("john.doe@mail.uni.acme.com", False),
+            ("john.doe@edu", False),
         ]
 
         for case in test_cases:


### PR DESCRIPTION
This allows to specify domains with a wildcard like `*.edu` for the domain whitelist.

Note that this is not a regex match, it doesn't evaluate the expression to support inner wildcards, e.g. it's not possible do do something like `cs.*.edu` - however that's intentional to keep this simple.