### PR TITLE
Fix: Add string filter to ctf_theme in admin template (fixes #2902)

### DIFF
--- a/CTFd/themes/admin/templates/configs/theme.html
+++ b/CTFd/themes/admin/templates/configs/theme.html
@@ -6,7 +6,7 @@
 					<h5 class="modal-title">Theme Settings</h5>
 				</div>
 				<div class="modal-body">
-				{% include ctf_theme + "/config.html" ignore missing %}
+				{% include (ctf_theme|string) + "/config.html" ignore missing %}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Description
Fixes #2902 

When a theme name consists only of numeric characters (e.g., `486`), the admin theme configuration template raises a `TypeError` due to string concatenation in Jinja2.

## Cause
The template attempts to concatenate `ctf_theme` with a string path:

    {% include ctf_theme + "/config.html" ignore missing %}

If `ctf_theme` is not treated as a string, Jinja2 fails during concatenation.

## Fix
Explicitly convert `ctf_theme` to string:

    {% include (ctf_theme|string) + "/config.html" ignore missing %}

## Testing
- Verified numeric-only theme names
- Verified existing themes still work
