### PR TITLE
Remove warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   ctfd:
     build: .


### PR DESCRIPTION
Remove warning from `docker compose`

```log
WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```