### PR TITLE
Mark 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 3.7.1 / UNRELEASED
+
+**Admin Panel**
+
+- The styling of the Config Panel has been updated to better organize different settings
+- When switching user modes via the Admin Panel, all teams will now be removed
+- Fix issues where importing CSVs comprised of JSON entries would fail
+- Add `serializeJSON` function back into the Admin Panel
+
+**API**
+
+- The `/api/v1/exports/raw` API endpoint has been added to allow for exports to be generated via the API
+- Update the ScoreboardDetail endpoint (`/api/v1/scoreboard/top/<count>`) to return account URL, score, and bracket
+- Add a query parameter to ScoreboardDetail endpoint (`/api/v1/scoreboard/top/<count>`) to filter by bracket
+- Return `function` field for DynamicValue challenges data read
+
+**General**
+
+- Add Italian and Vietnamese languages
+- Switch to Crowdin for translations
+
+**Themes**
+
+- Add `defer` parameter to `Assets.js()` to allow controlling the defer attribute of inserted `<script>` tags
+
+**Plugins**
+
+- Plugins can now define a `config` entry in `config.json` to define a template to embed into the Config Panel
+- Add the `make_cache_key_with_query_string` to allow for caching based on query string arguments
+
+**Deployment**
+
+- MariaDB version provided in docker-compose.yml has been updated to `10.11`
+- Static assets (theme files, static files) will now return a Cache-Control header with a `max-age` of 3600
+- Add the `/debug` endpoint to show CTFd debugging information
+  - Currently showing the IP address that CTFd is seeing for the request and the request headers
+  - `/debug` will only be enabled if the `SAFE_MODE` config is enabled
+
 # 3.7.0 / 2024-02-26
 
 **General**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.7.1 / UNRELEASED
+# 3.7.1 / 2024-05-31
 
 **Admin Panel**
 

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -32,7 +32,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 __channel__ = "oss"
 
 


### PR DESCRIPTION
# 3.7.1 / 2024-05-31

**Admin Panel**

- The styling of the Config Panel has been updated to better organize different settings
- When switching user modes via the Admin Panel, all teams will now be removed
- Fix issues where importing CSVs comprised of JSON entries would fail
- Add `serializeJSON` function back into the Admin Panel

**API**

- The `/api/v1/exports/raw` API endpoint has been added to allow for exports to be generated via the API
- Update the ScoreboardDetail endpoint (`/api/v1/scoreboard/top/<count>`) to return account URL, score, and bracket
- Add a query parameter to ScoreboardDetail endpoint (`/api/v1/scoreboard/top/<count>`) to filter by bracket
- Return `function` field for DynamicValue challenges data read

**General**

- Add Italian and Vietnamese languages
- Switch to Crowdin for translations

**Themes**

- Add `defer` parameter to `Assets.js()` to allow controlling the defer attribute of inserted `<script>` tags

**Plugins**

- Plugins can now define a `config` entry in `config.json` to define a template to embed into the Config Panel
- Add the `make_cache_key_with_query_string` to allow for caching based on query string arguments

**Deployment**

- MariaDB version provided in docker-compose.yml has been updated to `10.11`
- Static assets (theme files, static files) will now return a Cache-Control header with a `max-age` of 3600
- Add the `/debug` endpoint to show CTFd debugging information
  - Currently showing the IP address that CTFd is seeing for the request and the request headers
  - `/debug` will only be enabled if the `SAFE_MODE` config is enabled