### PR TITLE
Prevent teams with null passwords from generating invite codes until they set a password

### DIFF
--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -423,7 +423,11 @@ class TeamPrivateMembers(Resource):
             return (
                 {
                     "success": False,
-                    "errors": {"": ["Please set a team password before generating an invite code"]},
+                    "errors": {
+                        "": [
+                            "Please set a team password before generating an invite code"
+                        ]
+                    },
                 },
                 403,
             )

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -419,6 +419,15 @@ class TeamPrivateMembers(Resource):
                 403,
             )
 
+        if team.password is None:
+            return (
+                {
+                    "success": False,
+                    "errors": {"": ["Please set a team password and try again"]},
+                },
+                403,
+            )
+
         invite_code = team.get_invite_code()
         response = {"code": invite_code}
         return {"success": True, "data": response}

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -423,7 +423,7 @@ class TeamPrivateMembers(Resource):
             return (
                 {
                     "success": False,
-                    "errors": {"": ["Please set a team password and try again"]},
+                    "errors": {"": ["Please set a team password before generating an invite code"]},
                 },
                 403,
             )


### PR DESCRIPTION
* Prevent teams with null passwords from generating invite codes until they set a password