### PR TITLE
[chore]: Add timeout as environment variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+TIMEOUT=${TIMEOUT:120}
 WORKERS=${WORKERS:-1}
 WORKER_CLASS=${WORKER_CLASS:-gevent}
 ACCESS_LOG=${ACCESS_LOG:--}
@@ -32,6 +33,7 @@ flask db upgrade
 echo "Starting CTFd"
 exec gunicorn 'CTFd:create_app()' \
     --bind '0.0.0.0:8000' \
+    --timeout $TIMEOUT \
     --workers $WORKERS \
     --worker-tmp-dir "$WORKER_TEMP_DIR" \
     --worker-class "$WORKER_CLASS" \


### PR DESCRIPTION
When DB initialization does not complete by the 30 sec default timeframe, the worker crashes. Hence allow timeout environment variable to be custom set, and defaults to 120 seconds.