### PR TITLE
Turn docker-entrypoint.sh POSIX compliance

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
-WORKERS=${WORKERS:-1}
-WORKER_CLASS=${WORKER_CLASS:-gevent}
-ACCESS_LOG=${ACCESS_LOG:--}
-ERROR_LOG=${ERROR_LOG:--}
-WORKER_TEMP_DIR=${WORKER_TEMP_DIR:-/dev/shm}
-SECRET_KEY=${SECRET_KEY:-}
-SKIP_DB_PING=${SKIP_DB_PING:-false}
+WORKERS="${WORKERS:-1}"
+WORKER_CLASS="${WORKER_CLASS:-gevent}"
+ACCESS_LOG="${ACCESS_LOG:--}"
+ERROR_LOG="${ERROR_LOG:--}"
+WORKER_TEMP_DIR="${WORKER_TEMP_DIR:-/dev/shm}"
+SECRET_KEY="${SECRET_KEY:-}"
+SKIP_DB_PING="${SKIP_DB_PING:-false}"
 
 # Check that a .ctfd_secret_key file or SECRET_KEY envvar is set
 if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
-    if [ $WORKERS -gt 1 ]; then
+    if [ "$WORKERS" -gt 1 ]; then
         echo "[ ERROR ] You are configured to use more than 1 worker."
         echo "[ ERROR ] To do this, you must define the SECRET_KEY environment variable or create a .ctfd_secret_key file."
         echo "[ ERROR ] Exiting..."
@@ -19,10 +19,10 @@ if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
     fi
 fi
 
-# Skip db ping if SKIP_DB_PING is set to a value other than false or empty string
-if [[ "$SKIP_DB_PING" == "false" ]]; then
-  # Ensures that the database is available
-  python ping.py
+# Run db ping only if SKIP_DB_PING is 'false'
+if [ "$SKIP_DB_PING" = "false" ]; then
+    # Ensures that the database is available
+    python ping.py
 fi
 
 # Initialize database
@@ -32,7 +32,7 @@ flask db upgrade
 echo "Starting CTFd"
 exec gunicorn 'CTFd:create_app()' \
     --bind '0.0.0.0:8000' \
-    --workers $WORKERS \
+    --workers "$WORKERS" \
     --worker-tmp-dir "$WORKER_TEMP_DIR" \
     --worker-class "$WORKER_CLASS" \
     --access-logfile "$ACCESS_LOG" \


### PR DESCRIPTION
This PR updates the docker-entrypoint.sh script to ensure POSIX compliance and compatibility across different shell environments (sh, ash, bash) on both Alpine and Debian.

Key changes include:

Shebang updated: #!/bin/sh to maximize portability across minimal container environments.
Removed pipefail: The previous set -euo pipefail included pipefail, which is not supported in ash and had no practical use in this script.
POSIX compliance: Adjusted variable handling and conditional checks to work reliably in both POSIX shells and Bash.
Compatibility ensured: The script now works correctly in sh (Debian/Dash, Alpine/Ash) and bash environments.
No functional changes were introduced beyond shell compatibility. All original behaviors, environment variable defaults, and error handling remain intact.
