### PR TITLE
Add none-check to time filter funcs

### DIFF
--- a/CTFd/utils/dates/__init__.py
+++ b/CTFd/utils/dates/__init__.py
@@ -1,6 +1,5 @@
 import time
 from datetime import datetime as DateTime
-from datetime import timezone as TimeZone
 from typing import Union
 
 from CTFd.utils import get_config

--- a/CTFd/utils/dates/__init__.py
+++ b/CTFd/utils/dates/__init__.py
@@ -1,5 +1,6 @@
 import time
-from datetime import datetime, timezone
+from datetime import datetime as DateTime
+from datetime import timezone as TimeZone
 from typing import Union
 
 from CTFd.utils import get_config
@@ -58,29 +59,29 @@ def view_after_ctf():
     return get_config("view_after_ctf")
 
 
-def unix_time(dt: datetime) -> int:
-    if dt is None or not isinstance(dt, datetime):
+def unix_time(dt: DateTime) -> int:
+    if dt is None or not isinstance(dt, DateTime):
         print("Invalid datetime object for time filter function.")
         return None
-    return int((dt - datetime(1970, 1, 1)).total_seconds())
+    return int((dt - DateTime(1970, 1, 1)).total_seconds())
 
 
-def unix_time_millis(dt: datetime) -> int:
+def unix_time_millis(dt: DateTime) -> int:
     ut = unix_time(dt)
     if ut is None:
         return None
     return ut * 1000
 
 
-def unix_time_to_utc(t: Union[int, float]) -> datetime:
+def unix_time_to_utc(t: Union[int, float]) -> DateTime:
     if t is None:
         print("Invalid datetime object for time filter function.")
         return None
-    return datetime.fromtimestamp(t, tz=timezone.utc)
+    return DateTime.fromtimestamp(t, tz=TimeZone.utc)
 
 
-def isoformat(dt: datetime) -> str:
-    if dt is None or not isinstance(dt, datetime):
+def isoformat(dt: DateTime) -> str:
+    if dt is None or not isinstance(dt, DateTime):
         print("Invalid datetime object for time filter function.")
         return None
     return dt.isoformat() + "Z"

--- a/CTFd/utils/dates/__init__.py
+++ b/CTFd/utils/dates/__init__.py
@@ -58,16 +58,24 @@ def view_after_ctf():
 
 
 def unix_time(dt):
+    if dt is None or not isinstance(dt, datetime.datetime):
+        return None
     return int((dt - datetime.datetime(1970, 1, 1)).total_seconds())
 
 
 def unix_time_millis(dt):
+    if dt is None:
+        return None
     return unix_time(dt) * 1000
 
 
 def unix_time_to_utc(t):
+    if t is None:
+        return None
     return datetime.datetime.utcfromtimestamp(t)
 
 
 def isoformat(dt):
+    if dt is None or not isinstance(dt, datetime.datetime):
+        return None
     return dt.isoformat() + "Z"

--- a/CTFd/utils/dates/__init__.py
+++ b/CTFd/utils/dates/__init__.py
@@ -77,7 +77,8 @@ def unix_time_to_utc(t: Union[int, float]) -> DateTime:
     if t is None:
         print("Invalid datetime object for time filter function.")
         return None
-    return DateTime.fromtimestamp(t, tz=TimeZone.utc)
+    # TODO: The utcfromtimestamp() has been deprecated
+    return DateTime.utcfromtimestamp(t)
 
 
 def isoformat(dt: DateTime) -> str:

--- a/CTFd/utils/dates/__init__.py
+++ b/CTFd/utils/dates/__init__.py
@@ -1,5 +1,6 @@
-import datetime
 import time
+from datetime import datetime, timezone
+from typing import Union
 
 from CTFd.utils import get_config
 
@@ -57,25 +58,29 @@ def view_after_ctf():
     return get_config("view_after_ctf")
 
 
-def unix_time(dt):
-    if dt is None or not isinstance(dt, datetime.datetime):
+def unix_time(dt: datetime) -> int:
+    if dt is None or not isinstance(dt, datetime):
+        print("Invalid datetime object for time filter function.")
         return None
-    return int((dt - datetime.datetime(1970, 1, 1)).total_seconds())
+    return int((dt - datetime(1970, 1, 1)).total_seconds())
 
 
-def unix_time_millis(dt):
-    if dt is None:
+def unix_time_millis(dt: datetime) -> int:
+    ut = unix_time(dt)
+    if ut is None:
         return None
-    return unix_time(dt) * 1000
+    return ut * 1000
 
 
-def unix_time_to_utc(t):
+def unix_time_to_utc(t: Union[int, float]) -> datetime:
     if t is None:
+        print("Invalid datetime object for time filter function.")
         return None
-    return datetime.datetime.utcfromtimestamp(t)
+    return datetime.fromtimestamp(t, tz=timezone.utc)
 
 
-def isoformat(dt):
-    if dt is None or not isinstance(dt, datetime.datetime):
+def isoformat(dt: datetime) -> str:
+    if dt is None or not isinstance(dt, datetime):
+        print("Invalid datetime object for time filter function.")
         return None
     return dt.isoformat() + "Z"

--- a/tests/utils/test_ctftime.py
+++ b/tests/utils/test_ctftime.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+from datetime import datetime as DateTime
+from datetime import timezone as TimeZone
 
 import pytest
 
@@ -190,8 +191,8 @@ def test_unix_time():
     """
     Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
     """
-    assert unix_time(datetime(2017, 1, 1)) == 1483228800
-    assert type(unix_time(datetime(2017, 1, 1))) == int
+    assert unix_time(DateTime(2017, 1, 1)) == 1483228800
+    assert type(unix_time(DateTime(2017, 1, 1))) == int
     assert unix_time(None) is None
     assert unix_time("test") is None
     assert unix_time(1) is None
@@ -202,8 +203,8 @@ def test_unix_time_millis():
     Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
     """
     # Aware datetime object
-    assert unix_time_millis(datetime(2017, 1, 1)) == 1483228800000
-    assert type(unix_time_millis(datetime(2017, 1, 1))) == int
+    assert unix_time_millis(DateTime(2017, 1, 1)) == 1483228800000
+    assert type(unix_time_millis(DateTime(2017, 1, 1))) == int
     assert unix_time_millis(None) is None
     assert unix_time_millis("test") is None
     assert unix_time_millis(1) is None
@@ -213,14 +214,14 @@ def test_unix_time_to_utc():
     """
     Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
     """
-    assert unix_time_to_utc(0) == datetime(1970, 1, 1)
-    assert unix_time_to_utc(1483228800) == datetime(2017, 1, 1)
-    assert type(unix_time_to_utc(1483228800)) == datetime
+    assert unix_time_to_utc(0) == DateTime(1970, 1, 1)
+    assert unix_time_to_utc(1483228800) == DateTime(2017, 1, 1)
+    assert type(unix_time_to_utc(1483228800)) == DateTime
     assert unix_time_to_utc(None) is None
     with pytest.raises(TypeError):
         unix_time_to_utc("test")
     with pytest.raises(TypeError):
-        unix_time_to_utc(datetime(2017, 1, 1))
+        unix_time_to_utc(DateTime(2017, 1, 1))
 
 
 def test_isoformat():
@@ -228,8 +229,16 @@ def test_isoformat():
     Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
     """
     assert (
-        isoformat(datetime(2017, 1, 1, tzinfo=timezone.utc))
+        isoformat(DateTime(2017, 1, 1, tzinfo=TimeZone.utc))
         == "2017-01-01T00:00:00+00:00Z"
+    )
+    assert (
+        isoformat(DateTime(2017, 1, 1))
+        == "2017-01-01T00:00:00Z"
+    )
+    assert (
+        isoformat(DateTime(2017, 1, 1, tzinfo=None))
+        == "2017-01-01T00:00:00Z"
     )
     assert isoformat(None) is None
     assert isoformat("test") is None

--- a/tests/utils/test_ctftime.py
+++ b/tests/utils/test_ctftime.py
@@ -232,14 +232,8 @@ def test_isoformat():
         isoformat(DateTime(2017, 1, 1, tzinfo=TimeZone.utc))
         == "2017-01-01T00:00:00+00:00Z"
     )
-    assert (
-        isoformat(DateTime(2017, 1, 1))
-        == "2017-01-01T00:00:00Z"
-    )
-    assert (
-        isoformat(DateTime(2017, 1, 1, tzinfo=None))
-        == "2017-01-01T00:00:00Z"
-    )
+    assert isoformat(DateTime(2017, 1, 1)) == "2017-01-01T00:00:00Z"
+    assert isoformat(DateTime(2017, 1, 1, tzinfo=None)) == "2017-01-01T00:00:00Z"
     assert isoformat(None) is None
     assert isoformat("test") is None
     assert isoformat(1) is None

--- a/tests/utils/test_ctftime.py
+++ b/tests/utils/test_ctftime.py
@@ -1,5 +1,16 @@
+from datetime import datetime, timezone
+
+import pytest
+
 from CTFd.models import Solves
-from CTFd.utils.dates import ctf_ended, ctf_started
+from CTFd.utils.dates import (
+    ctf_ended,
+    ctf_started,
+    isoformat,
+    unix_time,
+    unix_time_millis,
+    unix_time_to_utc,
+)
 from CTFd.utils.modes import TEAMS_MODE
 from tests.helpers import (
     create_ctfd,
@@ -173,3 +184,53 @@ def test_ctf_ended():
             with ctftime.ended():
                 assert ctf_ended() is True
     destroy_ctfd(app)
+
+
+def test_unix_time():
+    """
+    Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
+    """
+    assert unix_time(datetime(2017, 1, 1)) == 1483228800
+    assert type(unix_time(datetime(2017, 1, 1))) == int
+    assert unix_time(None) is None
+    assert unix_time("test") is None
+    assert unix_time(1) is None
+
+
+def test_unix_time_millis():
+    """
+    Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
+    """
+    # Aware datetime object
+    assert unix_time_millis(datetime(2017, 1, 1)) == 1483228800000
+    assert type(unix_time_millis(datetime(2017, 1, 1))) == int
+    assert unix_time_millis(None) is None
+    assert unix_time_millis("test") is None
+    assert unix_time_millis(1) is None
+
+
+def test_unix_time_to_utc():
+    """
+    Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
+    """
+    assert unix_time_to_utc(0) == datetime(1970, 1, 1, tzinfo=timezone.utc)
+    assert unix_time_to_utc(1483228800) == datetime(2017, 1, 1, tzinfo=timezone.utc)
+    assert type(unix_time_to_utc(1483228800)) == datetime
+    assert unix_time_to_utc(None) is None
+    with pytest.raises(TypeError):
+        unix_time_to_utc("test")
+    with pytest.raises(TypeError):
+        unix_time_to_utc(datetime(2017, 1, 1))
+
+
+def test_isoformat():
+    """
+    Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
+    """
+    assert (
+        isoformat(datetime(2017, 1, 1, tzinfo=timezone.utc))
+        == "2017-01-01T00:00:00+00:00Z"
+    )
+    assert isoformat(None) is None
+    assert isoformat("test") is None
+    assert isoformat(1) is None

--- a/tests/utils/test_ctftime.py
+++ b/tests/utils/test_ctftime.py
@@ -213,8 +213,8 @@ def test_unix_time_to_utc():
     """
     Tests that the unix_time function returns the correct value and fails gracefully for strange inputs
     """
-    assert unix_time_to_utc(0) == datetime(1970, 1, 1, tzinfo=timezone.utc)
-    assert unix_time_to_utc(1483228800) == datetime(2017, 1, 1, tzinfo=timezone.utc)
+    assert unix_time_to_utc(0) == datetime(1970, 1, 1)
+    assert unix_time_to_utc(1483228800) == datetime(2017, 1, 1)
     assert type(unix_time_to_utc(1483228800)) == datetime
     assert unix_time_to_utc(None) is None
     with pytest.raises(TypeError):


### PR DESCRIPTION
Add additional layer of None-checks to the time filter functions, to prevent 500s. Although we already covered the bug, it's possible we missed some edge cases, so I am fixing it closer to the source of the error