### PR TITLE
Autocomplete attribute on login, register and password_reset

### DIFF
--- a/CTFd/themes/core/templates/login.html
+++ b/CTFd/themes/core/templates/login.html
@@ -30,7 +30,7 @@
 				</div>
 				<div class="form-group">
 					<b>{{ form.password.label }}</b>
-					{{ form.password(class="form-control", value=password) }}
+					{{ form.password(class="form-control", value=password, autocomplete="current-password") }}
 				</div>
 				<div class="row pt-3">
 					<div class="col-md-6">

--- a/CTFd/themes/core/templates/register.html
+++ b/CTFd/themes/core/templates/register.html
@@ -34,14 +34,14 @@
 				</div>
 				<div class="form-group">
 					<b>{{ form.email.label }}</b>
-					{{ form.email(class="form-control", value=email) }}
+					{{ form.email(class="form-control", value=email, autocomplete="email") }}
 					<small class="form-text text-muted">
 						Never shown to the public
 					</small>
 				</div>
 				<div class="form-group">
 					<b>{{ form.password.label }}</b>
-					{{ form.password(class="form-control", value=password) }}
+					{{ form.password(class="form-control", value=password, autocomplete="new-password") }}
 					<small class="form-text text-muted">
 						Password used to log into your account
 					</small>

--- a/CTFd/themes/core/templates/reset_password.html
+++ b/CTFd/themes/core/templates/reset_password.html
@@ -24,7 +24,7 @@
 					</div>
 					<div class="form-group">
 						{{ form.password.label }}
-						{{ form.password(class="form-control") }}
+						{{ form.password(class="form-control", autocomplete="new-password") }}
 					</div>
 					<div class="row">
 						<div class="col-md-6 offset-md-6">
@@ -44,7 +44,7 @@
 					</div>
 					<div class="form-group">
 						{{ form.email.label }}
-						{{ form.email(class="form-control") }}
+						{{ form.email(class="form-control", autocomplete="email") }}
 					</div>
 					<div class="row">
 						<div class="col-md-6 offset-md-6">


### PR DESCRIPTION
This PR is a small improvement for the input fields on the login, register and password_reset pages. 
It signals password managers to use
- `current-password` for login
- `new-password` for register and password_reset

See documentation for the `autocomplete` attribute here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#new-password