### PR TITLE
assets.py: JS as module implies defer

### DIFF
--- a/CTFd/constants/assets.py
+++ b/CTFd/constants/assets.py
@@ -31,15 +31,16 @@ class _AssetsWrapper:
         asset = self.manifest(theme=theme)[asset_key]
         entry = asset["file"]
         imports = asset.get("imports", [])
-        extra_attr = "defer " if defer else ""
+        # module type implies defer
+        extra_attr = 'type="module" ' if defer else ""
         html = ""
         for i in imports:
             # TODO: Needs a better recursive solution
             i = self.manifest(theme=theme)[i]["file"]
             url = url_for("views.themes_beta", theme=theme, path=i)
-            html += f'<script {extra_attr}type="module" src="{url}"></script>'
+            html += f'<script {extra_attr}src="{url}"></script>'
         url = url_for("views.themes_beta", theme=theme, path=entry)
-        html += f'<script {extra_attr}type="module" src="{url}"></script>'
+        html += f'<script {extra_attr}src="{url}"></script>'
         return markup(html)
 
     def css(self, asset_key, theme=None):

--- a/CTFd/constants/assets.py
+++ b/CTFd/constants/assets.py
@@ -33,20 +33,22 @@ class _AssetsWrapper:
         imports = asset.get("imports", [])
 
         # Add in extra attributes. Note that type="module" imples defer
-        attrs = f'type="{type}" '
+        _attrs = ""
+        if type:
+            _attrs = f'type="{type}" '
         if defer:
-            attrs += "defer "
+            _attrs += "defer "
         if extra:
-            attrs += extra
+            _attrs += extra
 
         html = ""
         for i in imports:
             # TODO: Needs a better recursive solution
             i = self.manifest(theme=theme)[i]["file"]
             url = url_for("views.themes_beta", theme=theme, path=i)
-            html += f'<script {attrs} src="{url}"></script>'
+            html += f'<script {_attrs} src="{url}"></script>'
         url = url_for("views.themes_beta", theme=theme, path=entry)
-        html += f'<script {attrs} src="{url}"></script>'
+        html += f'<script {_attrs} src="{url}"></script>'
         return markup(html)
 
     def css(self, asset_key, theme=None):

--- a/CTFd/constants/assets.py
+++ b/CTFd/constants/assets.py
@@ -25,22 +25,28 @@ class _AssetsWrapper:
                 raise e
         return manifest
 
-    def js(self, asset_key, theme=None, defer=True):
+    def js(self, asset_key, theme=None, type="module", defer=False, extra=""):
         if theme is None:
             theme = ctf_theme()
         asset = self.manifest(theme=theme)[asset_key]
         entry = asset["file"]
         imports = asset.get("imports", [])
-        # module type implies defer
-        extra_attr = 'type="module" ' if defer else ""
+
+        # Add in extra attributes. Note that type="module" imples defer
+        attrs = f'type="{type}" '
+        if defer:
+            attrs += "defer "
+        if extra:
+            attrs += extra
+
         html = ""
         for i in imports:
             # TODO: Needs a better recursive solution
             i = self.manifest(theme=theme)[i]["file"]
             url = url_for("views.themes_beta", theme=theme, path=i)
-            html += f'<script {extra_attr}src="{url}"></script>'
+            html += f'<script {attrs} src="{url}"></script>'
         url = url_for("views.themes_beta", theme=theme, path=entry)
-        html += f'<script {extra_attr}src="{url}"></script>'
+        html += f'<script {attrs} src="{url}"></script>'
         return markup(html)
 
     def css(self, asset_key, theme=None):


### PR DESCRIPTION
See https://github.com/CTFd/core-beta/pull/88 for discussion.

My bad, I didn't know that `type="module"` on a `<script>` tag implies defer mode.