### PR TITLE
Return more fields in ScoreboardDetail

### DIFF
--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -142,10 +142,14 @@ class ScoreboardDetail(Resource):
                 solves_mapper[team_id], key=lambda k: k["date"]
             )
 
-        for i, _team in enumerate(team_ids):
+        for i, x in enumerate(standings):
             response[i + 1] = {
-                "id": standings[i].account_id,
-                "name": standings[i].name,
-                "solves": solves_mapper.get(standings[i].account_id, []),
+                "id": x.account_id,
+                "account_url": generate_account_url(account_id=x.account_id),
+                "name": x.name,
+                "score": int(x.score),
+                "bracket_id": x.bracket_id,
+                "bracket_name": x.bracket_name,
+                "solves": solves_mapper.get(x.account_id, []),
             }
         return {"success": True, "data": response}

--- a/tests/users/test_scoreboard.py
+++ b/tests/users/test_scoreboard.py
@@ -114,6 +114,11 @@ def test_top_10():
         saved = {
             "1": {
                 "id": 2,
+                "account_url": "/users/2",
+                "name": "user1",
+                "score": 200,
+                "bracket_id": None,
+                "bracket_name": None,
                 "solves": [
                     {
                         "date": "2017-10-03T03:21:34Z",
@@ -132,10 +137,14 @@ def test_top_10():
                         "value": 100,
                     },
                 ],
-                "name": "user1",
             },
             "2": {
                 "id": 3,
+                "account_url": "/users/3",
+                "name": "user2",
+                "score": 100,
+                "bracket_id": None,
+                "bracket_name": None,
                 "solves": [
                     {
                         "date": "2017-10-03T03:21:34Z",
@@ -146,7 +155,6 @@ def test_top_10():
                         "value": 100,
                     }
                 ],
-                "name": "user2",
             },
         }
         assert saved == response


### PR DESCRIPTION
Linked to issue https://github.com/CTFd/CTFd/issues/2493

When using CTFd API, I would expect `ScoreboardDetail` to return more information than `ScoreboardList`. JavaScript codes need to query twice the API then merge information.

This patch proposes to expose more fields for each standing in `ScoreboardDetail`.

*Note: renaming `id` to `account_id` would be nice, but it would break backward compatibility, so I'm not proposing that.*