### PR TITLE
Bump pymysql version to 1.0.2 and simplify event timeout ping

### DIFF
--- a/CTFd/events/__init__.py
+++ b/CTFd/events/__init__.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, Response, current_app, stream_with_context
 
+from CTFd.models import db
 from CTFd.utils import get_app_config
 from CTFd.utils.decorators import authed_only, ratelimit
 
@@ -18,5 +19,8 @@ def subscribe():
     enabled = get_app_config("SERVER_SENT_EVENTS")
     if enabled is False:
         return ("", 204)
+
+    # Close the db session to avoid OperationalError with MySQL connection errors
+    db.session.close()
 
     return Response(gen(), mimetype="text/event-stream")

--- a/CTFd/utils/events/__init__.py
+++ b/CTFd/utils/events/__init__.py
@@ -58,12 +58,10 @@ class EventManager(object):
             # or else some reverse proxies will incorrectly buffer SSE
             yield ServerSentEvent(data="ping", type="ping")
             while True:
-                try:
-                    with Timeout(5):
-                        message = q[channel].get()
-                        yield ServerSentEvent(**message)
-                except Timeout:
-                    yield ServerSentEvent(data="ping", type="ping")
+                with Timeout(5, False):
+                    message = q[channel].get()
+                    yield ServerSentEvent(**message)
+                yield ServerSentEvent(data="ping", type="ping")
         finally:
             del self.clients[id(q)]
             del q
@@ -109,12 +107,10 @@ class RedisEventManager(EventManager):
             # or else some reverse proxies will incorrectly buffer SSE
             yield ServerSentEvent(data="ping", type="ping")
             while True:
-                try:
-                    with Timeout(5):
-                        message = q[channel].get()
-                        yield ServerSentEvent(**message)
-                except Timeout:
-                    yield ServerSentEvent(data="ping", type="ping")
+                with Timeout(5, False):
+                    message = q[channel].get()
+                    yield ServerSentEvent(**message)
+                yield ServerSentEvent(data="ping", type="ping")
         finally:
             del self.clients[id(q)]
             del q

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ SQLAlchemy-Utils==0.41.1
 passlib==1.7.4
 bcrypt==4.0.1
 requests==2.28.1
-PyMySQL[rsa]==0.9.3
+PyMySQL[rsa]==1.0.2
 gunicorn==20.1.0
 dataset==1.5.2
 cmarkgfm==2022.10.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ pycparser==2.20
     # via cffi
 pydantic==1.6.2
     # via -r requirements.in
-pymysql[rsa]==0.9.3
+pymysql[rsa]==1.0.2
     # via -r requirements.in
 pyrsistent==0.17.3
     # via jsonschema


### PR DESCRIPTION
* Bump PyMySQL to 1.0.2
* Simply event timeout ping as discussed here: https://www.gevent.org/api/gevent.timeout.html
* Close db connections in the event handler route