### PR TITLE
Add __iter__ to ChallengeResponse so that the previous tuple behavior fallback still works

### DIFF
--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -30,6 +30,7 @@ class ChallengeResponse:
 
     def __iter__(self):
         """Allow tuple-like unpacking for backwards compatibility."""
+        # TODO: CTFd 4.0 remove this behavior as we should move away from the tuple strategy
         yield (True if self.status == "correct" else False)
         yield self.message
 


### PR DESCRIPTION
* Add `__iter__` to ChallengeResponse so that the previous tuple behavior fallback still works