### PR TITLE
Allow teams with null passwords to create invite codes without setting their team password

### DIFF
--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -419,19 +419,6 @@ class TeamPrivateMembers(Resource):
                 403,
             )
 
-        if team.password is None:
-            return (
-                {
-                    "success": False,
-                    "errors": {
-                        "": [
-                            "Please set a team password before generating an invite code"
-                        ]
-                    },
-                },
-                403,
-            )
-
         invite_code = team.get_invite_code()
         response = {"code": invite_code}
         return {"success": True, "data": response}

--- a/CTFd/models/__init__.py
+++ b/CTFd/models/__init__.py
@@ -679,8 +679,10 @@ class Teams(db.Model):
         if isinstance(secret_key, str):
             secret_key = secret_key.encode("utf-8")
 
-        team_password_key = self.password.encode("utf-8")
-        verification_secret = secret_key + team_password_key
+        verification_secret = secret_key
+        if self.password:
+            team_password_key = self.password.encode("utf-8")
+            verification_secret += team_password_key
 
         invite_object = {
             "id": self.id,
@@ -719,8 +721,10 @@ class Teams(db.Model):
         team = cls.query.filter_by(id=team_id).first_or_404()
 
         # Create the team specific secret
-        team_password_key = team.password.encode("utf-8")
-        verification_secret = secret_key + team_password_key
+        verification_secret = secret_key
+        if team.password:
+            team_password_key = team.password.encode("utf-8")
+            verification_secret += team_password_key
 
         # Verify the team verficiation code
         verified = hmac(str(team.id), secret=verification_secret) == invite_object["v"]


### PR DESCRIPTION
* Allow teams with null passwords to create invite codes without setting their team password

This loosens the fix implemented in https://github.com/CTFd/CTFd/pull/2485. Teams with NULL passwords can now generate invite codes that are signed with only the CTFd secret key. 

The original idea was to use both the secret key and team password to allow revocation of the invite by changing the password but this achieves the same effect as if the team sets a password, the invite generated with only the secret key will no longer work
