### PR TITLE
Dockerfile: remove Debian deps and cache CTFd requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,14 @@ RUN python -m venv /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH"
 
-COPY . /opt/CTFd
+# Install CTFd requirements before copying the whole project,
+# this layer will be reused when rebuilding CTFd after a small change
+COPY ./requirements.txt /opt/CTFd
+RUN pip install --no-cache-dir -r requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt \
-    && for d in CTFd/plugins/*; do \
+# Install CTFd plugins requirements
+COPY . /opt/CTFd
+RUN for d in CTFd/plugins/*; do \
         if [ -f "$d/requirements.txt" ]; then \
             pip install --no-cache-dir -r "$d/requirements.txt";\
         fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,7 @@ FROM python:3.11-slim-bookworm AS build
 
 WORKDIR /opt/CTFd
 
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-        libffi-dev \
-        libssl-dev \
-        git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && python -m venv /opt/venv
+RUN python -m venv /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH"
 
@@ -27,14 +18,6 @@ RUN pip install --no-cache-dir -r requirements.txt \
 
 FROM python:3.11-slim-bookworm AS release
 WORKDIR /opt/CTFd
-
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libffi8 \
-        libssl3 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=1001:1001 . /opt/CTFd
 


### PR DESCRIPTION
The first commit removes unused apt-get dependencies, that are no longer needed thanks to https://github.com/CTFd/CTFd/pull/2652.

The second commit greatly improves build-time when rebuilding the Docker image during development. By separating requirements.txt installation in a layer, before copying CTFd source, we no longer need to reinstall all pipy deps after small code changes. It should also improve CI/CD speed.