### PR TITLE
Add EXTRA_CONFIGS_FORCE_TYPES config to force extra config types

### DIFF
--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -304,6 +304,13 @@ SQLALCHEMY_POOL_PRE_PING =
 # Defaults to false
 EMAIL_CONFIRMATION_REQUIRE_INTERACTION =
 
+# EXTRA_CONFIGS_FORCE_TYPES = 
+# Specifies config keys that will always be treated as a specific type
+# Can help with situations where CTFd's extra config processing is resulting in errors
+# Supported types are str, int, float, bool
+# Provide as CONFIG1=type,CONFIG2=type,CONFIG3=type
+EXTRA_CONFIGS_FORCE_TYPES =
+
 # SAFE_MODE
 # If SAFE_MODE is enabled, CTFd will not load any plugins which may alleviate issues preventing CTFd from starting
 # Defaults to false


### PR DESCRIPTION
* Add `EXTRA_CONFIGS_FORCE_TYPES` config to allow server admins to force types for configs specified in the `[extra]` section