### PR TITLE
Remove the "paused" message when the ctf is actually ended.

### DIFF
--- a/CTFd/challenges.py
+++ b/CTFd/challenges.py
@@ -38,11 +38,9 @@ def listing():
 
     if ctf_started() is False:
         errors.append(f"{Configs.ctf_name} has not started yet")
-
-    if ctf_paused() is True:
-        infos.append(f"{Configs.ctf_name} is paused")
-
-    if ctf_ended() is True:
+    elif ctf_ended() is True:
         infos.append(f"{Configs.ctf_name} has ended")
+    elif ctf_paused() is True:
+        infos.append(f"{Configs.ctf_name} is paused")
 
     return render_template("challenges.html", infos=infos, errors=errors)


### PR DESCRIPTION
Hello,
This small change is to remove the `<ctf> is paused` message when the ctf is actually finished (both messages are displayed at the same time, currently).
Thank you in advance for approving this PR.
Have a nice day,
AAA3A