### PR TITLE
Mark 3.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 3.7.6 / 2025-02-19
+
+**Security**
+
+- Added the `TRUSTED_HOSTS` configuration to more easily restrict CTFd to valid host names
+
+**General**
+
+- Added language switcher on the main navigation bar
+- Removed autocomplete=off from login, register, and reset password forms
+
+**Plugins**
+
+- Challenge type plugins can now raise `ChallengeCreateException` or `ChallengeUpdateException` to show input validation messages
+- Plugins specifying a config route will now appear in the Admin Panel under the Plugins section
+
+**Translations**
+
+- Add Romanian, Greek, Finnish, Slovenian, Swedish languages
+
 # 3.7.5 / 2024-12-27
 
 **Security**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -33,7 +33,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.7.5"
+__version__ = "3.7.6"
 __channel__ = "oss"
 
 


### PR DESCRIPTION
# 3.7.6 / 2025-02-19

**Security**

- Added the `TRUSTED_HOSTS` configuration to more easily restrict CTFd to valid host names

**General**

- Added language switcher on the main navigation bar
- Removed autocomplete=off from login, register, and reset password forms

**Plugins**

- Challenge type plugins can now raise `ChallengeCreateException` or `ChallengeUpdateException` to show input validation messages
- Plugins specifying a config route will now appear in the Admin Panel under the Plugins section

**Translations**

- Add Romanian, Greek, Finnish, Slovenian, Swedish languages