### PR TITLE
Allow admins to create user API tokens

### DIFF
--- a/CTFd/api/v1/tokens.py
+++ b/CTFd/api/v1/tokens.py
@@ -90,6 +90,13 @@ class TokenList(Resource):
             expiration = datetime.datetime.strptime(expiration, "%Y-%m-%d")
 
         user = get_current_user()
+
+        # Allow admins to create API tokens for users
+        if is_admin():
+            user_id = req.get("user_id")
+            if user_id is not None:
+                user = Users.query.filter_by(id=user_id).first_or_404()
+
         token = generate_user_token(
             user, expiration=expiration, description=description
         )


### PR DESCRIPTION
Hi folks, I am curious what you think about this feature. It adds functionality to the the `POST /api/v1/tokens` endpoint to optionally accept a `user_id` request parameter. If the caller is an admin, then this input `user_id` is the target for the API token creation.

The use case here is that we have automation that auto-registers users and provides them an API-key-only for interacting with CTFd (no UI). Thus we need a way to create tokens on their behalf.

Heads up that I want to test this thoroughly, and right now I am opening a PR to get feedback on direction/approach/applicability.  