### PR TITLE
Fix: Do not check CSRF for static theme content

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -354,6 +354,7 @@ def init_request_processors(app):
 
     @app.before_request
     def csrf():
+        # TODO: CTFd 4.0 Consider reorganizing this function to only run on non safe methods
         # Early exit: no CSRF for functions explicitly marked as bypassing CSRF
         try:
             func = app.view_functions[request.endpoint]


### PR DESCRIPTION
Hi,

We have been running CTFd (thanks for the great project!) behind a reverse proxy for our CTF. To reduce load on the backend, we enabled caching in the reverse proxy to serve static cacheable content directly from the reverse proxy.

Unfortunately, this caused hard to debug issues where sometimes users would get logged in as different users (in a non-reproducible manner). We've narrowed it down to CTFd setting the `Set-Cookie` header even for static content. This caused the same header being served to users as long as it's in the cache and therefore sessions getting mixed up.

Flask only sets the header if the session has been modified. The only place a session for the static themes is modified is in the CSRF `before_request` hook. By returning early from the hook if the request is for static theme content, the session object is not modified and Flask doesn't add the header, therefore making static theme content cacheable without issues.

Note that the probably even cleaner fix would be to return from the CSRF check for all `GET`/`HEAD`/... requests but I didn't know whether that could cause issues further down the line.

Cheers,
Florian