### PR TITLE
Mark 3.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 3.7.4 / 2024-10-08
+
+**Security**
+
+- Validate email length to be less than 320 chars to prevent Denial of Service in email validation
+
+**General**
+
+- Add attribution field to Challenges
+
+**Admin Panel**
+
+- Display brackets in the Admin Panel
+
+**Themes**
+
+- Display brackets for users/teams on listing pages and public/private pages
+- Fix miscellaneous issues in core-beta
+- Adds dark mode to core-beta theme
+- Fix issue with long titles in challenge buttons
+- Adds `type` and `extra` arguments to `Assets.js()` and default `defer` to `False` as `type="module"` automatically implies defer
+- ECharts behavior for some graphs in core-beta can now be overriden using the following window objects `window.scoreboardChartOptions`, `window.teamScoreGraphChartOptions`, `window.userScoreGraphChartOptions`
+- Update the scoreboard score graph to reflect the current active bracket changes
+
+**Deployment**
+
+- Add `.gitattributes` to keep LF line endings on .sh files under Windows
+- Fix issues where None values are not cast to empty string
+- Bump dependencies for `pybluemonday`, `requests`, and `boto3`
+
 # 3.7.3 / 2024-07-24
 
 **Security**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -32,7 +32,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.7.3"
+__version__ = "3.7.4"
 __channel__ = "oss"
 
 


### PR DESCRIPTION
# 3.7.4 / 2024-10-08

**Security**

- Validate email length to be less than 320 chars to prevent Denial of Service in email validation

**General**

- Add attribution field to Challenges

**Admin Panel**

- Display brackets in the Admin Panel

**Themes**

- Display brackets for users/teams on listing pages and public/private pages
- Fix miscellaneous issues in core-beta
- Adds dark mode to core-beta theme
- Fix issue with long titles in challenge buttons
- Adds `type` and `extra` arguments to `Assets.js()` and default `defer` to `False` as `type="module"` automatically implies defer
- ECharts behavior for some graphs in core-beta can now be overriden using the following window objects `window.scoreboardChartOptions`, `window.teamScoreGraphChartOptions`, `window.userScoreGraphChartOptions`
- Update the scoreboard score graph to reflect the current active bracket changes

**Deployment**

- Add `.gitattributes` to keep LF line endings on .sh files under Windows
- Fix issues where None values are not cast to empty string
- Bump dependencies for `pybluemonday`, `requests`, and `boto3`