### PR TITLE
Allow admins to control the share template

### DIFF
--- a/CTFd/api/v1/shares.py
+++ b/CTFd/api/v1/shares.py
@@ -13,7 +13,7 @@ shares_namespace = Namespace("shares", description="Endpoint to create Share lin
 class Share(Resource):
     @authed_only
     def post(self):
-        if bool(get_config("social_shares")) is False:
+        if bool(get_config("social_shares", default=True)) is False:
             abort(403)
         req = request.get_json()
         share_type = req.get("type")

--- a/CTFd/constants/config.py
+++ b/CTFd/constants/config.py
@@ -96,5 +96,9 @@ class _ConfigsWrapper:
     def privacy_link(self):
         return get_config("privacy_url", default=url_for("views.privacy"))
 
+    @property
+    def social_shares(self):
+        return get_config("social_shares", default=True)
+
 
 Configs = _ConfigsWrapper()

--- a/CTFd/forms/config.py
+++ b/CTFd/forms/config.py
@@ -12,6 +12,7 @@ from CTFd.constants.languages import SELECT_LANGUAGE_LIST
 from CTFd.forms import BaseForm
 from CTFd.forms.fields import SubmitField
 from CTFd.utils.csv import get_dumpable_tables
+from CTFd.utils.social import BASE_TEMPLATE
 
 
 class ResetInstanceForm(BaseForm):
@@ -119,6 +120,11 @@ class SocialSettingsForm(BaseForm):
         description="Enable or Disable social sharing links for challenge solves",
         choices=[("true", "Enabled"), ("false", "Disabled")],
         default="true",
+    )
+    social_share_solve_template = TextAreaField(
+        "Social Share Solve Template",
+        description="HTML for Share Template",
+        default=BASE_TEMPLATE,
     )
     submit = SubmitField("Update")
 

--- a/CTFd/forms/setup.py
+++ b/CTFd/forms/setup.py
@@ -147,4 +147,11 @@ class SetupForm(BaseForm):
         _l("End Time"),
         description=_l("Time when your CTF is scheduled to end. Optional."),
     )
+
+    social_shares = SelectField(
+        _l("Social Shares"),
+        description="Control whether users can share links commemorating their challenge solves",
+        choices=[("true", "Enabled"), ("false", "Disabled")],
+        default="true",
+    )
     submit = SubmitField(_l("Finish"))

--- a/CTFd/share.py
+++ b/CTFd/share.py
@@ -8,7 +8,7 @@ social = Blueprint("social", __name__)
 
 @social.route("/share/<type>/assets/<path>")
 def assets(type, path):
-    if bool(get_config("social_shares")) is False:
+    if bool(get_config("social_shares", default=True)) is False:
         abort(403)
     SocialShare = get_social_share(type)
     if SocialShare is None:
@@ -23,7 +23,7 @@ def assets(type, path):
 
 @social.route("/share/<type>")
 def share(type):
-    if bool(get_config("social_shares")) is False:
+    if bool(get_config("social_shares", default=True)) is False:
         abort(403)
     SocialShare = get_social_share(type)
     if SocialShare is None:

--- a/CTFd/themes/admin/templates/configs/social.html
+++ b/CTFd/themes/admin/templates/configs/social.html
@@ -1,5 +1,5 @@
 <div role="tabpanel" class="tab-pane config-section" id="social">
-	{% set social_shares = "true" if social_shares == True else "false" %}
+	{% set social_shares = "false" if social_shares == False else "true" %}
 	{% set social_share_solve_template = social_share_solve_template | default(Forms.config.SocialSettingsForm.social_share_solve_template.kwargs['default']) %}
 	{% with form = Forms.config.SocialSettingsForm(social_shares=social_shares, social_share_solve_template=social_share_solve_template) %}
 	<form method="POST" autocomplete="off" class="w-100">

--- a/CTFd/themes/admin/templates/configs/social.html
+++ b/CTFd/themes/admin/templates/configs/social.html
@@ -1,12 +1,20 @@
 <div role="tabpanel" class="tab-pane config-section" id="social">
 	{% set social_shares = "true" if social_shares == True else "false" %}
-	{% with form = Forms.config.SocialSettingsForm(social_shares=social_shares) %}
+	{% set social_share_solve_template = social_share_solve_template | default(Forms.config.SocialSettingsForm.social_share_solve_template.kwargs['default']) %}
+	{% with form = Forms.config.SocialSettingsForm(social_shares=social_shares, social_share_solve_template=social_share_solve_template) %}
 	<form method="POST" autocomplete="off" class="w-100">
 		<div class="form-group">
 			{{ form.social_shares.label }}
 			{{ form.social_shares(class="form-control", value=social_shares) }}
 			<small class="form-text text-muted">
 				{{ form.social_shares.description }}
+			</small>
+		</div>
+		<div class="form-group">
+			{{ form.social_share_solve_template.label }}
+			{{ form.social_share_solve_template(class="form-control", rows="10") }}
+			<small class="form-text text-muted">
+				{{ form.social_share_solve_template.description }}
 			</small>
 		</div>
 		{{ form.submit(class="btn btn-md btn-primary float-right") }}

--- a/CTFd/utils/social/__init__.py
+++ b/CTFd/utils/social/__init__.py
@@ -13,8 +13,7 @@ from CTFd.utils.humanize.words import pluralize
 from CTFd.utils.security.signing import hmac
 from CTFd.utils.uploads import get_uploader
 
-BASE_TEMPLATE = """
-<div class="container">
+BASE_TEMPLATE = """<div class="container">
     <div class="row">
         <div class="col-md-6 offset-md-3">
             <h3 class="text-center">{ctf_name}</h3>
@@ -30,8 +29,7 @@ BASE_TEMPLATE = """
             </h6>
         </div>
     </div>
-</div>
-"""
+</div>"""
 
 
 def get_logo():

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -109,6 +109,7 @@ def setup():
                 )
             )
             verify_emails = request.form.get("verify_emails")
+            social_shares = request.form.get("social_shares")
             team_size = request.form.get("team_size")
 
             # Style
@@ -232,6 +233,9 @@ def setup():
 
             # Verify emails
             set_config("verify_emails", verify_emails)
+
+            # Social shares
+            set_config("social_shares", social_shares)
 
             # Team Size
             set_config("team_size", team_size)

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -20,6 +20,9 @@ def test_share_endpoints():
         register_user(app)
         gen_solve(app.db, user_id=2, challenge_id=chal_id)
 
+        # social_shares are enabled by default now
+        set_config("social_shares", False)
+
         # Test disabled shares dont work
         with login_as_user(app) as client:
             r = client.post(


### PR DESCRIPTION
* Allow admins to control the template that is shown when users click share links
* Enable social shares by default
* Closes #2802