### PR TITLE
Update pytest packages

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -1,16 +1,16 @@
 -r requirements.txt
 pip-tools==5.4.0
-pytest==7.3.1
-pytest-randomly==3.12.0
-coverage==7.2.3
+pytest==8.4.2
+pytest-randomly==4.0.1
+coverage==7.10.7
 psycopg2-binary==2.9.6
 moto==4.1.11
 bandit==1.6.2
 flask_profiler==1.8.1
-pytest-xdist==3.2.1
-pytest-cov==4.0.0
+pytest-xdist==3.8.0
+pytest-cov==7.0.0
 sphinx_rtd_theme==0.4.3
 flask-debugtoolbar==0.11.0
 Faker==4.1.0
 pipdeptree==2.2.0
-pytest-sugar==0.9.7
+pytest-sugar==1.1.1


### PR DESCRIPTION
Pytest packages are out of date.
There are many warning like:

```log
site-packages/_pytest/assertion/rewrite.py:965: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
  inlocs = ast.Compare(ast.Str(name.id), [ast.In()], [locs])
```

or

```log
site-packages/_pytest/assertion/rewrite.py:941: DeprecationWarning: ast.NameConstant is deprecated and will be removed in Python 3.14; use ast.Constant instead
  clear = ast.Assign(variables, ast.NameConstant(None))
```