### PR TITLE
CVE-2024-4068 - Upgrade npm package 'braces' utilized by 2 themes

### DIFF
--- a/CTFd/themes/admin/yarn.lock
+++ b/CTFd/themes/admin/yarn.lock
@@ -619,10 +619,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2, braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+braces@^3.0.3, braces@~3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.0.1"
 
@@ -650,7 +650,7 @@ chalk@^4.0.0:
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
-    braces "~3.0.2"
+    braces "~3.0.3"
     glob-parent "~5.1.2"
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
@@ -1248,7 +1248,7 @@ micromatch@^4.0.4:
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
-    braces "^3.0.2"
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:

--- a/CTFd/themes/core-beta/yarn.lock
+++ b/CTFd/themes/core-beta/yarn.lock
@@ -243,10 +243,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2, braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+braces@^3.0.3, braces@~3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.0.1"
 
@@ -261,7 +261,7 @@ cash-dom@^8.1.1:
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
-    braces "~3.0.2"
+    braces "~3.0.3"
     glob-parent "~5.1.2"
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
@@ -629,7 +629,7 @@ micromatch@^4.0.4:
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
-    braces "^3.0.2"
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 minimatch@^3.0.4:


### PR DESCRIPTION
A security flaw named CVE-2024-4068 has been identified, impacting npm package braces up to version 3.0.2. Within CTFD, the braces npm package version 3.0.2 is currently mentioned in yarn.lock across two themes: admin and core-beta. The recommended action is to update the package to version 3.0.3 to address this vulnerability.


References:
https://nvd.nist.gov/vuln/detail/CVE-2024-4068
https://github.com/micromatch/braces/issues/35
https://devhub.checkmarx.com/cve-details/CVE-2024-4068
https://github.com/micromatch/braces/blob/98414f9f1fabe021736e26836d8306d5de747e0d/lib/parse.js#L308
https://github.com/micromatch/braces/pull/37
https://github.com/micromatch/braces/pull/40
https://github.com/micromatch/braces/commit/415d660c3002d1ab7e63dbf490c9851da80596ff