### PR TITLE
Add the ability to require browser interaction on email confirmation links

### DIFF
--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -56,6 +56,16 @@ def confirm(data=None):
         if user.verified:
             return redirect(url_for("views.settings"))
 
+        if (
+            get_app_config("EMAIL_CONFIRMATION_REQUIRE_INTERACTION")
+            and request.args.get("interaction") is None
+        ):
+            button = """<button onclick="
+                let u = new window.URL(window.location.href); 
+                u.searchParams.set('interaction', '1'); 
+                window.location.href = u;">Confirm Email</button>"""
+            return render_template("page.html", content=button)
+
         user.verified = True
         log(
             "registrations",

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -61,8 +61,8 @@ def confirm(data=None):
             and request.args.get("interaction") is None
         ):
             button = """<button onclick="
-                let u = new window.URL(window.location.href); 
-                u.searchParams.set('interaction', '1'); 
+                let u = new window.URL(window.location.href);
+                u.searchParams.set('interaction', '1');
                 window.location.href = u;">Confirm Email</button>"""
             return render_template("page.html", content=button)
 

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -293,6 +293,12 @@ SQLALCHEMY_MAX_OVERFLOW =
 # https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/#configuration-keys
 SQLALCHEMY_POOL_PRE_PING =
 
+# EMAIL_CONFIRMATION_REQUIRE_INTERACTION
+# If enabled email confirmation links will show a page with a button for email confirmation instead of confirming immediately upon link open
+# Can help with properly confirming emails under certain link phishing protections
+# Defaults to false
+EMAIL_CONFIRMATION_REQUIRE_INTERACTION =
+
 # SAFE_MODE
 # If SAFE_MODE is enabled, CTFd will not load any plugins which may alleviate issues preventing CTFd from starting
 # Defaults to false

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -248,6 +248,8 @@ class ServerConfig(object):
 
     SAFE_MODE: bool = process_boolean_str(empty_str_cast(config_ini["optional"].get("SAFE_MODE", False), default=False))
 
+    EMAIL_CONFIRMATION_REQUIRE_INTERACTION: bool = process_boolean_str(empty_str_cast(config_ini["optional"].get("EMAIL_CONFIRMATION_REQUIRE_INTERACTION", False), default=False))
+
     if DATABASE_URL.startswith("sqlite") is False:
         SQLALCHEMY_ENGINE_OPTIONS = {
             "max_overflow": int(empty_str_cast(config_ini["optional"]["SQLALCHEMY_MAX_OVERFLOW"], default=20)),  # noqa: E131


### PR DESCRIPTION
* Closes #2690
* Adds `EMAIL_CONFIRMATION_REQUIRE_INTERACTION` to config.ini and config.py which controls whether confirmation links confirm accounts upon opening the confirmation link or if it confirms upon clicking an additional button. 

<img width="831" height="203" alt="image" src="https://github.com/user-attachments/assets/1cdf0a24-9264-463f-80cc-4f22e8fbaf14" />
