### PR TITLE
Fix of html markup of team private template

### DIFF
--- a/CTFd/themes/core-beta/templates/teams/private.html
+++ b/CTFd/themes/core-beta/templates/teams/private.html
@@ -203,7 +203,7 @@
 
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-danger" data-bs-dismiss="modal"{% trans %}>No{% endtrans %}</button>
+          <button type="button" class="btn btn-danger" data-bs-dismiss="modal">{% trans %}No{% endtrans %}</button>
           <button type="button" class="btn btn-primary" @click="disbandTeam()" :disabled="errors.length > 0">{% trans %}Yes{% endtrans %}</button>
         </div>
       </div>


### PR DESCRIPTION
### Issue
Not valid HTML and token for localization

I wanted to improve translations and just after run of `make translations-extract`, and then `make translations-update` I noticed that there is one kind of typo inside html markup of `private template` for team.

This PR is about hotfix of that issue.

Without that we have not valid HTML markup and strange localization token like: 
<img width="431" alt="image" src="https://github.com/CTFd/CTFd/assets/12082939/755affb9-b285-4b08-ac36-76ee6c9cc796">
