### PR TITLE
Update smtp.py to add  List-Unsubscribe header.

### DIFF
--- a/CTFd/utils/email/providers/smtp.py
+++ b/CTFd/utils/email/providers/smtp.py
@@ -44,6 +44,7 @@ class SMTPEmailProvider(EmailProvider):
             msg["Subject"] = subject
             msg["From"] = mailfrom_addr
             msg["To"] = addr
+            msg["List-Unsubscribe"]= f"<mailto:{mailfrom_addr}?subject=unsubscribe>"
 
             # Check whether we are using an admin-defined SMTP server
             custom_smtp = bool(get_config("mail_server"))


### PR DESCRIPTION
Add List-Unsubscribe header:
- rfc2369
- to avoid being classified as spam.
- to be compliant with CAN-SPAM.

use the sender's address to avoid creating a dedicated configuration field.
