### PR TITLE
Make email verification a default feature if email sending is enabled

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -38,10 +38,6 @@ auth = Blueprint("auth", __name__)
 @auth.route("/confirm/<data>", methods=["POST", "GET"])
 @ratelimit(method="POST", limit=10, interval=60)
 def confirm(data=None):
-    if not get_config("verify_emails"):
-        # If the CTF doesn't care about confirming email addresses then redierct to challenges
-        return redirect(url_for("challenges.listing"))
-
     # User is confirming email account
     if data and request.method == "GET":
         try:

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -13,7 +13,7 @@ from CTFd.models import Brackets, Teams, UserFieldEntries, UserFields, Users, db
 from CTFd.utils import config, email, get_app_config, get_config
 from CTFd.utils import user as current_user
 from CTFd.utils import validators
-from CTFd.utils.config import is_teams_mode
+from CTFd.utils.config import can_send_mail, is_teams_mode
 from CTFd.utils.config.integrations import mlc_registration
 from CTFd.utils.config.visibility import registration_visible
 from CTFd.utils.crypto import verify_password
@@ -38,6 +38,10 @@ auth = Blueprint("auth", __name__)
 @auth.route("/confirm/<data>", methods=["POST", "GET"])
 @ratelimit(method="POST", limit=10, interval=60)
 def confirm(data=None):
+    if not can_send_mail():
+        # If the CTF doesn't care about confirming email addresses then redierct to challenges
+        return redirect(url_for("challenges.listing"))
+
     # User is confirming email account
     if data and request.method == "GET":
         try:

--- a/CTFd/forms/auth.py
+++ b/CTFd/forms/auth.py
@@ -71,7 +71,7 @@ class LoginForm(BaseForm):
 
 
 class ConfirmForm(BaseForm):
-    submit = SubmitField(_l("Resend Confirmation Email"))
+    submit = SubmitField(_l("Send Confirmation Email"))
 
 
 class ResetPasswordRequestForm(BaseForm):

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -38,7 +38,7 @@ from CTFd.models import (
 from CTFd.utils import config, get_config, set_config
 from CTFd.utils import user as current_user
 from CTFd.utils import validators
-from CTFd.utils.config import is_setup, is_teams_mode
+from CTFd.utils.config import is_setup, is_teams_mode, can_send_mail
 from CTFd.utils.config.pages import build_markdown, get_page
 from CTFd.utils.config.visibility import challenges_visible
 from CTFd.utils.dates import ctf_ended, ctftime, view_after_ctf
@@ -361,12 +361,11 @@ def settings():
 
     prevent_name_change = get_config("prevent_name_change")
 
-    if get_config("verify_emails") and not user.verified:
+    if can_send_mail() and not user.verified:
         confirm_url = markup(url_for("auth.confirm"))
         infos.append(
             markup(
                 "Your email address isn't confirmed!<br>"
-                "Please check your email to confirm your email address.<br><br>"
                 f'To have the confirmation email resent please <a href="{confirm_url}">click here</a>.'
             )
         )

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -362,11 +362,11 @@ def settings():
     prevent_name_change = get_config("prevent_name_change")
 
     if can_send_mail() and not user.verified:
-        confirm_url = markup(url_for("auth.confirm"))
+        confirm_url = markup(url_for("auth.confirm", flow="init"))
         infos.append(
             markup(
                 "Your email address isn't confirmed!<br>"
-                f'To have the confirmation email resent please <a href="{confirm_url}">click here</a>.'
+                f'To confirm your email address please <a href="{confirm_url}">click here</a>.'
             )
         )
 

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -38,7 +38,7 @@ from CTFd.models import (
 from CTFd.utils import config, get_config, set_config
 from CTFd.utils import user as current_user
 from CTFd.utils import validators
-from CTFd.utils.config import is_setup, is_teams_mode, can_send_mail
+from CTFd.utils.config import can_send_mail, is_setup, is_teams_mode
 from CTFd.utils.config.pages import build_markdown, get_page
 from CTFd.utils.config.visibility import challenges_visible
 from CTFd.utils.dates import ctf_ended, ctftime, view_after_ctf

--- a/tests/users/test_auth.py
+++ b/tests/users/test_auth.py
@@ -213,6 +213,11 @@ def test_expired_confirmation_links():
     """Test that expired confirmation links are reported to the user"""
     app = create_ctfd()
     with app.app_context():
+        set_config("mail_server", "localhost")
+        set_config("mail_port", 25)
+        set_config("mail_useauth", True)
+        set_config("mail_username", "username")
+        set_config("mail_password", "password")
         set_config("verify_emails", True)
 
         register_user(app, email="user@user.com")
@@ -237,6 +242,11 @@ def test_invalid_confirmation_links():
     """Test that invalid confirmation links are reported to the user"""
     app = create_ctfd()
     with app.app_context():
+        set_config("mail_server", "localhost")
+        set_config("mail_port", 25)
+        set_config("mail_useauth", True)
+        set_config("mail_username", "username")
+        set_config("mail_password", "password")
         set_config("verify_emails", True)
 
         register_user(app, email="user@user.com")

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -408,6 +408,11 @@ def test_confirm_links_single_use():
     """Test that confirm links are single use"""
     app = create_ctfd()
     with app.app_context():
+        set_config("mail_server", "localhost")
+        set_config("mail_port", 25)
+        set_config("mail_useauth", True)
+        set_config("mail_username", "username")
+        set_config("mail_password", "password")
         set_config("verify_emails", True)
         register_user(app)
         client = login_as_user(app)


### PR DESCRIPTION
* Email confirmation is now enabled if email sending is enabled on the CTFd instance
* CTFd will also nudge users to verify their email with a dismissable message