### PR TITLE
Bump dependencies for 3.12

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ SQLAlchemy==1.4.48
 SQLAlchemy-Utils==0.41.1
 passlib==1.7.4
 bcrypt==4.0.1
-requests==2.28.1
+requests==2.32.3
 PyMySQL[rsa]==1.0.2
 gunicorn==20.1.0
 dataset==1.6.2
@@ -19,7 +19,7 @@ python-dotenv==0.13.0
 flask-restx==1.1.0
 flask-marshmallow==0.10.1
 marshmallow-sqlalchemy==0.17.0
-boto3==1.34.39
+boto3==1.35.27
 marshmallow==2.20.2
 pydantic==1.6.2
 WTForms==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ banal==1.0.6
     # via dataset
 bcrypt==4.0.1
     # via -r requirements.in
-boto3==1.34.39
+boto3==1.35.27
     # via -r requirements.in
-botocore==1.34.39
+botocore==1.35.27
     # via
     #   boto3
     #   s3transfer
@@ -144,7 +144,7 @@ pytz==2020.4
     #   flask-restx
 redis==4.5.5
     # via -r requirements.in
-requests==2.28.1
+requests==2.32.3
     # via -r requirements.in
 s3transfer==0.10.0
     # via boto3


### PR DESCRIPTION
* Bump requests to 2.32.3
* Bump boto3 to 1.35.27

This starts work on getting CTFd to run on Python 3.12