### PR TITLE
Add for_each challenge logic

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -254,6 +254,7 @@ class ChallengeList(Resource):
             ),
         },
     )
+    
     def post(self):
         data = request.form or request.get_json()
 

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -243,6 +243,7 @@ class ChallengeList(Resource):
 
         db.session.close()
         return {"success": True, "data": response}
+
     @admins_only
     @challenges_namespace.doc(
         description="Endpoint to create a Challenge object",
@@ -254,7 +255,7 @@ class ChallengeList(Resource):
             ),
         },
     )
-    
+
     def post(self):
         data = request.form or request.get_json()
 

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -244,6 +244,7 @@ class ChallengeList(Resource):
         db.session.close()
 
         return {"success": True, "data": response}
+
     @admins_only
     @challenges_namespace.doc(
         description="Endpoint to create a Challenge object",

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -243,7 +243,6 @@ class ChallengeList(Resource):
 
         db.session.close()
         return {"success": True, "data": response}
-
     @admins_only
     @challenges_namespace.doc(
         description="Endpoint to create a Challenge object",

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -1289,3 +1289,4 @@ class ChallengeSolution(Resource):
         response["id"] = solution_id
         response["state"] = solution_state
         return {"success": True, "data": response}
+

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -242,8 +242,8 @@ class ChallengeList(Resource):
             )
 
         db.session.close()
-        return {"success": True, "data": response}
 
+        return {"success": True, "data": response}
     @admins_only
     @challenges_namespace.doc(
         description="Endpoint to create a Challenge object",
@@ -255,7 +255,6 @@ class ChallengeList(Resource):
             ),
         },
     )
-
     def post(self):
         data = request.form or request.get_json()
 
@@ -1290,4 +1289,3 @@ class ChallengeSolution(Resource):
         response["id"] = solution_id
         response["state"] = solution_state
         return {"success": True, "data": response}
-

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -243,6 +243,7 @@ class ChallengeList(Resource):
 
         db.session.close()
         return {"success": True, "data": response}
+
     @admins_only
     @challenges_namespace.doc(
         description="Endpoint to create a Challenge object",

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -12,6 +12,7 @@ from CTFd.models import (
     Awards,
     ChallengeFiles,
     Challenges,
+    db,
     Fails,
     Flags,
     Hints,
@@ -20,7 +21,6 @@ from CTFd.models import (
     Solves,
     Submissions,
     Tags,
-    db,
 )
 from CTFd.plugins import register_plugin_assets_directory
 from CTFd.plugins.challenges.decay import DECAY_FUNCTIONS, logarithmic

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -26,6 +26,7 @@ from CTFd.plugins.challenges.logic import (
     challenge_attempt_all,
     challenge_attempt_any,
     challenge_attempt_team,
+    challenge_attempt_for_each,
 )
 from CTFd.utils.uploads import delete_file
 from CTFd.utils.user import get_ip
@@ -208,6 +209,8 @@ class BaseChallenge(object):
             return challenge_attempt_all(submission, challenge, flags)
         elif challenge.logic == "team":
             return challenge_attempt_team(submission, challenge, flags)
+        elif challenge.logic == "for_each":  # <- new
+            return challenge_attempt_for_each(submission, challenge, flags)
         else:
             return challenge_attempt_any(submission, challenge, flags)
 

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -12,7 +12,6 @@ from CTFd.models import (
     Awards,
     ChallengeFiles,
     Challenges,
-    db,
     Fails,
     Flags,
     Hints,
@@ -21,6 +20,7 @@ from CTFd.models import (
     Solves,
     Submissions,
     Tags,
+    db,
 )
 from CTFd.plugins import register_plugin_assets_directory
 from CTFd.plugins.challenges.decay import DECAY_FUNCTIONS, logarithmic

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -273,8 +273,9 @@ class BaseChallenge(object):
 
             existing = Submissions.query.filter_by(**filters).first()
             if existing:
-                return ChallengeResponse(status="duplicate", message="You already submitted this flag")
-
+                return ChallengeResponse(
+                    status="duplicate", message="You already submitted this flag"
+                )
 
             # Record the submission for audit
             sub = Submissions(

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -273,10 +273,7 @@ class BaseChallenge(object):
 
             existing = Submissions.query.filter_by(**filters).first()
             if existing:
-                return ChallengeResponse(
-                    status="duplicate",
-                    message="You already submitted this flag"
-                )
+                return ChallengeResponse(status="duplicate", message="You already submitted this flag")
 
 
             # Record the submission for audit

--- a/CTFd/themes/admin/templates/challenges/update.html
+++ b/CTFd/themes/admin/templates/challenges/update.html
@@ -141,6 +141,7 @@
 			<option value="any" {% if challenge.logic == "any" or not challenge.logic %}selected{% endif %}>Require Any Flag</option>
 			<option value="all" {% if challenge.logic == "all" %}selected{% endif %}>Require All Flags</option>
 			<option value="team" {% if challenge.logic == "team" %}selected{% endif %}>Require Any Flags by All Team Members</option>
+			<option value="for_each" {% if challenge.logic == "for_each" %}selected{% endif %}>Require All Flags, Points Per Submission</option>
 		</select>
 	</div>
 	{% endblock %}


### PR DESCRIPTION
Added a logic function that works for each flag submission.

It functions like the all flag required logic function but has a different working upon the partial answer,
it uses an award to give point matching the challenge points.

the logic function works for individual scoring and grants point for teams as well.
duplicate answers for teams are allowed

