### PR TITLE
Improve caching by returning proper Cache-Control header for static file handlers

### DIFF
--- a/CTFd/plugins/__init__.py
+++ b/CTFd/plugins/__init__.py
@@ -55,7 +55,7 @@ def register_plugin_asset(app, asset_path, admins_only=False, endpoint=None):
         endpoint = asset_path.replace("/", ".")
 
     def asset_handler():
-        return send_file(asset_path)
+        return send_file(asset_path, max_age=3600)
 
     if admins_only:
         asset_handler = admins_only_wrapper(asset_handler)

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -521,7 +521,7 @@ def themes(theme, path):
         if cand_path is None:
             abort(404)
         if os.path.isfile(cand_path):
-            return send_file(cand_path)
+            return send_file(cand_path, max_age=3600)
     abort(404)
 
 
@@ -544,7 +544,7 @@ def themes_beta(theme, path):
         if cand_path is None:
             abort(404)
         if os.path.isfile(cand_path):
-            return send_file(cand_path)
+            return send_file(cand_path, max_age=3600)
     abort(404)
 
 


### PR DESCRIPTION
* Return a proper Cache-Control header with an hour timeout instead of relying on the conditional browser checks