### PR TITLE
Assets.js: add optional defer option

### DIFF
--- a/CTFd/constants/assets.py
+++ b/CTFd/constants/assets.py
@@ -16,20 +16,21 @@ class _AssetsWrapper:
         )
         return get_asset_json(path=manifest)
 
-    def js(self, asset_key, theme=None):
+    def js(self, asset_key, theme=None, defer=True):
         if theme is None:
             theme = ctf_theme()
         asset = self.manifest(theme=theme)[asset_key]
         entry = asset["file"]
         imports = asset.get("imports", [])
+        extra_attr = "defer " if defer else ""
         html = ""
         for i in imports:
             # TODO: Needs a better recursive solution
             i = self.manifest(theme=theme)[i]["file"]
             url = url_for("views.themes_beta", theme=theme, path=i)
-            html += f'<script defer type="module" src="{url}"></script>'
+            html += f'<script {extra_attr}type="module" src="{url}"></script>'
         url = url_for("views.themes_beta", theme=theme, path=entry)
-        html += f'<script defer type="module" src="{url}"></script>'
+        html += f'<script {extra_attr}type="module" src="{url}"></script>'
         return markup(html)
 
     def css(self, asset_key, theme=None):


### PR DESCRIPTION
When creating custom templates, it can be useful to include some JavaScript code without `defer`. For example, in the case of a Bootstrap template this is needed to load a dark mode selector before showing the page (to prevent white/dark flickering).

Currently the only solution to remove defer is:
```diff
-  {{ Assets.js("assets/js/color_mode_switcher.js") }}
+  <script src="{{ Assets.file("assets/js/color_mode_switcher.js") }}"></script>
```
This pull request proposes to add an optional parameter "defer" to `Assets.js` to be able to write:
```diff
-  {{ Assets.js("assets/js/color_mode_switcher.js") }}
+  {{ Assets.js("assets/js/color_mode_switcher.js", defer=False) }}
```
