### PR TITLE
Add the possibility to include solution write ups, and to hide them

### DIFF
--- a/CTFd/admin/challenges.py
+++ b/CTFd/admin/challenges.py
@@ -7,7 +7,7 @@ from CTFd.schemas.tags import TagSchema
 from CTFd.utils.decorators import admins_only
 from CTFd.utils.security.signing import serialize
 from CTFd.utils.user import get_current_team, get_current_user
-
+from CTFd.utils.config.visibility import solutions_visible
 
 @admin.route("/admin/challenges")
 @admins_only
@@ -15,7 +15,8 @@ def challenges_listing():
     q = request.args.get("q")
     field = request.args.get("field")
     filters = []
-
+    solution_visible = solutions_visible()
+    
     if q:
         # The field exists as an exposed column
         if Challenges.__mapper__.has_property(field):
@@ -31,12 +32,15 @@ def challenges_listing():
         total=total,
         q=q,
         field=field,
+        solution_visible=solution_visible,
     )
 
 
 @admin.route("/admin/challenges/<int:challenge_id>")
 @admins_only
 def challenges_detail(challenge_id):
+    solution_visible = solutions_visible()
+
     challenges = dict(
         Challenges.query.with_entities(Challenges.id, Challenges.name).all()
     )
@@ -57,7 +61,7 @@ def challenges_detail(challenge_id):
         )
 
     update_j2 = render_template(
-        challenge_class.templates["update"].lstrip("/"), challenge=challenge
+        challenge_class.templates["update"].lstrip("/"), challenge=challenge, solution_visible=solution_visible,
     )
 
     update_script = url_for(

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -286,6 +286,9 @@ class Challenge(Resource):
         },
     )
     def get(self, challenge_id):
+        from CTFd.constants.config import SolutionVisibilityTypes, ConfigTypes
+        solution_visible = get_config(ConfigTypes.SOLUTION_VISIBILITY) == SolutionVisibilityTypes.PUBLISH
+
         if is_admin():
             chal = Challenges.query.filter(Challenges.id == challenge_id).first_or_404()
         else:
@@ -411,6 +414,10 @@ class Challenge(Resource):
         if scores_visible() is False or accounts_visible() is False:
             solve_count = None
 
+        # Hide solution if it is empty or marked as hidden
+        if solution_visible and (not chal.solution or chal.solution == "" or chal.solution_state == "hidden"):
+            solution_visible = False
+
         if authed():
             # Get current attempts for the user
             attempts = Submissions.query.filter_by(
@@ -436,6 +443,7 @@ class Challenge(Resource):
             max_attempts=chal.max_attempts,
             attempts=attempts,
             challenge=chal,
+            solution_visible=solution_visible,
         )
 
         db.session.close()

--- a/CTFd/constants/config.py
+++ b/CTFd/constants/config.py
@@ -11,6 +11,7 @@ class ConfigTypes(str, RawEnum):
     SCORE_VISIBILITY = "score_visibility"
     ACCOUNT_VISIBILITY = "account_visibility"
     REGISTRATION_VISIBILITY = "registration_visibility"
+    SOLUTION_VISIBILITY = "solution_visibility"
 
 
 @JinjaEnum
@@ -24,6 +25,13 @@ class ChallengeVisibilityTypes(str, RawEnum):
     PUBLIC = "public"
     PRIVATE = "private"
     ADMINS = "admins"
+
+
+@JinjaEnum
+class SolutionVisibilityTypes(str, RawEnum):
+    PUBLISH = "publish"
+    ADMINS = "admins"
+    NONE = "none"
 
 
 @JinjaEnum

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -105,6 +105,8 @@ class Challenges(db.Model):
     type = db.Column(db.String(80))
     state = db.Column(db.String(80), nullable=False, default="visible")
     requirements = db.Column(db.JSON)
+    solution = db.Column(db.Text)
+    solution_state = db.Column(db.String(80), nullable=False, default="visible")
 
     files = db.relationship("ChallengeFiles", backref="challenge")
     tags = db.relationship("Tags", backref="challenge")
@@ -136,6 +138,13 @@ class Challenges(db.Model):
         from CTFd.utils.helpers import markup
 
         return markup(build_markdown(self.description))
+
+    @property
+    def solution_html(self):
+        from CTFd.utils.config.pages import build_markdown
+        from CTFd.utils.helpers import markup
+
+        return markup(build_markdown(self.solution))
 
     @property
     def plugin_class(self):

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -53,10 +53,12 @@ class BaseChallenge(object):
             "name": challenge.name,
             "value": challenge.value,
             "description": challenge.description,
+            "solution": challenge.solution,
             "connection_info": challenge.connection_info,
             "next_id": challenge.next_id,
             "category": challenge.category,
             "state": challenge.state,
+            "solution_state": challenge.solution_state,
             "max_attempts": challenge.max_attempts,
             "type": challenge.type,
             "type_data": {

--- a/CTFd/plugins/dynamic_challenges/__init__.py
+++ b/CTFd/plugins/dynamic_challenges/__init__.py
@@ -74,9 +74,11 @@ class DynamicValueChallenge(BaseChallenge):
             "decay": challenge.decay,
             "minimum": challenge.minimum,
             "description": challenge.description,
+            "solution": challenge.solution,
             "connection_info": challenge.connection_info,
             "category": challenge.category,
             "state": challenge.state,
+            "solution_state": challenge.solution_state,
             "max_attempts": challenge.max_attempts,
             "type": challenge.type,
             "type_data": {

--- a/CTFd/schemas/challenges.py
+++ b/CTFd/schemas/challenges.py
@@ -67,6 +67,19 @@ class ChallengeSchema(ma.ModelSchema):
         ],
     )
 
+    description = field_for(
+        Challenges,
+        "solution",
+        allow_none=True,
+        validate=[
+            validate.Length(
+                min=0,
+                max=65535,
+                error="Challenge could not be saved. Challenge solution too long",
+            )
+        ],
+    )
+
     requirements = field_for(
         Challenges,
         "requirements",

--- a/CTFd/themes/admin/assets/js/pages/challenges.js
+++ b/CTFd/themes/admin/assets/js/pages/challenges.js
@@ -33,9 +33,7 @@ function bulkEditChallenges(_event) {
     return $(this).data("challenge-id");
   });
 
-  ezAlert({
-    title: "Edit Challenges",
-    body: $(`
+  let body = `
     <form id="challenges-bulk-edit">
       <div class="form-group">
         <label>Category</label>
@@ -53,8 +51,23 @@ function bulkEditChallenges(_event) {
           <option value="hidden">Hidden</option>
         </select>
       </div>
+      `
+  if (document.getElementById("solution_state"))
+    body += `<div class="form-group">
+        <label>Solution</label>
+        <select name="solution_state" data-initial="">
+          <option value="">--</option>
+          <option value="visible">Visible</option>
+          <option value="hidden">Hidden</option>
+        </select>
+      </div>
+      `
+  body += `
     </form>
-    `),
+    `
+  ezAlert({
+    title: "Edit Challenges",
+    body: $(body),
     button: "Submit",
     success: function() {
       let data = $("#challenges-bulk-edit").serializeJSON(true);

--- a/CTFd/themes/admin/templates/challenges/challenges.html
+++ b/CTFd/themes/admin/templates/challenges/challenges.html
@@ -81,6 +81,9 @@
 						<th class="sort-col text-center"><b>Value</b></th>
 						<th class="sort-col text-center"><b>Type</b></th>
 						<th class="sort-col text-center"><b>State</b></th>
+						{% if solution_visible %}
+						<th class="sort-col text-center" id="solution_state"><b>Solution</b></th>
+						{% endif %}
 					</tr>
 					</thead>
 					<tbody>
@@ -100,6 +103,12 @@
 								{% set badge_state = 'badge-danger' if challenge.state == 'hidden' else 'badge-success' %}
 								<span class="badge {{ badge_state }}">{{ challenge.state }}</span>
 							</td>
+							{% if solution_visible %}
+							<td class="text-center">
+								{% set badge_solution_state = 'badge-danger' if challenge.solution_state == 'hidden' else 'badge-success' %}
+								<span class="badge {{ badge_solution_state }}">{{ challenge.solution_state }}</span>
+							</td>
+							{% endif %}
 						</tr>
 					{% endfor %}
 					</tbody>

--- a/CTFd/themes/admin/templates/challenges/update.html
+++ b/CTFd/themes/admin/templates/challenges/update.html
@@ -34,6 +34,20 @@
 	</div>
 	{% endblock %}
 
+	{% if solution_visible %}
+	{% block solution %}
+	<div class="form-group">
+		<label>
+			Solution<br>
+			<small class="form-text text-muted">
+				Use this to give a solution to your challenge.
+			</small>
+		</label>
+		<textarea id="sol-editor" class="form-control chal-desc-editor markdown" name="solution" rows="10">{{ challenge.solution }}</textarea>
+	</div>
+	{% endblock %}
+	{% endif %}
+
 	{% block connection_info %}
 	<div class="form-group">
 		<label>
@@ -82,7 +96,23 @@
 		</select>
 	</div>
 	{% endblock %}
+	
+	{% if solution_visible %}
+	{% block solution_state %}
+	<div class="form-group">
+		<label>
+			Solution State<br>
+			<small class="form-text text-muted">Changes the state of the challenge solution (e.g. visible, hidden)</small>
+		</label>
 
+		<select class="form-control custom-select" name="solution_state">
+			<option value="visible" {% if challenge.solution_state == "visible" %}selected{% endif %}>Visible</option>
+			<option value="hidden" {% if challenge.solution_state == "hidden" %}selected{% endif %}>Hidden</option>
+		</select>
+	</div>
+	{% endblock %}
+	{% endif %}
+	
 	{% block submit %}
 	<div>
 		<button class="btn btn-success btn-outlined float-right" type="submit">

--- a/CTFd/themes/admin/templates/configs/settings.html
+++ b/CTFd/themes/admin/templates/configs/settings.html
@@ -47,6 +47,26 @@
 
 		<div class="form-group">
 			<label>
+				Solution Visibility<br>
+				<small class="form-text text-muted">
+					Control whether the challenges have solutions and if they are visible
+				</small>
+			</label>
+			<select class="form-control custom-select" name="solution_visibility">
+				<option value="publish" {% if solution_visibility == 'publish' %}selected{% endif %}>
+					Publish
+				</option>
+				<option value="admins" {% if solution_visibility == 'admins' %}selected{% endif %}>
+					Admins Only
+				</option>
+				<option value="none" {% if solution_visibility == 'none' %}selected{% endif %}>
+					None
+				</option>
+			</select>
+		</div>
+
+		<div class="form-group">
+			<label>
 				Pause<br>
 				<small class="form-text text-muted">
 					Prevent users from submitting answers until unpaused. Challenges can still be viewed.

--- a/CTFd/themes/core-beta/assets/js/challenges.js
+++ b/CTFd/themes/core-beta/assets/js/challenges.js
@@ -110,6 +110,10 @@ Alpine.data("Challenge", () => ({
     });
     new Tab(this.$el).show();
   },
+  
+  async showSolution() {
+    new Tab(this.$el).show();
+  },
 
   getNextId() {
     let data = Alpine.store("challenge").data;

--- a/CTFd/themes/core-beta/templates/challenge.html
+++ b/CTFd/themes/core-beta/templates/challenge.html
@@ -21,6 +21,16 @@
               </a>
             </li>
           {% endblock %}
+          
+          {% if solution_visible %}
+            {% block solution %}
+               <li class="nav-item">
+                 <a class="nav-link" data-bs-target="#solution" @click="showSolution()">
+                   {% trans %}Solution{% endtrans %}
+                 </a>
+               </li>
+            {% endblock %}
+          {% endif %}
         </ul>
       </div>
 
@@ -201,6 +211,11 @@
               </div>
             </div>
           </div>
+          {% if solution_visible %}
+            <div role="tabpanel" class="tab-pane fade" id="solution">
+              <span class="challenge-desc">{% block chall_sol %}{{ challenge.solution_html }}{% endblock %}</span>
+            </div>
+          {% endif %}         
         </div>
       </div>
     </div>

--- a/CTFd/themes/core/templates/challenge.html
+++ b/CTFd/themes/core/templates/challenge.html
@@ -17,6 +17,13 @@
 						</a>
 					</li>
 				{% endblock %}
+				{% if solution_visible %}
+					{% block solution %}
+						<li class="nav-item">
+							<a class="nav-link" href="#solution">Solution</a>
+						</li>
+					{% endblock %}
+				{% endif %}
 			</ul>
 			<div role="tabpanel">
 				<div class="tab-content">
@@ -149,6 +156,11 @@
 							</div>
 						</div>
 					</div>
+					{% if solution_visible %}
+	                                        <div role="tabpanel" class="tab-pane fade" id="solution">
+							<span class="challenge-desc">{% block chall_sol %}{{ challenge.solution_html }}{% endblock %}</span>
+						</div>
+					{% endif %}
 				</div>
 			</div>
 		</div>

--- a/CTFd/utils/config/visibility.py
+++ b/CTFd/utils/config/visibility.py
@@ -4,6 +4,7 @@ from CTFd.constants.config import (
     ConfigTypes,
     RegistrationVisibilityTypes,
     ScoreVisibilityTypes,
+    SolutionVisibilityTypes,
 )
 from CTFd.utils import get_config
 from CTFd.utils.user import authed, is_admin
@@ -17,6 +18,16 @@ def challenges_visible():
         return authed()
     elif v == ChallengeVisibilityTypes.ADMINS:
         return is_admin()
+
+
+def solutions_visible():
+    v = get_config(ConfigTypes.SOLUTION_VISIBILITY)
+    if v == SolutionVisibilityTypes.PUBLISH:
+        return challenges_visible()
+    elif v == SolutionVisibilityTypes.ADMINS:
+        return is_admin()
+    else:
+        return False
 
 
 def scores_visible():

--- a/migrations/versions/f69787339de7_add_solution_column_to_challenges.py
+++ b/migrations/versions/f69787339de7_add_solution_column_to_challenges.py
@@ -1,0 +1,24 @@
+"""Add solution column to Challenges
+
+Revision ID: f69787339de7
+Revises: 9e6f6578ca84
+Create Date: 2023-08-30 14:55:23.569321
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f69787339de7"
+down_revision = "9e6f6578ca84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("challenges", sa.Column("solution", sa.Text(), nullable=True))
+    op.add_column("challenges", sa.Column("solution_state", sa.String(length=80), nullable=False)),
+
+def downgrade():
+    op.drop_column("challenges", "solution_state")
+    op.drop_column("challenges", "solution")

--- a/migrations/versions/f69787339de7_add_solution_column_to_challenges.py
+++ b/migrations/versions/f69787339de7_add_solution_column_to_challenges.py
@@ -5,7 +5,7 @@ Revises: 9e6f6578ca84
 Create Date: 2023-08-30 14:55:23.569321
 
 """
-from alembic import op
+from alembic import op  # noqa: I001
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
This is an updated version of the pull request #2238 that also includes 

- The possibility to hide solutions individually
- The possibility to bulk edit the visibilty of the solutions
- Updated  for 3.6.0

ColdHeat stated

```
I like the general idea behind this but I'm not sure how complete the implementation has to be. It's simple to just have some text but eventually people will want to add in pictures and such. I will circle back on this.
```

to the previous pull request. Though this code uses the same editor as the challenge description that already includes the possiblity to include images. See 

![image](https://github.com/CTFd/CTFd/assets/23368653/f344145a-915f-4bd5-857c-93a923b94cda)

For an example (sorry in french) of what I already have. So I'm not sure I understand the issue. Please note that this pull request modifies the javascript, but doesn't include the changes to the "*.dev.js" and "*.min.js" files. So an `npm run build` will be needed to actually use this code. I felt it was better to not include the webpacked files to make it easier to read.