### PR TITLE
Improve the way that the Admin Panel detects modern themes and fallbacks the challenge preview behavior

### DIFF
--- a/CTFd/constants/assets.py
+++ b/CTFd/constants/assets.py
@@ -8,13 +8,22 @@ from CTFd.utils.helpers import markup
 
 
 class _AssetsWrapper:
-    def manifest(self, theme=None):
+    def manifest(self, theme=None, _return_none_on_load_failure=False):
         if theme is None:
             theme = ctf_theme()
-        manifest = os.path.join(
+        file_path = os.path.join(
             current_app.root_path, "themes", theme, "static", "manifest.json"
         )
-        return get_asset_json(path=manifest)
+
+        try:
+            manifest = get_asset_json(path=file_path)
+        except FileNotFoundError as e:
+            # This check allows us to determine if we are on a legacy theme and fallback if necessary
+            if _return_none_on_load_failure:
+                manifest = None
+            else:
+                raise e
+        return manifest
 
     def js(self, asset_key, theme=None, defer=True):
         if theme is None:

--- a/CTFd/themes/admin/templates/challenges/preview.html
+++ b/CTFd/themes/admin/templates/challenges/preview.html
@@ -4,7 +4,7 @@
     <script>
         var CHALLENGE_ID = {{ challenge.id }};
     </script>
-    {% if "beta" in Configs.ctf_theme %}
+    {% if Assets.manifest(_return_none_on_load_failure=True) %}
         {{ Assets.js("assets/js/challenges.js") }}
         <script type="module">
             CTFd.config.preview = true;


### PR DESCRIPTION
* Add `Assets.manifest(_return_none_on_load_failure=False)` to allow the Admin Panel to detect if the current theme is a legacy theme or modern theme
* Fix challenge preview for custom themes