### PR TITLE
Revert datetime changes from #2653

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -245,7 +245,7 @@ def init_request_processors(app):
                 ).first()
 
                 if track:
-                    track.date = datetime.datetime.now(datetime.UTC)
+                    track.date = datetime.datetime.utcnow()
                 else:
                     track = Tracking(ip=get_ip(), user_id=session["id"])
                     db.session.add(track)

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -203,7 +203,7 @@ def get_current_user_recent_ips():
 
 @cache.memoize(timeout=300)
 def get_user_recent_ips(user_id):
-    hour_ago = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    hour_ago = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
     addrs = (
         Tracking.query.with_entities(Tracking.ip.distinct())
         .filter(Tracking.user_id == user_id, Tracking.date >= hour_ago)


### PR DESCRIPTION
@adam-lebon I am reverting the datetime changes here because I think it will be better to put it in an whole application wide migration

Also using utcnow in the recent IPs query to fix the issue you had raised