### PR TITLE
Fix issue where a custom field named affiliation or website prevents registration

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -242,7 +242,10 @@ def register():
 
             # Handle special casing of existing profile fields
             # We still want to assign the field entries in case the fields are required
-            # TODO (CTFd 4.0): Consider converting affiliation & website into custom fields
+            # TODO (CTFd 4.0): Consider converting affiliation & website into custom fields. 
+            # There is also the issue of keeping the custom field and affiliation/website
+            # in sync if the custom field is required. Custom fields are an overall better 
+            # solution.
             if field.name.lower() == "affiliation":
                 affiliation = value
             elif field.name.lower() == "website":

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -240,17 +240,6 @@ def register():
                 errors.append("Please provide all required fields")
                 break
 
-            # Handle special casing of existing profile fields
-            # We still want to assign the field entries in case the fields are required
-            # TODO (CTFd 4.0): Consider converting affiliation & website into custom fields. 
-            # There is also the issue of keeping the custom field and affiliation/website
-            # in sync if the custom field is required. Custom fields are an overall better 
-            # solution.
-            if field.name.lower() == "affiliation":
-                affiliation = value
-            elif field.name.lower() == "website":
-                website = value
-
             if field.field_type == "boolean":
                 entries[field_id] = bool(value)
             else:

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -241,12 +241,12 @@ def register():
                 break
 
             # Handle special casing of existing profile fields
+            # We still want to assign the field entries in case the fields are required
+            # TODO (CTFd 4.0): Consider converting affiliation & website into custom fields
             if field.name.lower() == "affiliation":
                 affiliation = value
-                break
             elif field.name.lower() == "website":
                 website = value
-                break
 
             if field.field_type == "boolean":
                 entries[field_id] = bool(value)

--- a/CTFd/forms/teams.py
+++ b/CTFd/forms/teams.py
@@ -15,7 +15,7 @@ def build_custom_team_fields(
     include_entries=False,
     fields_kwargs=None,
     field_entries_kwargs=None,
-    blacklisted_items=("affiliation", "website"),
+    blacklisted_items=(),
 ):
     if fields_kwargs is None:
         fields_kwargs = {}

--- a/CTFd/forms/users.py
+++ b/CTFd/forms/users.py
@@ -16,7 +16,7 @@ def build_custom_user_fields(
     include_entries=False,
     fields_kwargs=None,
     field_entries_kwargs=None,
-    blacklisted_items=("affiliation", "website"),
+    blacklisted_items=(),
 ):
     """
     Function used to reinject values back into forms for accessing by themes

--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -249,14 +249,6 @@ def new():
                 errors.append("Please provide all required fields")
                 break
 
-            # Handle special casing of existing profile fields
-            if field.name.lower() == "affiliation":
-                affiliation = value
-                break
-            elif field.name.lower() == "website":
-                website = value
-                break
-
             if field.field_type == "boolean":
                 entries[field_id] = bool(value)
             else:


### PR DESCRIPTION
* Fix issue where a custom field named affiliation or website prevents registration
* No longer special case "Affiliation" or "Website" as custom field titles

We don't special case affiliation or website anymore as we will look to remove these fields and make them custom fields. By removing the special casing admins have more control over what field they specifically want to collect and show. Similarly if admins want to require Affiliation or Website on registration there exists the field collection that happens for the registration fields:

```python
        website = request.form.get("website")
        affiliation = request.form.get("affiliation")
        country = request.form.get("country")
```