### PR TITLE
Downgrade Werkzeug from 2.1.2 to 2.0.3 to avoid removal errors

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -6,12 +6,12 @@ from distutils.version import StrictVersion
 
 import jinja2
 from flask import Flask, Request
-from flask.helpers import safe_join
 from flask_babel import Babel
 from flask_migrate import upgrade
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from werkzeug.middleware.proxy_fix import ProxyFix
+from werkzeug.utils import safe_join
 
 import CTFd.utils.config
 from CTFd import utils

--- a/CTFd/admin/__init__.py
+++ b/CTFd/admin/__init__.py
@@ -166,8 +166,8 @@ def export_csv():
     return send_file(
         output,
         as_attachment=True,
-        cache_timeout=-1,
-        attachment_filename="{name}-{table}.csv".format(
+        max_age=-1,
+        download_name="{name}-{table}.csv".format(
             name=ctf_config.ctf_name(), table=table
         ),
     )

--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -10,9 +10,8 @@ from urllib.parse import urlparse
 import boto3
 from botocore.client import Config
 from flask import current_app, redirect, send_file
-from flask.helpers import safe_join
 from freezegun import freeze_time
-from werkzeug.utils import secure_filename
+from werkzeug.utils import safe_join, secure_filename
 
 from CTFd.utils import get_app_config
 from CTFd.utils.encoding import hexencode

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -11,9 +11,9 @@ from flask import (
     session,
     url_for,
 )
-from flask.helpers import safe_join
 from jinja2.exceptions import TemplateNotFound
 from sqlalchemy.exc import IntegrityError
+from werkzeug.utils import safe_join
 
 from CTFd.cache import cache
 from CTFd.constants.config import (
@@ -492,6 +492,9 @@ def themes(theme, path):
         # admin pages, so we check that first
         for cand_theme in (theme, *config.ctf_theme_candidates())
     ):
+        # Handle werkzeug behavior of returning None on malicious paths
+        if cand_path is None:
+            abort(404)
         if os.path.isfile(cand_path):
             return send_file(cand_path)
     abort(404)
@@ -512,6 +515,9 @@ def themes_beta(theme, path):
         # admin pages, so we check that first
         for cand_theme in (theme, *config.ctf_theme_candidates())
     ):
+        # Handle werkzeug behavior of returning None on malicious paths
+        if cand_path is None:
+            abort(404)
         if os.path.isfile(cand_path):
             return send_file(cand_path)
     abort(404)

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 Flask==2.0.3
-Werkzeug==2.1.2
+Werkzeug==2.0.3
 Flask-SQLAlchemy==2.5.1
 Flask-Caching==2.0.2
 Flask-Migrate==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -170,7 +170,7 @@ urllib3==1.25.11
     # via
     #   botocore
     #   requests
-werkzeug==2.1.2
+werkzeug==2.0.3
     # via
     #   -r requirements.in
     #   flask

--- a/tests/admin/test_views.py
+++ b/tests/admin/test_views.py
@@ -59,7 +59,7 @@ def test_admin_access():
         for route in routes:
             r = client.get(route)
             assert r.status_code == 302
-            assert r.location.startswith("/login")
+            assert r.location.startswith("http://localhost/login")
 
         admin = login_as_user(app, name="admin")
         routes.remove("/admin")
@@ -78,5 +78,5 @@ def test_get_admin_as_user():
         client = login_as_user(app)
         r = client.get("/admin")
         assert r.status_code == 302
-        assert r.location.startswith("/login")
+        assert r.location.startswith("http://localhost/login")
     destroy_ctfd(app)

--- a/tests/api/v1/user/test_admin_access.py
+++ b/tests/api/v1/user/test_admin_access.py
@@ -44,5 +44,5 @@ def test_api_hint_404():
         for endpoint in endpoints:
             r = client.get(endpoint.format(1))
             assert r.status_code == 302
-            assert r.location.startswith("/login")
+            assert r.location.startswith("http://localhost/login")
     destroy_ctfd(app)

--- a/tests/oauth/test_redirect.py
+++ b/tests/oauth/test_redirect.py
@@ -18,7 +18,7 @@ def test_oauth_not_configured():
     with app.app_context():
         with app.test_client() as client:
             r = client.get("/oauth", follow_redirects=False)
-            assert r.location == "/login"
+            assert r.location == "http://localhost/login"
             r = client.get(r.location)
             resp = r.get_data(as_text=True)
             assert "OAuth Settings not configured" in resp

--- a/tests/teams/test_challenges.py
+++ b/tests/teams/test_challenges.py
@@ -51,7 +51,7 @@ def test_anonymous_users_view_public_challenges_without_team():
         with app.test_client() as client:
             r = client.get("/challenges")
             assert r.status_code == 302
-            assert r.location.startswith("/login")
+            assert r.location.startswith("http://localhost/login")
 
         set_config("challenge_visibility", "public")
         with app.test_client() as client:
@@ -61,5 +61,5 @@ def test_anonymous_users_view_public_challenges_without_team():
         with login_as_user(app) as client:
             r = client.get("/challenges")
             assert r.status_code == 302
-            assert r.location.startswith("/team")
+            assert r.location.startswith("http://localhost/team")
     destroy_ctfd(app)

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -108,9 +108,9 @@ def test_that_ctfd_can_be_deployed_in_subdir():
             assert r.location == "http://localhost/ctf/"
 
             c = Client(app)
-            app_iter, status, headers = c.get("/")
-            headers = dict(headers)
-            assert status == "302 FOUND"
+            response = c.get("/")
+            headers = dict(response.headers)
+            assert response.status == "302 FOUND"
             assert headers["Location"] == "http://localhost/ctf/"
 
             r = client.get("/challenges")

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -90,7 +90,7 @@ def test_that_ctfd_can_be_deployed_in_subdir():
         with app.test_client() as client:
             r = client.get("/")
             assert r.status_code == 302
-            assert r.location == "/ctf/setup"
+            assert r.location == "http://localhost/ctf/setup"
 
             r = client.get("/setup")
             with client.session_transaction() as sess:
@@ -105,13 +105,13 @@ def test_that_ctfd_can_be_deployed_in_subdir():
                 }
             r = client.post("/setup", data=data)
             assert r.status_code == 302
-            assert r.location == "/ctf/"
+            assert r.location == "http://localhost/ctf/"
 
             c = Client(app)
-            response = c.get("/")
-            headers = dict(response.headers)
-            assert response.status == "302 FOUND"
-            assert headers["Location"] == "/ctf/?"
+            app_iter, status, headers = c.get("/")
+            headers = dict(headers)
+            assert status == "302 FOUND"
+            assert headers["Location"] == "http://localhost/ctf/"
 
             r = client.get("/challenges")
             assert r.status_code == 200

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -388,6 +388,13 @@ def test_user_can_access_files_with_auth_token():
                     # Friday, October 6, 2017 12:00:00 AM GMT-04:00 DST
                     set_config("end", "1507262400")
                     set_config("view_after_ctf", True)
+
+                    # Get file_url under current time
+                    with login_as_user(app) as user:
+                        req = user.get("/api/v1/challenges/1")
+                        data = req.get_json()
+                        file_url = data["data"]["files"][0]
+
                     for v in ("public", "private"):
                         set_config("challenge_visibility", v)
 
@@ -424,12 +431,13 @@ def test_user_can_access_files_if_view_after_ctf():
 
             register_user(app)
             with login_as_user(app) as client:
-                req = client.get("/api/v1/challenges/1")
-                data = req.get_json()
-                file_url = data["data"]["files"][0]
-
                 # After ctf end
+                # Get file_url during freeze time
                 with freeze_time("2017-10-7"):
+                    req = client.get("/api/v1/challenges/1")
+                    data = req.get_json()
+                    file_url = data["data"]["files"][0]
+
                     # Friday, October 6, 2017 12:00:00 AM GMT-04:00 DST
                     set_config("end", "1507262400")
 
@@ -443,8 +451,8 @@ def test_user_can_access_files_if_view_after_ctf():
                     assert r.get_data(as_text=True) == "testing file load"
 
                     # Unauthed users should be able to download if view_after_ctf
-                    client = app.test_client()
-                    r = client.get(file_url)
+                    unauth_client = app.test_client()
+                    r = unauth_client.get(file_url)
                     assert r.status_code == 200
                     assert r.get_data(as_text=True) == "testing file load"
         finally:

--- a/tests/users/test_fields.py
+++ b/tests/users/test_fields.py
@@ -259,7 +259,7 @@ def test_user_needs_all_required_fields():
 
             r = client.get("/challenges")
             assert r.status_code == 302
-            assert r.location.startswith("/settings")
+            assert r.location.startswith("http://localhost/settings")
 
             # Populate the non-required fields
             r = client.patch(
@@ -277,7 +277,7 @@ def test_user_needs_all_required_fields():
             # I should still be restricted from seeing challenges
             r = client.get("/challenges")
             assert r.status_code == 302
-            assert r.location.startswith("/settings")
+            assert r.location.startswith("http://localhost/settings")
 
             # I should still see all fields b/c I don't have a complete profile
             r = client.get("/settings")

--- a/tests/users/test_setup.py
+++ b/tests/users/test_setup.py
@@ -11,7 +11,7 @@ def test_ctfd_setup_redirect():
         with app.test_client() as client:
             r = client.get("/users")
             assert r.status_code == 302
-            assert r.location == "/setup"
+            assert r.location == "http://localhost/setup"
 
             # Files in /themes load properly
             r = client.get("/themes/core/static/css/main.dev.css")
@@ -52,5 +52,5 @@ def test_ctfd_setup_verification():
             data["email"] = "admin@examplectf.com"
             r = client.post("/setup", data=data)
             assert r.status_code == 302
-            assert r.location == "/"
+            assert r.location == "http://localhost/"
     destroy_ctfd(app)

--- a/tests/utils/test_sessions.py
+++ b/tests/utils/test_sessions.py
@@ -1,6 +1,5 @@
+from unittest.mock import Mock, patch
 from uuid import UUID
-
-from mock import Mock, patch
 
 from tests.helpers import create_ctfd, destroy_ctfd, login_as_user, register_user
 

--- a/tests/utils/test_sessions.py
+++ b/tests/utils/test_sessions.py
@@ -1,5 +1,6 @@
-from unittest.mock import Mock, patch
 from uuid import UUID
+
+from mock import Mock, patch
 
 from tests.helpers import create_ctfd, destroy_ctfd, login_as_user, register_user
 
@@ -39,7 +40,7 @@ def test_session_invalidation_on_admin_password_change():
             r = user.get("/settings")
             # User's password was changed
             # They should be logged out
-            assert r.location.startswith("/login")
+            assert r.location.startswith("http://localhost/login")
             assert r.status_code == 302
     destroy_ctfd(app)
 


### PR DESCRIPTION
* Downgrade Werkzeug from 2.1.2 to 2.0.3 to avoid removal errors
* Fix warnings from Werkzeug migration from v1 to v2

Revert test changes from #2332:

```
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/teams/test_challenges.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/users/test_setup.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/users/test_auth.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/test_themes.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/utils/test_sessions.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/admin/test_views.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/oauth/test_redirect.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/users/test_fields.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/test_views.py
git checkout 7b68babee616a26e372a2883f3144754909c66ca -- tests/api/v1/user/test_admin_access.py
```