### PR TITLE
fix(cache): fix possible cache poisoning attack (#2741)

### DIFF
--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -93,7 +93,9 @@ class ScoreboardDetail(Resource):
     @check_score_visibility
     @cache.cached(
         timeout=60,
-        key_prefix=make_cache_key_with_query_string(allowed_query_params=["bracket_id"], allowed_route_params=["count"]),
+        key_prefix=make_cache_key_with_query_string(
+            allowed_query_params=["bracket_id"], allowed_route_params=["count"]
+        ),
     )
     def get(self, count):
         response = {}

--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -93,7 +93,7 @@ class ScoreboardDetail(Resource):
     @check_score_visibility
     @cache.cached(
         timeout=60,
-        key_prefix=make_cache_key_with_query_string(allowed_params=["bracket_id"]),
+        key_prefix=make_cache_key_with_query_string(allowed_query_params=["bracket_id"], allowed_route_params=["count"]),
     )
     def get(self, count):
         response = {}

--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -53,7 +53,9 @@ def make_cache_key(path=None, key_prefix="view/%s"):
     return cache_key
 
 
-def make_cache_key_with_query_string(allowed_query_params=None, query_string_hash=None, allowed_route_params=None):
+def make_cache_key_with_query_string(
+    allowed_query_params=None, query_string_hash=None, allowed_route_params=None
+):
     if allowed_query_params is None:
         allowed_query_params = []
     if allowed_route_params is None:

--- a/CTFd/cache/__init__.py
+++ b/CTFd/cache/__init__.py
@@ -56,7 +56,6 @@ def make_cache_key(path=None, key_prefix="view/%s"):
 def make_cache_key_with_query_string(allowed_query_params=None, query_string_hash=None, allowed_route_params=None):
     if allowed_query_params is None:
         allowed_query_params = []
-    
     if allowed_route_params is None:
         allowed_route_params = []
 


### PR DESCRIPTION
Made improvements to caching mechanism inside of the `make_cache_key_with_query_string` function. Modified the `make_cache_key_with_query_string` function to accept `allowed_route_params` in addition to renaming `allowed_params` to `allowed_query_params`, and updated the logic to include route parameters in the cache key generation.

Fixes #2741 