### PR TITLE
Tracking: Fix "cache miss" bug which causes too many DB queries

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -235,7 +235,7 @@ def init_request_processors(app):
             ip = get_ip()
 
             track = None
-            if (ip not in user_ips):
+            if ip not in user_ips:
                 track = Tracking.query.filter_by(
                     ip=get_ip(), user_id=session["id"]
                 ).first()

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -235,7 +235,7 @@ def init_request_processors(app):
             ip = get_ip()
 
             track = None
-            if (ip not in user_ips) or (request.method != "GET"):
+            if (ip not in user_ips):
                 track = Tracking.query.filter_by(
                     ip=get_ip(), user_id=session["id"]
                 ).first()

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -235,7 +235,12 @@ def init_request_processors(app):
             ip = get_ip()
 
             track = None
-            if ip not in user_ips:
+            if ip not in user_ips or request.method in (
+                "POST",
+                "PUT",
+                "PATCH",
+                "DELETE",
+            ):
                 track = Tracking.query.filter_by(
                     ip=get_ip(), user_id=session["id"]
                 ).first()

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -237,7 +237,6 @@ def init_request_processors(app):
             track = None
             if ip not in user_ips or request.method in (
                 "POST",
-                "PUT",
                 "PATCH",
                 "DELETE",
             ):

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -241,7 +241,7 @@ def init_request_processors(app):
                 ).first()
 
                 if track:
-                    track.date = datetime.datetime.utcnow()
+                    track.date = datetime.datetime.now(datetime.UTC)
                 else:
                     track = Tracking(ip=get_ip(), user_id=session["id"])
                     db.session.add(track)

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -203,7 +203,7 @@ def get_current_user_recent_ips():
 
 @cache.memoize(timeout=300)
 def get_user_recent_ips(user_id):
-    hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)
+    hour_ago = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
     addrs = (
         Tracking.query.with_entities(Tracking.ip.distinct())
         .filter(Tracking.user_id == user_id, Tracking.date >= hour_ago)


### PR DESCRIPTION
# Current behavior

Before each request, the initialization process module executes the following process:
1. Query the cache to get the recent IPs of the current user
    - If the cache is missing, select the recent IPs from the database.
    - The comparison is computed using `datetime.datetime.now() - datetime.timedelta()` 
    - The MySQL query isn't timezone aware, the date will be encoded in local time without timezone information
2. If the request IP isn't stored in database OR if the request is not GET then update the database
    - The date column is filled using `datetime.datetime.utcnow()`
    - The cache is invalidated

# Bugs

The first bug is caused by the following condition:
```python
if (ip not in user_ips) or (request.method != "GET"):
```
Browser issue many HEAD requests and trigger this condition. This invalidates cache and leads to two SELECT queries and one UPDATE query before every HEAD request.

The second bug is caused by differences in timezone treatment. The Datetime column type of SQLAlchemy isn't timezone aware. Because of that, the SELECT query is encoded using local time, while the UPDATE query was encoded using UTC time.

If a CTFd server is hosted on a timezone >= UTC+1, then the SELECT query would always return an empty result. This results in cache invalidation + UPDATE query **before each HTTP request** (even GET requests).

# Fixes

The condition `if ... or request.method != "GET"` has been removed. I don't really understand why it has been introduced in the first place. It removes forced updates during HEAD requests.

The usage of `datetime.datetime.now()` has been replaced by `datetime.datetime.now(datetime.UTC)` in order to always use UTC time accordingly to the whole project, which uses the deprecated `datetime.datetime.utcnow()` 


# Further proposal

`datetime.now()` with default timezone should be avoided, since the `Datetime` column type of SQLAlchemy doesn't store timezone information.

Every `datetime.datetime.utcnow()` should be replaced by `datetime.datetime.now(datetime.UTC)` in order to follow the [python deprecation notice](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow)
