### PR TITLE
Mark 3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 3.7.2 / 2024-06-18
+
+**Security**
+
+- Patches an issue where on certain browsers flags could be leaked with admin interaction on a malicious page
+
+**API**
+
+- Disable returning 404s in listing pages with pagination
+  - Instead of returning 404 these pages will now return 200
+  - For API endpoints, the response will be a 200 with an empty listing instead of a 404
+
+**Deployment**
+
+- CTFd will now add the `Cross-Origin-Opener-Policy` response header to all responses with the default value of `same-origin-allow-popups`
+- Add `CROSS_ORIGIN_OPENER_POLICY` setting to control the `Cross-Origin-Opener-Policy` header
+
 # 3.7.1 / 2024-05-31
 
 **Admin Panel**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -32,7 +32,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.7.1"
+__version__ = "3.7.2"
 __channel__ = "oss"
 
 

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -141,7 +141,7 @@ class ServerConfig(object):
     PERMANENT_SESSION_LIFETIME: int = config_ini["security"].getint("PERMANENT_SESSION_LIFETIME") \
         or 604800
 
-    CROSS_ORIGIN_OPENER_POLICY: str = empty_str_cast(config_ini["security"]["CROSS_ORIGIN_OPENER_POLICY"]) \
+    CROSS_ORIGIN_OPENER_POLICY: str = empty_str_cast(config_ini["security"].get("CROSS_ORIGIN_OPENER_POLICY")) \
         or "same-origin-allow-popups"
 
     """


### PR DESCRIPTION
# 3.7.2 / 2024-06-18

**Security**

- Patches an issue where on certain browsers flags could be leaked with admin interaction on a malicious page

**API**

- Disable returning 404s in listing pages with pagination
  - Instead of returning 404 these pages will now return 200
  - For API endpoints, the response will be a 200 with an empty listing instead of a 404

**Deployment**

- CTFd will now add the `Cross-Origin-Opener-Policy` response header to all responses with the default value of `same-origin-allow-popups`
- Add `CROSS_ORIGIN_OPENER_POLICY` setting to control the `Cross-Origin-Opener-Policy` header