### PR TITLE
Bring SLSA 3 on Docker containers (plug & play)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,37 +10,118 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      dockerhub_image: ${{ steps.image.outputs.dockerhub_image }}
+      ghcrio_image: ${{ steps.image.outputs.ghcrio_image }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
       - name: Set repo name lowercase
         id: repo
         uses: ASzc/change-string-case-action@v2
         with:
           string: ${{ github.repository }}
-      - name: Checkout
-        uses: actions/checkout@v3
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.0.2
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ github.actor }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
+          images: ${{ steps.repo.outputs.lowercase }}
+
+      - name: Fan the tags to other registries
+        id: fan
+        run: |
+          # Read tags from the previous step which stored them in environment variables
+          readarray -t tags_list <<<"$DOCKER_METADATA_OUTPUT_TAGS"
+
+          # Repeat the following as many time as necessary
+          # ghcr.io
+          ghcrio_list=()
+          for item in "${tags_list[@]}"; do
+            ghcrio_list+=("ghcr.io/${item}")
+          done
+
+          combined_list=("${tags_list[@]}" "${ghcrio_list[@]}")
+
+          # Combine all duplicated+prefixed lists in 1 output
+          {
+            echo "tags<<EOF"
+            printf "%s\n" "${combined_list[@]}"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        id: build
+        with:
           push: true
-          tags: |
-            ${{ steps.repo.outputs.lowercase }}:latest
-            ghcr.io/${{ steps.repo.outputs.lowercase }}:latest
-            ${{ steps.repo.outputs.lowercase }}:${{ github.event.release.tag_name }}
-            ghcr.io/${{ steps.repo.outputs.lowercase }}:${{ github.event.release.tag_name }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.fan.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Output image
+        id: image
+        run: |
+          # NOTE: Set the image as an output because the `env` context is not
+          # available to the inputs of a reusable workflow call.
+
+          dockerhub_image_name="${{ steps.repo.outputs.lowercase }}"
+          echo "dockerhub_image=$dockerhub_image_name" >> "$GITHUB_OUTPUT"
+
+          ghcrio_image_name="ghcr.io/${{ steps.repo.outputs.lowercase }}"
+          echo "ghcrio_image=$ghcrio_image_name" >> "$GITHUB_OUTPUT"
+
+  # This step calls the container workflow to generate provenance and push it to
+  # the container registry.
+  provenance_dockerhub:
+    needs: [docker]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ${{ needs.docker.outputs.dockerhub_image }}
+      digest: ${{ needs.docker.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  # This step calls the container workflow to generate provenance and push it to
+  # the container registry.
+  provenance_ghcrio:
+    needs: [docker]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ${{ needs.docker.outputs.ghcrio_image }}
+      digest: ${{ needs.docker.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ You can use the auto-generated Docker images with the following command:
 
 `docker run -p 8000:8000 -it ctfd/ctfd`
 
+You can verify a specific image using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) and the following.
+
+```
+slsa-verifier slsa-verifier verify-image "ctfd/ctfd:<tag>@sha256:<digest>" \
+    --source-uri github.com/CTFd/CTFd \
+    --source-tag <tag>
+```
+
 Or you can use Docker Compose with the following command from the source repository:
 
 `docker compose up`


### PR DESCRIPTION
Hello,

This PR comes as a partial response to #2641: it brings SLSA 3 on the Docker containers for both [Docker Hub](https://hub.docker.com/repository/docker/pandatix/ctfd/tags) and [ghcr.io](https://github.com/pandatix/CTFd/pkgs/container/ctfd/versions).
It will be triggered as before, when a maintainer creates a release.
It still tags them for the specific tag and `latest`, build them for `linux` `amd64` and `arm64`, then pushes them.
Finally, it generates the provenance and publish them as OCI blobs.

For plugins, this does not imply any change : the CTFd Docker image could mount the plugin to a volume thus unchange the digest of the image (and so the attestation).
For end users, verifying SLSA compliance is not required thus unchange the current CTFd usage workflow.

I demonstrated the proper work of this PR with a [random tag](https://github.com/pandatix/CTFd/releases/tag/v1.0.0) which triggered the [workflow](https://github.com/pandatix/CTFd/actions/runs/11480508240). It comes with nearly no cost for the release process (<1 min).

Notice I dropped the usage of `DOCKER_USERNAME` secret as it will then be contained in an output, and for security purposes, GitHub Actions drop the content of the output that is passed through jobs... Frustrating hours of debug :upside_down_face:
Instead I use `github.actor`, but I'm unsure if `ctfdbot` (hardcoded string) fits there better :shrug: 

Dependencies are [pinned as a good practice from OpenSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies).
