### PR TITLE
Fix SQLAlchemy warning about back_populates

### DIFF
--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -349,7 +349,10 @@ class Users(db.Model):
     team_id = db.Column(db.Integer, db.ForeignKey("teams.id"))
 
     field_entries = db.relationship(
-        "UserFieldEntries", foreign_keys="UserFieldEntries.user_id", lazy="joined"
+        "UserFieldEntries",
+        foreign_keys="UserFieldEntries.user_id",
+        lazy="joined",
+        back_populates="user",
     )
 
     created = db.Column(db.DateTime, default=datetime.datetime.utcnow)
@@ -558,7 +561,10 @@ class Teams(db.Model):
     captain = db.relationship("Users", foreign_keys=[captain_id])
 
     field_entries = db.relationship(
-        "TeamFieldEntries", foreign_keys="TeamFieldEntries.team_id", lazy="joined"
+        "TeamFieldEntries",
+        foreign_keys="TeamFieldEntries.team_id",
+        lazy="joined",
+        back_populates="team",
     )
 
     created = db.Column(db.DateTime, default=datetime.datetime.utcnow)
@@ -1027,10 +1033,14 @@ class FieldEntries(db.Model):
 class UserFieldEntries(FieldEntries):
     __mapper_args__ = {"polymorphic_identity": "user"}
     user_id = db.Column(db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"))
-    user = db.relationship("Users", foreign_keys="UserFieldEntries.user_id")
+    user = db.relationship(
+        "Users", foreign_keys="UserFieldEntries.user_id", back_populates="field_entries"
+    )
 
 
 class TeamFieldEntries(FieldEntries):
     __mapper_args__ = {"polymorphic_identity": "team"}
     team_id = db.Column(db.Integer, db.ForeignKey("teams.id", ondelete="CASCADE"))
-    team = db.relationship("Teams", foreign_keys="TeamFieldEntries.team_id")
+    team = db.relationship(
+        "Teams", foreign_keys="TeamFieldEntries.team_id", back_populates="field_entries"
+    )


### PR DESCRIPTION
* Fix SQLAlchemy warning about back_populates

```
flask_sqlalchemy/__init__.py:550: SAWarning: relationship 'UserFieldEntries.user' will copy column users.id to column field_entries.user_id, which conflicts with relationship(s): 'Users.field_entries' (copies users.id to field_entries.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="field_entries"' to the 'UserFieldEntries.user' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  mapper = orm.class_mapper(type)
flask_sqlalchemy/__init__.py:550: SAWarning: relationship 'TeamFieldEntries.team' will copy column teams.id to column field_entries.team_id, which conflicts with relationship(s): 'Teams.field_entries' (copies teams.id to field_entries.team_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="field_entries"' to the 'TeamFieldEntries.team' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  mapper = orm.class_mapper(type)
```