### PR TITLE
Allow user/team emails to be queried via API by admin users

### DIFF
--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -84,6 +84,7 @@ class TeamList(Resource):
                         "country": "country",
                         "bracket": "bracket",
                         "affiliation": "affiliation",
+                        "email": "email",
                     },
                 ),
                 None,
@@ -94,6 +95,14 @@ class TeamList(Resource):
     def get(self, query_args):
         q = query_args.pop("q", None)
         field = str(query_args.pop("field", None))
+
+        if field == "email":
+            if is_admin() is False:
+                return {
+                    "success": False,
+                    "errors": {"field": "Emails can only be queried by admins"},
+                }
+
         filters = build_model_filters(model=Teams, query=q, field=field)
 
         if is_admin() and request.args.get("view") == "admin":

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -101,7 +101,7 @@ class TeamList(Resource):
                 return {
                     "success": False,
                     "errors": {"field": "Emails can only be queried by admins"},
-                }
+                }, 400
 
         filters = build_model_filters(model=Teams, query=q, field=field)
 

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -87,6 +87,7 @@ class UserList(Resource):
                         "country": "country",
                         "bracket": "bracket",
                         "affiliation": "affiliation",
+                        "email": "email",
                     },
                 ),
                 None,
@@ -97,6 +98,14 @@ class UserList(Resource):
     def get(self, query_args):
         q = query_args.pop("q", None)
         field = str(query_args.pop("field", None))
+
+        if field == "email":
+            if is_admin() is False:
+                return {
+                    "success": False,
+                    "errors": {"field": "Emails can only be queried by admins"},
+                }
+
         filters = build_model_filters(model=Users, query=q, field=field)
 
         if is_admin() and request.args.get("view") == "admin":

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -104,7 +104,7 @@ class UserList(Resource):
                 return {
                     "success": False,
                     "errors": {"field": "Emails can only be queried by admins"},
-                }
+                }, 400
 
         filters = build_model_filters(model=Users, query=q, field=field)
 

--- a/tests/api/v1/teams/test_teams.py
+++ b/tests/api/v1/teams/test_teams.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from tests.helpers import (
+    create_ctfd,
+    destroy_ctfd,
+    gen_team,
+    login_as_user,
+    register_user,
+)
+
+
+def test_api_can_query_by_team_emails():
+    """Can an admin user query /api/v1/teams using a teams's email address"""
+    app = create_ctfd(user_mode="teams")
+    with app.app_context():
+        gen_team(app.db, email="team@findme.com")
+        register_user(app, name="testuser", email="user@findme.com")
+        with login_as_user(app, "testuser") as client:
+            r = client.get("/api/v1/teams?field=email&q=findme", json=True)
+            assert r.status_code == 400
+            assert r.get_json()["errors"].get("field")
+        with login_as_user(app, "admin") as client:
+            r = client.get("/api/v1/teams?field=email&q=findme", json=True)
+            assert r.status_code == 200
+            assert r.get_json()["data"][0]["id"] == 1
+            assert r.get_json()["data"][0]["name"] == "team_name"
+    destroy_ctfd(app)


### PR DESCRIPTION
* Allow user/team emails to be queried via API by admin users
* Add `email` as an acceptable `field` to query to `/api/v1/users` and `/api/v1/teams`