### PR TITLE
Changed team create/join/invite behaviour to redirect to the team and not the challenges.

### DIFF
--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -118,7 +118,7 @@ def invite():
         clear_user_session(user_id=user.id)
         clear_team_session(team_id=team.id)
 
-        return redirect(url_for("challenges.listing"))
+        return redirect(url_for('teams.private'))
 
 
 @teams.route("/teams/join", methods=["GET", "POST"])
@@ -179,7 +179,7 @@ def join():
             clear_user_session(user_id=user.id)
             clear_team_session(team_id=team.id)
 
-            return redirect(url_for("challenges.listing"))
+            return redirect(url_for('teams.private'))
         else:
             errors.append("That information is incorrect")
             return render_template("teams/join_team.html", infos=infos, errors=errors)
@@ -330,7 +330,7 @@ def new():
         clear_user_session(user_id=user.id)
         clear_team_session(team_id=team.id)
 
-        return redirect(url_for("challenges.listing"))
+        return redirect(url_for('teams.private'))
 
 
 @teams.route("/team")

--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -118,7 +118,7 @@ def invite():
         clear_user_session(user_id=user.id)
         clear_team_session(team_id=team.id)
 
-        return redirect(url_for('teams.private'))
+        return redirect(url_for("teams.private"))
 
 
 @teams.route("/teams/join", methods=["GET", "POST"])
@@ -179,7 +179,7 @@ def join():
             clear_user_session(user_id=user.id)
             clear_team_session(team_id=team.id)
 
-            return redirect(url_for('teams.private'))
+            return redirect(url_for("teams.private"))
         else:
             errors.append("That information is incorrect")
             return render_template("teams/join_team.html", infos=infos, errors=errors)
@@ -330,7 +330,7 @@ def new():
         clear_user_session(user_id=user.id)
         clear_team_session(team_id=team.id)
 
-        return redirect(url_for('teams.private'))
+        return redirect(url_for("teams.private"))
 
 
 @teams.route("/team")

--- a/tests/teams/test_invites.py
+++ b/tests/teams/test_invites.py
@@ -62,7 +62,7 @@ def test_api_user_facing_invite_tokens():
                 }
             r = user.post(url, data=data)
             assert r.status_code == 302
-            assert r.location.endswith("/challenges")
+            assert r.location.endswith("/team")
         assert Users.query.filter_by(id=new_user.id).first().team_id == team1.id
 
         # Test team size limits


### PR DESCRIPTION
Creating a team now redirects to the team instead of challenges. 
Joining a team now redirects to the team instead of challenges. 
Accepting an invite to a team now redirects to the team instead of challenges.

This is useful especially because there's no clear indication wether or not it worked since you're immediatly redirected to the challenge list.

This is also to avoid getting redirected to a "Forbidden" when the CTF hasn't yet started, this behaviour could make the user believe that the action did not work even though it did.