### PR TITLE
Add OpenSSF Scoreboard audit

### DIFF
--- a/.github/workflows/scoreboard.yml
+++ b/.github/workflows/scoreboard.yml
@@ -1,0 +1,35 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 6 * * 6'
+  push:
+    branches: [ "master" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Linting](https://github.com/CTFd/CTFd/workflows/Linting/badge.svg?branch=master)
 [![MajorLeagueCyber Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.majorleaguecyber.org%2F)](https://community.majorleaguecyber.org/)
 [![Documentation Status](https://api.netlify.com/api/v1/badges/6d10883a-77bb-45c1-a003-22ce1284190e/deploy-status)](https://docs.ctfd.io)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/CTFd/CTFd/badge)](https://securityscorecards.dev/viewer/?uri=github.com/CTFd/CTFd)
 
 ## What is CTFd?
 


### PR DESCRIPTION
Hello,

This PR comes as a partial response to #2641: it brings the [OpenSSF Scoreboard](https://openssf.org/projects/scorecard/) as a continuous security audit tool. It should help contributors that are non-developers but have a security profile to give them guidelines on how to help CTFd improve its security practices and posture.

My last manually-triggered audit showed **current CTFd scores 4.9/10** which highlights plenty room for improvement, but no big security defect. The expected behavior with Scoreboard is to raise both the score thus the security practices **and** the security knowledge of the community.
Moreover it has a cool badge :smile: 

Dependencies are [pinned as a good practice from OpenSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies).
