### PR TITLE
Fix S3 file upload

### DIFF
--- a/CTFd/utils/uploads/__init__.py
+++ b/CTFd/utils/uploads/__init__.py
@@ -44,10 +44,11 @@ def upload_file(*args, **kwargs):
         model = PageFiles
         model_args["page_id"] = page_id
 
+    # Hash is calculated before upload since S3 file upload closes file object
+    sha1sum = hash_file(fp=file_obj)
+
     uploader = get_uploader()
     location = uploader.upload(file_obj=file_obj, filename=filename, path=parent)
-
-    sha1sum = hash_file(fp=file_obj)
 
     model_args["location"] = location
     model_args["sha1sum"] = sha1sum


### PR DESCRIPTION
Fixes #2456

Issue was that boto3 `upload_fileobj` function closes the file object it is passed, so by moving hash calculation (which requires a reference to the file object) before the upload, the bug is fixed.