### PR TITLE
Allow string searching in extra_columns passed to build_model_filters

### DIFF
--- a/CTFd/utils/helpers/models.py
+++ b/CTFd/utils/helpers/models.py
@@ -18,6 +18,9 @@ def build_model_filters(model, query, field, extra_columns=None):
         else:
             if field in extra_columns:
                 column = extra_columns[field]
-                _filter = column.op("=")(query)
+                if type(column.type) == sqlalchemy.sql.sqltypes.Integer:
+                    _filter = column.op("=")(query)
+                else:
+                    _filter = column.like(f"%{query}%")
                 filters.append(_filter)
     return filters


### PR DESCRIPTION
* Allow searches based on `build_model_filters` using `extra_columns` to do a string search. This really only applies to Admin Panel submission search