### PR TITLE
Update mirror-core-theme.yml

### DIFF
--- a/.github/workflows/mirror-core-theme.yml
+++ b/.github/workflows/mirror-core-theme.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches: 
       - main
-    paths:
-      - 'CTFd/themes/core/**'
+  workflow_dispatch:
 
 jobs:
   mirror:


### PR DESCRIPTION
Seems like this is the only way to get the action to run on squash merge. We can also just manually trigger. 