### PR TITLE
Remove unexpected Flask-Sqlalchemy paginate 404

### DIFF
--- a/CTFd/admin/submissions.py
+++ b/CTFd/admin/submissions.py
@@ -38,7 +38,7 @@ def submissions_listing(submission_type):
         .join(Challenges)
         .join(Model)
         .order_by(Submissions.date.desc())
-        .paginate(page=page, per_page=50)
+        .paginate(page=page, per_page=50, error_out=False)
     )
 
     args = dict(request.args)

--- a/CTFd/admin/teams.py
+++ b/CTFd/admin/teams.py
@@ -22,7 +22,7 @@ def teams_listing():
     teams = (
         Teams.query.filter(*filters)
         .order_by(Teams.id.asc())
-        .paginate(page=page, per_page=50)
+        .paginate(page=page, per_page=50, error_out=False)
     )
 
     args = dict(request.args)

--- a/CTFd/admin/users.py
+++ b/CTFd/admin/users.py
@@ -27,13 +27,13 @@ def users_listing():
             Users.query.join(Tracking, Users.id == Tracking.user_id)
             .filter(Tracking.ip.like("%{}%".format(q)))
             .order_by(Users.id.asc())
-            .paginate(page=page, per_page=50)
+            .paginate(page=page, per_page=50, error_out=False)
         )
     else:
         users = (
             Users.query.filter(*filters)
             .order_by(Users.id.asc())
-            .paginate(page=page, per_page=50)
+            .paginate(page=page, per_page=50, error_out=False)
         )
 
     args = dict(request.args)

--- a/CTFd/api/v1/comments.py
+++ b/CTFd/api/v1/comments.py
@@ -91,7 +91,7 @@ class CommentList(Resource):
             CommentModel.query.filter_by(**query_args)
             .filter(*filters)
             .order_by(CommentModel.id.desc())
-            .paginate(max_per_page=100)
+            .paginate(max_per_page=100, error_out=False)
         )
         schema = CommentSchema(many=True)
         response = schema.dump(comments.items)

--- a/CTFd/api/v1/submissions.py
+++ b/CTFd/api/v1/submissions.py
@@ -91,7 +91,7 @@ class SubmissionsList(Resource):
         submissions = (
             Submissions.query.filter_by(**args)
             .filter(*filters)
-            .paginate(max_per_page=100)
+            .paginate(max_per_page=100, error_out=False)
         )
 
         response = schema.dump(submissions.items)

--- a/CTFd/api/v1/teams.py
+++ b/CTFd/api/v1/teams.py
@@ -109,13 +109,13 @@ class TeamList(Resource):
             teams = (
                 Teams.query.filter_by(**query_args)
                 .filter(*filters)
-                .paginate(per_page=50, max_per_page=100)
+                .paginate(per_page=50, max_per_page=100, error_out=False)
             )
         else:
             teams = (
                 Teams.query.filter_by(hidden=False, banned=False, **query_args)
                 .filter(*filters)
-                .paginate(per_page=50, max_per_page=100)
+                .paginate(per_page=50, max_per_page=100, error_out=False)
             )
 
         user_type = get_current_user_type(fallback="user")

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -112,13 +112,13 @@ class UserList(Resource):
             users = (
                 Users.query.filter_by(**query_args)
                 .filter(*filters)
-                .paginate(per_page=50, max_per_page=100)
+                .paginate(per_page=50, max_per_page=100, error_out=False)
             )
         else:
             users = (
                 Users.query.filter_by(banned=False, hidden=False, **query_args)
                 .filter(*filters)
-                .paginate(per_page=50, max_per_page=100)
+                .paginate(per_page=50, max_per_page=100, error_out=False)
             )
 
         response = UserSchema(view="user", many=True).dump(users.items)

--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -37,7 +37,7 @@ def listing():
         Teams.query.filter_by(hidden=False, banned=False)
         .filter(*filters)
         .order_by(Teams.id.asc())
-        .paginate(per_page=50)
+        .paginate(per_page=50, error_out=False)
     )
 
     args = dict(request.args)

--- a/CTFd/users.py
+++ b/CTFd/users.py
@@ -29,7 +29,7 @@ def listing():
         Users.query.filter_by(banned=False, hidden=False)
         .filter(*filters)
         .order_by(Users.id.asc())
-        .paginate(per_page=50)
+        .paginate(per_page=50, error_out=False)
     )
 
     args = dict(request.args)


### PR DESCRIPTION
* Disable returning 404s in listing pages with pagination
* For the API endpoints instead of returning 404 these will now return 200 with an empty listing which is the better (and intended) response