### PR TITLE
Safer handling of None from get_current_user_attrs

### DIFF
--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -123,7 +123,8 @@ def get_team_attrs(team_id):
 def get_current_user_type(fallback=None):
     if authed():
         user = get_current_user_attrs()
-        return user.type
+        if user and user.type:
+            return user.type
     else:
         return fallback
 
@@ -135,7 +136,8 @@ def authed():
 def is_admin():
     if authed():
         user = get_current_user_attrs()
-        return user.type == "admin"
+        if user and user.type:
+            return user.type == "admin"
     else:
         return False
 
@@ -147,6 +149,7 @@ def is_verified():
             return user.verified
         else:
             return False
+    # If config doesn't specify to verify emails, then everyone is 'verified'
     else:
         return True
 
@@ -179,7 +182,7 @@ def get_ip(req=None):
 def get_locale():
     if authed():
         user = get_current_user_attrs()
-        if user.language:
+        if user and user.language:
             return user.language
     languages = Languages.values()
     return request.accept_languages.best_match(languages)


### PR DESCRIPTION
`get_current_user_attrs` can and will return `None` and needs to be handled appropriately by the functions that rely on it. Some already had `None` checkers, some did not.