### PR TITLE
Handle IntegrityError arrising from duplicate adds to Solves table, add many BaseChallenge tests

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -502,6 +502,13 @@ class ChallengeAttempt(Resource):
         else:
             request_data = request.get_json()
 
+        # Light validation to ensure the request is well formed
+        # This is not a replacement for actual validation
+        if request_data.get("challenge_id") is None:
+            return {"success": False}, 400
+        if request_data.get("submission") is None:
+            return {"success": False}, 400
+
         challenge_id = request_data.get("challenge_id")
 
         if current_user.is_admin():

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -145,13 +145,16 @@ class BaseChallenge(object):
         if not data or not data.get("submission"):
             return False, "No submission sent"
         submission = data["submission"].strip()
-        if not user or not user.id or not challenge or not challenge.id:
-            raise Exception("User or challenge is missing")
+
         existing_solve = Solves.query.filter_by(
-            challenge_id=challenge.id, user_id=user.id
+            user_id=user.id,
+            team_id=team.id if team else None,
+            challenge_id=challenge.id,
         ).first()
+
         if existing_solve:
             return
+
         else:
             solve = Solves(
                 user_id=user.id,

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -118,7 +118,8 @@ class BaseChallenge(object):
         :return: (boolean, string)
         """
         data = request.form or request.get_json()
-        if not data or not data.get("submission"):
+        # Empty string "" is a potentially valid submission
+        if not data or data.get("submission") is None:
             return False, "No submission sent"
         submission = data["submission"].strip()
         flags = Flags.query.filter_by(challenge_id=challenge.id).all()

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -183,7 +183,7 @@ class BaseChallenge(object):
         :return:
         """
         data = request.form or request.get_json()
-        if not data or not data.get("submission"):
+        if not data or data.get("submission") is None:
             return False, "No submission sent"
         submission = data["submission"].strip()
         wrong = Fails(

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -143,7 +143,7 @@ class BaseChallenge(object):
         :return:
         """
         data = request.form or request.get_json()
-        if not data or not data.get("submission"):
+        if not data or data.get("submission") is None:
             return False, "No submission sent"
         submission = data["submission"].strip()
 

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -118,6 +118,8 @@ class BaseChallenge(object):
         :return: (boolean, string)
         """
         data = request.form or request.get_json()
+        if not data or not data.get("submission"):
+            return False, "No submission sent"
         submission = data["submission"].strip()
         flags = Flags.query.filter_by(challenge_id=challenge.id).all()
         for flag in flags:
@@ -140,9 +142,11 @@ class BaseChallenge(object):
         :return:
         """
         data = request.form or request.get_json()
+        if not data or not data.get("submission"):
+            return False, "No submission sent"
         submission = data["submission"].strip()
         if not user or not user.id or not challenge or not challenge.id:
-            return
+            raise Exception("User or challenge is missing")
         existing_solve = Solves.query.filter_by(
             challenge_id=challenge.id, user_id=user.id
         ).first()
@@ -175,6 +179,8 @@ class BaseChallenge(object):
         :return:
         """
         data = request.form or request.get_json()
+        if not data or not data.get("submission"):
+            return False, "No submission sent"
         submission = data["submission"].strip()
         wrong = Fails(
             user_id=user.id,

--- a/tests/challenges/test_base_challenge.py
+++ b/tests/challenges/test_base_challenge.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import dataclasses
+
+import pytest
+
+from CTFd.models import Challenges, Solves, Users
+from CTFd.plugins.challenges import BaseChallenge
+from tests.helpers import create_ctfd, destroy_ctfd, gen_challenge, gen_flag, gen_team
+
+
+@dataclasses.dataclass
+class FakeRequest:
+    form: dict[str, str]
+    access_route: list[str] = dataclasses.field(default_factory=list)
+    remote_addr: str = dataclasses.field(default_factory=str)
+
+
+def test_good_solve_user_mode():
+    """
+    Test that a user can solve a challenge in user mode.
+    """
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+
+        assert Users.query.count() == 1
+        user = Users.query.filter_by(id=1).first()
+
+        assert Solves.query.count() == 0
+        solve_request = FakeRequest(form={"submission": "flag"})
+
+        BaseChallenge.solve(
+            user=user, team=None, challenge=challenge, request=solve_request
+        )
+        assert Solves.query.count() == 1
+
+        solve = Solves.query.filter_by(
+            user_id=user.id, team_id=None, challenge_id=challenge.id
+        ).first()
+        assert solve is not None
+
+    destroy_ctfd(app)
+
+
+def test_good_solve_team_mode():
+    """
+    Test that a user can solve a challenge in team mode.
+    """
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+
+        assert Solves.query.count() == 0
+        solve_request = FakeRequest(form={"submission": "flag"})
+
+        assert Users.query.count() == 1
+        user = Users.query.filter_by(id=1).first()
+
+        team = gen_team(app.db)
+
+        BaseChallenge.solve(
+            user=user, team=team, challenge=challenge, request=solve_request
+        )
+        assert Solves.query.count() == 1
+
+        solve = Solves.query.filter_by(
+            user_id=user.id, team_id=team.id, challenge_id=challenge.id
+        ).first()
+        assert solve is not None
+
+
+def test_duplicate_solve_user_mode():
+    """
+    Test that duplicate solves in user mode are not added to the database and don't raise an error.
+    """
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+
+        assert Users.query.count() == 1
+        user = Users.query.filter_by(id=1).first()
+
+        assert Solves.query.count() == 0
+        solve_request = FakeRequest(form={"submission": "flag"})
+
+        # First solve attempt
+        BaseChallenge.solve(
+            user=user, team=None, challenge=challenge, request=solve_request
+        )
+        assert Solves.query.count() == 1
+
+        solve = Solves.query.filter_by(
+            user_id=user.id, team_id=None, challenge_id=challenge.id
+        ).first()
+        assert solve is not None
+
+        # Second solve attempt - should not be added to the database
+        BaseChallenge.solve(
+            user=user, team=None, challenge=challenge, request=solve_request
+        )
+        assert Solves.query.count() == 1
+
+
+def test_duplicate_solve_team_mode():
+    """
+    Test that duplicate solves in team mode are not added to the database and don't raise an error.
+    """
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+
+        assert Users.query.count() == 1
+        user = Users.query.filter_by(id=1).first()
+
+        team = gen_team(app.db)
+
+        assert Solves.query.count() == 0
+        solve_request = FakeRequest(form={"submission": "flag"})
+
+        # First solve attempt
+        BaseChallenge.solve(
+            user=user, team=team, challenge=challenge, request=solve_request
+        )
+        assert Solves.query.count() == 1
+
+        solve = Solves.query.filter_by(
+            user_id=user.id, team_id=team.id, challenge_id=challenge.id
+        ).first()
+        assert solve is not None
+
+        # Second solve attempt - should not be added to the database
+        BaseChallenge.solve(
+            user=user, team=team, challenge=challenge, request=solve_request
+        )
+        assert Solves.query.count() == 1
+
+
+def test_bad_submission():
+    """
+    Test that a malformed solve request does not add to Solves table
+    """
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+
+        assert Challenges.query.count() == 1
+
+        assert Users.query.count() == 1
+        user = Users.query.filter_by(id=1).first()
+
+        assert Solves.query.count() == 0
+
+        bad_solve_request = FakeRequest(form={"submission": None})
+        r = BaseChallenge.solve(
+            user=user, team=None, challenge=challenge, request=bad_solve_request
+        )
+        assert r == (False, "No submission sent")
+        assert Solves.query.count() == 0
+
+        # Note: the solve() function does NOT validate the accuracy of flags!
+        # Thus, we expect the following to be successful
+        bad_solve_request = FakeRequest(form={"submission": "incorrect_flag"})
+        r = BaseChallenge.solve(
+            user=user, team=None, challenge=challenge, request=bad_solve_request
+        )
+        assert r is None
+        assert Solves.query.count() == 1
+
+
+def test_empty_solve_request():
+    """
+    Test that an empty solve request does not add a solve to the database.
+    """
+    app = create_ctfd(enable_plugins=True)
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+
+        assert Users.query.count() == 1
+        user = Users.query.filter_by(id=1).first()
+
+        assert Solves.query.count() == 0
+
+        # No submission sent
+        solve_request = FakeRequest(form={})
+
+        with pytest.raises(Exception, match="'FakeRequest' object has no attribute 'get_json'"):
+            BaseChallenge.solve(
+                user=user, team=None, challenge=challenge, request=solve_request
+            )
+
+        assert Solves.query.count() == 0
+
+    destroy_ctfd(app)

--- a/tests/challenges/test_base_challenge.py
+++ b/tests/challenges/test_base_challenge.py
@@ -4,7 +4,7 @@ import dataclasses
 
 import pytest
 
-from CTFd.models import Challenges, Flags, Solves, Users
+from CTFd.models import Fails, Solves, Users
 from CTFd.plugins.challenges import BaseChallenge
 from tests.helpers import create_ctfd, destroy_ctfd, gen_challenge, gen_flag, gen_team
 
@@ -24,22 +24,21 @@ def test_good_user_mode_solve():
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Users.query.count() == 1
         user = Users.query.filter_by(id=1).first()
-
-        assert Solves.query.count() == 0
         solve_request = FakeRequest(form={"submission": "flag"})
 
         BaseChallenge.solve(
             user=user, team=None, challenge=challenge, request=solve_request
         )
+        # There is only 1 new Solve
         assert Solves.query.count() == 1
-
-        solve = Solves.query.filter_by(
-            user_id=user.id, team_id=None, challenge_id=challenge.id
-        ).first()
-        assert solve is not None
+        # That Solve is the one we just added
+        assert (
+            Solves.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
 
     destroy_ctfd(app)
 
@@ -52,39 +51,34 @@ def test_good_team_mode_solve():
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Solves.query.count() == 0
-        solve_request = FakeRequest(form={"submission": "flag"})
-
-        assert Users.query.count() == 1
         user = Users.query.filter_by(id=1).first()
-
         team = gen_team(app.db)
+        solve_request = FakeRequest(form={"submission": "flag"})
 
         BaseChallenge.solve(
             user=user, team=team, challenge=challenge, request=solve_request
         )
+        # There is only 1 new Solve
         assert Solves.query.count() == 1
-
-        solve = Solves.query.filter_by(
-            user_id=user.id, team_id=team.id, challenge_id=challenge.id
-        ).first()
-        assert solve is not None
+        # That Solve is the one we just added
+        assert (
+            Solves.query.filter_by(
+                user_id=user.id, team_id=team.id, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
 
 
 def test_duplicate_user_mode_solve():
     """
-    Test that duplicate solve() in user mode (team=None) does not add to Solves table twice, and does not raise an error.
+    Test that duplicate solve() in user mode (team=None) does not add to Solves table twice,
+    and does not raise an error.
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Users.query.count() == 1
         user = Users.query.filter_by(id=1).first()
-
-        assert Solves.query.count() == 0
         solve_request = FakeRequest(form={"submission": "flag"})
 
         # First solve attempt
@@ -92,11 +86,12 @@ def test_duplicate_user_mode_solve():
             user=user, team=None, challenge=challenge, request=solve_request
         )
         assert Solves.query.count() == 1
-
-        solve = Solves.query.filter_by(
-            user_id=user.id, team_id=None, challenge_id=challenge.id
-        ).first()
-        assert solve is not None
+        assert (
+            Solves.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
 
         # Second solve attempt - should not be added to the database
         BaseChallenge.solve(
@@ -107,19 +102,15 @@ def test_duplicate_user_mode_solve():
 
 def test_duplicate_team_mode_solve():
     """
-    Test that duplicate solve() in team mode (team=not None) does not add to Solves table twice, and does not raise an error.
+    Test that duplicate solve() in team mode (team=not None) does not add to Solves table twice,
+    and does not raise an error.
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Users.query.count() == 1
         user = Users.query.filter_by(id=1).first()
-
         team = gen_team(app.db)
-
-        assert Solves.query.count() == 0
         solve_request = FakeRequest(form={"submission": "flag"})
 
         # First solve attempt
@@ -127,11 +118,12 @@ def test_duplicate_team_mode_solve():
             user=user, team=team, challenge=challenge, request=solve_request
         )
         assert Solves.query.count() == 1
-
-        solve = Solves.query.filter_by(
-            user_id=user.id, team_id=team.id, challenge_id=challenge.id
-        ).first()
-        assert solve is not None
+        assert (
+            Solves.query.filter_by(
+                user_id=user.id, team_id=team.id, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
 
         # Second solve attempt - should not be added to the database
         BaseChallenge.solve(
@@ -148,29 +140,45 @@ def test_bad_submission_solve():
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Challenges.query.count() == 1
-
-        assert Users.query.count() == 1
         user = Users.query.filter_by(id=1).first()
-
-        assert Solves.query.count() == 0
-
         bad_solve_request = FakeRequest(form={"submission": None})
+
         r = BaseChallenge.solve(
             user=user, team=None, challenge=challenge, request=bad_solve_request
         )
         assert r == (False, "No submission sent")
         assert Solves.query.count() == 0
 
+
+def test_incorrect_flag_solve():
+    """
+    Test that passing an incorrect flag to solve() does adds to Solves table because solve() does not
+    validate the accuracy of flags. It should ONLY check if the submission is not empty and add to Solves table.
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+        user = Users.query.filter_by(id=1).first()
         # Note: the solve() function does NOT validate the accuracy of flags!
         # Thus, we expect the following to be successful
-        bad_solve_request = FakeRequest(form={"submission": "incorrect_flag"})
+        incorrect_flag_request = FakeRequest(form={"submission": "incorrect_flag"})
+
         r = BaseChallenge.solve(
-            user=user, team=None, challenge=challenge, request=bad_solve_request
+            user=user, team=None, challenge=challenge, request=incorrect_flag_request
         )
         assert r is None
+        # There is only 1 new Solve
         assert Solves.query.count() == 1
+        # That Solve is the one we just added
+        assert (
+            Solves.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
+
+    destroy_ctfd(app)
 
 
 def test_empty_request_solve():
@@ -181,13 +189,7 @@ def test_empty_request_solve():
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Users.query.count() == 1
         user = Users.query.filter_by(id=1).first()
-
-        assert Solves.query.count() == 0
-
-        # No submission sent
         solve_request = FakeRequest(form={})
 
         with pytest.raises(
@@ -204,121 +206,223 @@ def test_empty_request_solve():
 
 def test_correct_attempt():
     """
-    Test that passing a correct flag to attempt() returns (True, "Correct") and does not add to the Solves table
+    Test that passing a correct flag to attempt() returns (True, "Correct") and
+    does not add to the Solves or Fails tables
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         flag = gen_flag(app.db, challenge.id)
-
-        assert Challenges.query.count() == 1
-
         correct_attempt = FakeRequest(form={"submission": flag.content})
+
         r = BaseChallenge.attempt(challenge=challenge, request=correct_attempt)
         assert r == (True, "Correct")
         assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
 
     destroy_ctfd(app)
 
 
 def test_incorrect_attempt():
     """
-    Test that passing an incorrect flag to attempt() returns (False, "Incorrect") and does not add to the Solves table
+    Test that passing an incorrect flag to attempt() returns (False, "Incorrect") and
+    does not add to the Solves or Fails tables
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Challenges.query.count() == 1
-
         incorrect_attempt = FakeRequest(form={"submission": "incorrect_flag"})
+
         r = BaseChallenge.attempt(challenge=challenge, request=incorrect_attempt)
         assert r == (False, "Incorrect")
         assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
 
     destroy_ctfd(app)
 
 
 def test_duplicate_attempt():
     """
-    Test that passing a duplicate flag to attempt() returns (True, "Correct") and does not add to the Solves table
+    Test that passing a duplicate flag to attempt() returns (True, "Correct") and
+    does not add to the Solves or Fails tables
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         flag = gen_flag(app.db, challenge.id)
-
-        assert Challenges.query.count() == 1
-
         correct_attempt = FakeRequest(form={"submission": flag.content})
-        r = BaseChallenge.attempt(challenge=challenge, request=correct_attempt)
-        assert r == (True, "Correct")
-        assert Solves.query.count() == 0
 
         r = BaseChallenge.attempt(challenge=challenge, request=correct_attempt)
         assert r == (True, "Correct")
         assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
+
+        r = BaseChallenge.attempt(challenge=challenge, request=correct_attempt)
+        assert r == (True, "Correct")
+        assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
 
     destroy_ctfd(app)
 
 
 def test_bad_submission_attempt():
     """
-    Test that passing a None submission to attempt() returns (False, "No submission sent") and does not add to the Solves table
+    Test that passing a None submission to attempt() returns (False, "No submission sent") and
+    does not add to the Solves or Fails tables
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Challenges.query.count() == 1
-
         bad_attempt = FakeRequest(form={"submission": None})
+
         r = BaseChallenge.attempt(challenge=challenge, request=bad_attempt)
         assert r == (False, "No submission sent")
         assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
 
     destroy_ctfd(app)
 
 
 def test_empty_form_attempt():
     """
-    Test that passing a request with empty form to attempt() raises an exception and does not add to the Solves table
+    Test that passing a request with empty form to attempt() raises an exception and
+    does not add to the Solves or Fails tables
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         gen_flag(app.db, challenge.id)
-
-        assert Challenges.query.count() == 1
-        assert Flags.query.filter_by(challenge_id=challenge.id).count() == 1
-
         empty_attempt = FakeRequest(form={})
+
         with pytest.raises(
             Exception, match="'FakeRequest' object has no attribute 'get_json'"
         ):
             BaseChallenge.attempt(challenge=challenge, request=empty_attempt)
         assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
 
     destroy_ctfd(app)
 
 
 def test_empty_flag_attempt():
     """
-    Test that passing an empty flag to attempt() returns (True, "Correct") when the flag matches the challenge's flag and does not add to the Solves table
+    Test that passing an empty flag to attempt() returns (True, "Correct") when the flag matches
+    the challenge's flag and does not add to the Solves or Fails tables
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
-        flag = gen_flag(app.db, challenge.id, content="")
-
-        assert flag.content == ""
-        assert Challenges.query.count() == 1
-
+        gen_flag(app.db, challenge.id, content="")
         empty_flag_attempt = FakeRequest(form={"submission": ""})
+
         r = BaseChallenge.attempt(challenge=challenge, request=empty_flag_attempt)
         assert r == (True, "Correct")
         assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_good_user_mode_fail():
+    """
+    Test that good fail() in user mode (team=None) adds to the Fails table.
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        fail_request = FakeRequest(form={"submission": "flag"})
+
+        BaseChallenge.fail(
+            user=user, team=None, challenge=challenge, request=fail_request
+        )
+        # There is only 1 new Fail
+        assert Fails.query.count() == 1
+        # That Fail is the one we just added
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
+
+    destroy_ctfd(app)
+
+
+def test_good_team_mode_fail():
+    """
+    Test that good fail() in team mode (team=not None) adds to the Fails table in team mode.
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        team = gen_team(app.db)
+        fail_request = FakeRequest(form={"submission": "flag"})
+
+        BaseChallenge.fail(
+            user=user, team=team, challenge=challenge, request=fail_request
+        )
+        # There is only 1 new Fail
+        assert Fails.query.count() == 1
+        # That Fail is the one we just added
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=team.id, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
+
+    destroy_ctfd(app)
+
+
+def test_bad_submission_fail():
+    """
+    Test that passing malformed request to fail() does not add to Fails table
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+        user = Users.query.filter_by(id=1).first()
+        bad_fail_request = FakeRequest(form={"submission": None})
+
+        r = BaseChallenge.fail(
+            user=user, team=None, challenge=challenge, request=bad_fail_request
+        )
+        assert r == (False, "No submission sent")
+        assert Fails.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_incorrect_flag_fail():
+    """
+    Test that passing an incorrect flag to fail() does adds to Fails table because fail() does not validate
+    the accuracy of flags. It should ONLY check if the submission is not empty and add to Fails table.
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        # Note: the fail() function does NOT validate the accuracy of flags!
+        # Thus, we expect the following to be successful
+        bad_fail_request = FakeRequest(form={"submission": "incorrect_flag"})
+
+        r = BaseChallenge.fail(
+            user=user, team=None, challenge=challenge, request=bad_fail_request
+        )
+        assert r is None
+        # There is only 1 new Fail
+        assert Fails.query.count() == 1
+        # That Fail is the one we just added
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
 
     destroy_ctfd(app)

--- a/tests/challenges/test_base_challenge.py
+++ b/tests/challenges/test_base_challenge.py
@@ -190,7 +190,9 @@ def test_empty_solve_request():
         # No submission sent
         solve_request = FakeRequest(form={})
 
-        with pytest.raises(Exception, match="'FakeRequest' object has no attribute 'get_json'"):
+        with pytest.raises(
+            Exception, match="'FakeRequest' object has no attribute 'get_json'"
+        ):
             BaseChallenge.solve(
                 user=user, team=None, challenge=challenge, request=solve_request
             )

--- a/tests/challenges/test_base_challenge.py
+++ b/tests/challenges/test_base_challenge.py
@@ -128,23 +128,6 @@ def test_duplicate_team_mode_solve():
         assert Solves.query.count() == 1
 
 
-def test_none_submission_solve():
-    """
-    Test that passing malformed request to solve() does not add to Solves table
-    """
-    app = create_ctfd()
-    with app.app_context():
-        challenge = gen_challenge(app.db)
-        user = Users.query.filter_by(id=1).first()
-        bad_solve_request = FakeRequest(form={"submission": None})
-
-        r = BaseChallenge.solve(
-            user=user, team=None, challenge=challenge, request=bad_solve_request
-        )
-        assert r == (False, "No submission sent")
-        assert Solves.query.count() == 0
-
-
 def test_incorrect_flag_solve():
     """
     Test that passing an incorrect flag to solve() does adds to Solves table because solve() does not
@@ -175,28 +158,6 @@ def test_incorrect_flag_solve():
     destroy_ctfd(app)
 
 
-def test_empty_request_solve():
-    """
-    Test that passing an empty request to solve() does not add to Solves table
-    """
-    app = create_ctfd()
-    with app.app_context():
-        challenge = gen_challenge(app.db)
-        user = Users.query.filter_by(id=1).first()
-        solve_request = FakeRequest(form={})
-
-        with pytest.raises(
-            Exception, match="'FakeRequest' object has no attribute 'get_json'"
-        ):
-            BaseChallenge.solve(
-                user=user, team=None, challenge=challenge, request=solve_request
-            )
-
-        assert Solves.query.count() == 0
-
-    destroy_ctfd(app)
-
-
 def test_empty_flag_solve():
     """
     Test that passing an empty flag to solve() adds to Solves table
@@ -223,7 +184,46 @@ def test_empty_flag_solve():
     destroy_ctfd(app)
 
 
-def test_correct_attempt():
+def test_none_submission_solve():
+    """
+    Test that passing malformed request to solve() does not add to Solves table
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        bad_solve_request = FakeRequest(form={"submission": None})
+
+        r = BaseChallenge.solve(
+            user=user, team=None, challenge=challenge, request=bad_solve_request
+        )
+        assert r == (False, "No submission sent")
+        assert Solves.query.count() == 0
+
+
+def test_empty_form_solve():
+    """
+    Test that passing an empty request to solve() does not add to Solves table
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        solve_request = FakeRequest(form={})
+
+        with pytest.raises(
+            Exception, match="'FakeRequest' object has no attribute 'get_json'"
+        ):
+            BaseChallenge.solve(
+                user=user, team=None, challenge=challenge, request=solve_request
+            )
+
+        assert Solves.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_correct_flag_attempt():
     """
     Test that passing a correct flag to attempt() returns (True, "Correct") and
     does not add to the Solves or Fails tables
@@ -242,26 +242,7 @@ def test_correct_attempt():
     destroy_ctfd(app)
 
 
-def test_incorrect_attempt():
-    """
-    Test that passing an incorrect flag to attempt() returns (False, "Incorrect") and
-    does not add to the Solves or Fails tables
-    """
-    app = create_ctfd()
-    with app.app_context():
-        challenge = gen_challenge(app.db)
-        gen_flag(app.db, challenge.id)
-        incorrect_attempt = FakeRequest(form={"submission": "incorrect_flag"})
-
-        r = BaseChallenge.attempt(challenge=challenge, request=incorrect_attempt)
-        assert r == (False, "Incorrect")
-        assert Solves.query.count() == 0
-        assert Fails.query.count() == 0
-
-    destroy_ctfd(app)
-
-
-def test_duplicate_attempt():
+def test_duplicate_correct_attempt():
     """
     Test that passing a duplicate flag to attempt() returns (True, "Correct") and
     does not add to the Solves or Fails tables
@@ -285,7 +266,69 @@ def test_duplicate_attempt():
     destroy_ctfd(app)
 
 
-def test_bad_submission_attempt():
+def test_incorrect_flag_attempt():
+    """
+    Test that passing an incorrect flag to attempt() returns (False, "Incorrect") and
+    does not add to the Solves or Fails tables
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+        incorrect_attempt = FakeRequest(form={"submission": "incorrect_flag"})
+
+        r = BaseChallenge.attempt(challenge=challenge, request=incorrect_attempt)
+        assert r == (False, "Incorrect")
+        assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_duplicate_incorrect_attempt():
+    """
+    Test that passing a duplicate incorrect flag to attempt() returns (False, "Incorrect") and
+    does not add to the Solves or Fails tables
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id)
+        incorrect_attempt = FakeRequest(form={"submission": "incorrect_flag"})
+
+        r = BaseChallenge.attempt(challenge=challenge, request=incorrect_attempt)
+        assert r == (False, "Incorrect")
+        assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
+
+        r = BaseChallenge.attempt(challenge=challenge, request=incorrect_attempt)
+        assert r == (False, "Incorrect")
+        assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_empty_flag_attempt():
+    """
+    Test that passing an empty flag to attempt() returns (True, "Correct") when the flag matches
+    the challenge's flag and does not add to the Solves or Fails tables
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        gen_flag(app.db, challenge.id, content="")
+        empty_flag_attempt = FakeRequest(form={"submission": ""})
+
+        r = BaseChallenge.attempt(challenge=challenge, request=empty_flag_attempt)
+        assert r == (True, "Correct")
+        assert Solves.query.count() == 0
+        assert Fails.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_none_submission_attempt():
     """
     Test that passing a None submission to attempt() returns (False, "No submission sent") and
     does not add to the Solves or Fails tables
@@ -319,25 +362,6 @@ def test_empty_form_attempt():
             Exception, match="'FakeRequest' object has no attribute 'get_json'"
         ):
             BaseChallenge.attempt(challenge=challenge, request=empty_attempt)
-        assert Solves.query.count() == 0
-        assert Fails.query.count() == 0
-
-    destroy_ctfd(app)
-
-
-def test_empty_flag_attempt():
-    """
-    Test that passing an empty flag to attempt() returns (True, "Correct") when the flag matches
-    the challenge's flag and does not add to the Solves or Fails tables
-    """
-    app = create_ctfd()
-    with app.app_context():
-        challenge = gen_challenge(app.db)
-        gen_flag(app.db, challenge.id, content="")
-        empty_flag_attempt = FakeRequest(form={"submission": ""})
-
-        r = BaseChallenge.attempt(challenge=challenge, request=empty_flag_attempt)
-        assert r == (True, "Correct")
         assert Solves.query.count() == 0
         assert Fails.query.count() == 0
 
@@ -397,21 +421,79 @@ def test_good_team_mode_fail():
     destroy_ctfd(app)
 
 
-def test_bad_submission_fail():
+def test_duplicate_user_mode_fail():
     """
-    Test that passing malformed request to fail() does not add to Fails table
+    Test that duplicate fail() in user mode (team=None) adds to Fails table twice,
+    and does not raise an error.
     """
     app = create_ctfd()
     with app.app_context():
         challenge = gen_challenge(app.db)
         user = Users.query.filter_by(id=1).first()
-        bad_fail_request = FakeRequest(form={"submission": None})
+        fail_request = FakeRequest(form={"submission": "flag"})
 
-        r = BaseChallenge.fail(
-            user=user, team=None, challenge=challenge, request=bad_fail_request
+        # First fail attempt
+        BaseChallenge.fail(
+            user=user, team=None, challenge=challenge, request=fail_request
         )
-        assert r == (False, "No submission sent")
-        assert Fails.query.count() == 0
+        assert Fails.query.count() == 1
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
+
+        # Second fail attempt - should not be added to the database
+        BaseChallenge.fail(
+            user=user, team=None, challenge=challenge, request=fail_request
+        )
+        assert Fails.query.count() == 2
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=None, challenge_id=challenge.id
+            ).count()
+            == 2
+        )
+
+    destroy_ctfd(app)
+
+
+def test_duplicate_team_mode_fail():
+    """
+    Test that duplicate fail() in team mode (team=not None) adds to Fails table twice,
+    and does not raise an error.
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        team = gen_team(app.db)
+        fail_request = FakeRequest(form={"submission": "flag"})
+
+        # First fail attempt
+        BaseChallenge.fail(
+            user=user, team=team, challenge=challenge, request=fail_request
+        )
+        assert Fails.query.count() == 1
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=team.id, challenge_id=challenge.id
+            ).count()
+            == 1
+        )
+
+        # Second fail attempt - should not be added to the database
+        BaseChallenge.fail(
+            user=user, team=team, challenge=challenge, request=fail_request
+        )
+        assert Fails.query.count() == 2
+        assert (
+            Fails.query.filter_by(
+                user_id=user.id, team_id=team.id, challenge_id=challenge.id
+            ).count()
+            == 2
+        )
 
     destroy_ctfd(app)
 
@@ -468,5 +550,46 @@ def test_empty_flag_fail():
             ).count()
             == 1
         )
+
+    destroy_ctfd(app)
+
+
+def test_none_submission_fail():
+    """
+    Test that passing malformed request to fail() does not add to Fails table
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        bad_fail_request = FakeRequest(form={"submission": None})
+
+        r = BaseChallenge.fail(
+            user=user, team=None, challenge=challenge, request=bad_fail_request
+        )
+        assert r == (False, "No submission sent")
+        assert Fails.query.count() == 0
+
+    destroy_ctfd(app)
+
+
+def test_empty_form_fail():
+    """
+    Test that passing an empty request to fail() does not add to Fails table
+    """
+    app = create_ctfd()
+    with app.app_context():
+        challenge = gen_challenge(app.db)
+        user = Users.query.filter_by(id=1).first()
+        fail_request = FakeRequest(form={})
+
+        with pytest.raises(
+            Exception, match="'FakeRequest' object has no attribute 'get_json'"
+        ):
+            BaseChallenge.fail(
+                user=user, team=None, challenge=challenge, request=fail_request
+            )
+
+        assert Fails.query.count() == 0
 
     destroy_ctfd(app)


### PR DESCRIPTION
The primary goal of this PR is to resolve a long-standing IntegrityError arising from failure to check for existing Solves rows before attempting to add another.

1. [Check for existing_solve](https://github.com/CTFd/CTFd/pull/2554/files#diff-bf014fce9dead43b10bb25ec04702d8245f4e4adcdd0f2973ad1ce73ec910fc6R150)
2. Gracefully handle malformed requests in [BaseChallenge.attempt()](https://github.com/CTFd/CTFd/pull/2554/files#diff-bf014fce9dead43b10bb25ec04702d8245f4e4adcdd0f2973ad1ce73ec910fc6R122), [BaseChallenge.solve()](https://github.com/CTFd/CTFd/pull/2554/files#diff-bf014fce9dead43b10bb25ec04702d8245f4e4adcdd0f2973ad1ce73ec910fc6R146), and [BaseChallenge.fail()](https://github.com/CTFd/CTFd/pull/2554/files#diff-bf014fce9dead43b10bb25ec04702d8245f4e4adcdd0f2973ad1ce73ec910fc6R186)
3. Add tests for the `/api/v1/challenges/attempt` endpoint for: [missing challenge_id](https://github.com/CTFd/CTFd/pull/2554/files#diff-7958118edbb33742e0ebf1c1b6752e0fd51276180a175815672307d5bf6b4adbR39), [missing submission](https://github.com/CTFd/CTFd/pull/2554/files#diff-7958118edbb33742e0ebf1c1b6752e0fd51276180a175815672307d5bf6b4adbR46), and [duplicate solves](https://github.com/CTFd/CTFd/pull/2554/files#diff-7958118edbb33742e0ebf1c1b6752e0fd51276180a175815672307d5bf6b4adbR54)
4. Add tests for the `BaseChallenge` class for `attempt()`, `solve()`, and `fail()` functions. These tests each cover: good user mode calls, good team mode calls, duplicate calls, incorrect flag calls, empty flag calls, submission=None calls, and empty form calls.