### PR TITLE
When unlocking a hint, always use an accounts true score and not their public visible score

### DIFF
--- a/CTFd/api/v1/unlocks.py
+++ b/CTFd/api/v1/unlocks.py
@@ -109,7 +109,8 @@ class UnlockList(Resource):
 
         # We should use the team's score if in teams mode
         # user.account gives the appropriate account based on team mode
-        if target.cost > user.account.score:
+        # Use get_score with admin to get the account's full score value
+        if target.cost > user.account.get_score(admin=True):
             return (
                 {
                     "success": False,


### PR DESCRIPTION
* When unlocking a hint, always use an accounts true score and not their publicly visible score