### PR TITLE
bug: S3 uploader incorrect timezone

### DIFF
--- a/CTFd/utils/uploads/uploaders.py
+++ b/CTFd/utils/uploads/uploaders.py
@@ -131,7 +131,7 @@ class S3Uploader(BaseUploader):
         truncated_timestamp = current_timestamp - (current_timestamp % 3600)
         key = filename
         filename = filename.split("/").pop()
-        with freeze_time(datetime.datetime.fromtimestamp(truncated_timestamp)):
+        with freeze_time(datetime.datetime.utcfromtimestamp(truncated_timestamp)):
             url = self.s3.generate_presigned_url(
                 "get_object",
                 Params={


### PR DESCRIPTION
## About

The S3 Uploader is coded to assume that the system time will always be in UTC, this is not always going to be true.

fixes CTFd/CTFd#2431