### PR TITLE
Allow envvars for variables not set in config.ini

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -15,7 +15,7 @@ class EnvInterpolation(configparser.BasicInterpolation):
     def before_get(self, parser, section, option, value, defaults):
         value = super().before_get(parser, section, option, value, defaults)
         envvar = os.getenv(option)
-        if value == "" and envvar:
+        if not value and envvar:
             return process_string_var(envvar, key=option)
         else:
             return value


### PR DESCRIPTION
One thing I've run into constantly when writing plugins is that `CTFd.utils.get_app_config` returns None if the key is not in the ini file, even if it is set as an environment variable. This forces each plugin to implement their way around this, if they want to support it. For example:

```python
import os
from CTFd.utils import get_app_config as utils_get_app_config

def get_app_config (key):
    value = utils_get_app_config(key)
    if not value:
        value = os.getenv(key)
    return value
```

The way I run CTFd is containerized in ECS. I do all my configuration in environment variables, and do not wish to mess with the ini file within the container. This should be a quite common way of doing things.

So, when writing plugins that want to utilize the built in function for fetching configuration from the ini-file or the environment variables, I also have to force the user to fiddle in the ini file, even if they plan on using environment variables. I don't think this is a very pretty solution, and I don't think CTFd should rely on each plugin to circumvent this.

By allowing CTFd to look for configuration in environment variables even if they are not set in config.ini, we simplify running CTFd containerized in ECS, Kubernetes or similar environments.