### PR TITLE
feat: Allow deployment to specify RUN_ID environment variable 

### DIFF
--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -60,15 +60,15 @@ class CTFdFlask(Flask):
         # Store server start time
         self.start_time = datetime.datetime.utcnow()
 
-        # Create time-based unique run identifier
-        time_based_run_id = sha256(str(self.start_time))[0:8]
+        # Create time-based run identifier
+        self.time_based_run_id = sha256(
+            str(round(self.start_time.timestamp() / 60) * 60)
+        )[0:8]
 
-        if self.debug:
-            # When in debug we want a new run_id each time worker starts
-            self.run_id = time_based_run_id
-        else:
-            # use RUN_ID if exists, otherwise fall back to time_based_run_in
-            self.run_id = os.getenv("RUN_ID", time_based_run_id)
+    @property
+    def run_id(self):
+        # use RUN_ID if exists, otherwise fall back to time_based_run_in
+        return self.config.get("RUN_ID") or self.time_based_run_id
 
     def create_jinja_environment(self):
         """Overridden jinja environment constructor"""

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -55,12 +55,20 @@ class CTFdFlask(Flask):
         self.session_interface = CachingSessionInterface(key_prefix="session")
         self.request_class = CTFdRequest
 
+        Flask.__init__(self, *args, **kwargs)
+
         # Store server start time
         self.start_time = datetime.datetime.utcnow()
 
-        # Create generally unique run identifier
-        self.run_id = sha256(str(self.start_time))[0:8]
-        Flask.__init__(self, *args, **kwargs)
+        # Create time-based unique run identifier
+        time_based_run_id = sha256(str(self.start_time))[0:8]
+
+        if self.debug:
+            # When in debug we want a new run_id each time worker starts
+            self.run_id = time_based_run_id
+        else:
+            # use RUN_ID if exists, otherwise fall back to time_based_run_in
+            self.run_id = os.getenv("RUN_ID", time_based_run_id)
 
     def create_jinja_environment(self):
         """Overridden jinja environment constructor"""

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -60,10 +60,14 @@ class CTFdFlask(Flask):
         # Store server start time
         self.start_time = datetime.datetime.utcnow()
 
-        # Create time-based run identifier
-        self.time_based_run_id = sha256(
-            str(round(self.start_time.timestamp() / 60) * 60)
-        )[0:8]
+        # Create time-based run identifier.
+        # In production round the timestamp to incrase chances that workers get the same run_id
+        if self.debug:
+            time_based_run_id = str(self.start_time)
+        else:
+            time_based_run_id = str(round(self.start_time.timestamp() / 60) * 60)
+
+        self.time_based_run_id = sha256(time_based_run_id)[0:8]
 
     @property
     def run_id(self):

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -271,6 +271,11 @@ UPDATE_CHECK =
 # Example: /ctfd
 APPLICATION_ROOT =
 
+# RUN_ID
+# Specifies an identifier that can be used to cache bust between deployments
+# If not set, CTFd will default to an time-based identifier
+RUN_ID =
+
 # SERVER_SENT_EVENTS
 # Specifies whether or not to enable the Server-Sent Events based Notifications system.
 # Defaults to true

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -243,6 +243,8 @@ class ServerConfig(object):
 
     APPLICATION_ROOT: str = empty_str_cast(config_ini["optional"]["APPLICATION_ROOT"], default="/")
 
+    RUN_ID: str = empty_str_cast(config_ini["optional"].get("RUN_ID"), default=None)
+
     SERVER_SENT_EVENTS: bool = process_boolean_str(empty_str_cast(config_ini["optional"]["SERVER_SENT_EVENTS"], default=True))
 
     HTML_SANITIZATION: bool = process_boolean_str(empty_str_cast(config_ini["optional"]["HTML_SANITIZATION"], default=False))


### PR DESCRIPTION
Allow deployments to specify a `RUN_ID` environment variable so that all workers will use the same run_id for cache busting (see #2681).

Logic is:

- If in debug mode, use prior behavior run_id (time-based)
- Otherwise, if RUN_ID environment variable is set, use that, otherwise fall back to time-based.

Should be backward compatible but allow deployments to specify a RUN_ID.
