### PR TITLE
fixed problem with multiple parallel transactions failing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     networks:
         internal:
     # This command is required to set important mariadb defaults
-    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0]
+    command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --wait_timeout=28800, --log-warnings=0, --transaction-isolation=READ-COMMITTED]
 
   cache:
     image: redis:4


### PR DESCRIPTION
This is a fix to allow multiple transactions from different threads of the web server.

This problem is common when selecting multiple challenges on the admin panel and selecting to make them hidden/visible all at the same time. In most cases, half of them would fail.