### PR TITLE
Replace request content_type check with is_json

### DIFF
--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -73,7 +73,7 @@ def require_verified_emails(f):
                     current_user.is_admin() is False
                     and current_user.is_verified() is False
                 ):  # User is not confirmed
-                    if request.content_type == "application/json":
+                    if request.is_json():
                         abort(403)
                     else:
                         return redirect(url_for("auth.confirm"))
@@ -95,7 +95,7 @@ def authed_only(f):
             return f(*args, **kwargs)
         else:
             if (
-                request.content_type == "application/json"
+                request.is_json()
                 or request.accept_mimetypes.best == "text/event-stream"
             ):
                 abort(403)
@@ -118,7 +118,7 @@ def registered_only(f):
             return f(*args, **kwargs)
         else:
             if (
-                request.content_type == "application/json"
+                request.is_json()
                 or request.accept_mimetypes.best == "text/event-stream"
             ):
                 abort(403)
@@ -140,7 +140,7 @@ def admins_only(f):
         if is_admin():
             return f(*args, **kwargs)
         else:
-            if request.content_type == "application/json":
+            if request.is_json():
                 abort(403)
             else:
                 return redirect(url_for("auth.login", next=request.full_path))
@@ -154,7 +154,7 @@ def require_team(f):
         if is_teams_mode():
             team = get_current_team()
             if team is None:
-                if request.content_type == "application/json":
+                if request.is_json():
                     abort(403)
                 else:
                     return redirect(url_for("teams.private", next=request.full_path))

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -73,7 +73,7 @@ def require_verified_emails(f):
                     current_user.is_admin() is False
                     and current_user.is_verified() is False
                 ):  # User is not confirmed
-                    if request.is_json():
+                    if request.is_json:
                         abort(403)
                     else:
                         return redirect(url_for("auth.confirm"))
@@ -95,7 +95,7 @@ def authed_only(f):
             return f(*args, **kwargs)
         else:
             if (
-                request.is_json()
+                request.is_json
                 or request.accept_mimetypes.best == "text/event-stream"
             ):
                 abort(403)
@@ -118,7 +118,7 @@ def registered_only(f):
             return f(*args, **kwargs)
         else:
             if (
-                request.is_json()
+                request.is_json
                 or request.accept_mimetypes.best == "text/event-stream"
             ):
                 abort(403)
@@ -140,7 +140,7 @@ def admins_only(f):
         if is_admin():
             return f(*args, **kwargs)
         else:
-            if request.is_json():
+            if request.is_json:
                 abort(403)
             else:
                 return redirect(url_for("auth.login", next=request.full_path))
@@ -154,7 +154,7 @@ def require_team(f):
         if is_teams_mode():
             team = get_current_team()
             if team is None:
-                if request.is_json():
+                if request.is_json:
                     abort(403)
                 else:
                     return redirect(url_for("teams.private", next=request.full_path))

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -94,10 +94,7 @@ def authed_only(f):
         if authed():
             return f(*args, **kwargs)
         else:
-            if (
-                request.is_json
-                or request.accept_mimetypes.best == "text/event-stream"
-            ):
+            if request.is_json or request.accept_mimetypes.best == "text/event-stream":
                 abort(403)
             else:
                 return redirect(url_for("auth.login", next=request.full_path))
@@ -117,10 +114,7 @@ def registered_only(f):
         if authed():
             return f(*args, **kwargs)
         else:
-            if (
-                request.is_json
-                or request.accept_mimetypes.best == "text/event-stream"
-            ):
+            if request.is_json or request.accept_mimetypes.best == "text/event-stream":
                 abort(403)
             else:
                 return redirect(url_for("auth.register", next=request.full_path))

--- a/CTFd/utils/decorators/visibility.py
+++ b/CTFd/utils/decorators/visibility.py
@@ -24,7 +24,7 @@ def check_score_visibility(f):
             if authed():
                 return f(*args, **kwargs)
             else:
-                if request.is_json():
+                if request.is_json:
                     abort(403)
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))
@@ -33,7 +33,7 @@ def check_score_visibility(f):
             if is_admin():
                 return f(*args, **kwargs)
             else:
-                if request.is_json():
+                if request.is_json:
                     abort(403)
                 else:
                     return (
@@ -63,7 +63,7 @@ def check_challenge_visibility(f):
             if authed():
                 return f(*args, **kwargs)
             else:
-                if request.is_json():
+                if request.is_json:
                     abort(403)
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))
@@ -73,7 +73,7 @@ def check_challenge_visibility(f):
                 return f(*args, **kwargs)
             else:
                 if authed():
-                    if request.is_json():
+                    if request.is_json:
                         abort(403)
                     else:
                         abort(
@@ -97,7 +97,7 @@ def check_account_visibility(f):
             if authed():
                 return f(*args, **kwargs)
             else:
-                if request.is_json():
+                if request.is_json:
                     abort(403)
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))

--- a/CTFd/utils/decorators/visibility.py
+++ b/CTFd/utils/decorators/visibility.py
@@ -24,7 +24,7 @@ def check_score_visibility(f):
             if authed():
                 return f(*args, **kwargs)
             else:
-                if request.content_type == "application/json":
+                if request.is_json():
                     abort(403)
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))
@@ -33,7 +33,7 @@ def check_score_visibility(f):
             if is_admin():
                 return f(*args, **kwargs)
             else:
-                if request.content_type == "application/json":
+                if request.is_json():
                     abort(403)
                 else:
                     return (
@@ -63,7 +63,7 @@ def check_challenge_visibility(f):
             if authed():
                 return f(*args, **kwargs)
             else:
-                if request.content_type == "application/json":
+                if request.is_json():
                     abort(403)
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))
@@ -73,7 +73,7 @@ def check_challenge_visibility(f):
                 return f(*args, **kwargs)
             else:
                 if authed():
-                    if request.content_type == "application/json":
+                    if request.is_json():
                         abort(403)
                     else:
                         abort(
@@ -97,7 +97,7 @@ def check_account_visibility(f):
             if authed():
                 return f(*args, **kwargs)
             else:
-                if request.content_type == "application/json":
+                if request.is_json():
                     abort(403)
                 else:
                     return redirect(url_for("auth.login", next=request.full_path))

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -385,7 +385,7 @@ def init_request_processors(app):
                 # API requests with JSON body => token in header
                 if session["nonce"] != request.headers.get("CSRF-Token"):
                     abort(403)
-            if not request.is_json:
+            else:
                 # Form submissions => token in form body
                 if session["nonce"] != request.form.get("nonce"):
                     abort(403)

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -332,7 +332,7 @@ def init_request_processors(app):
     def tokens():
         token = request.headers.get("Authorization")
         if token and (
-            request.is_json()
+            request.is_json
             # Specially allow multipart/form-data for file uploads
             or (
                 request.endpoint == "api.files_files_list"
@@ -381,7 +381,7 @@ def init_request_processors(app):
         if not session.get("nonce"):
             session["nonce"] = generate_nonce()
         if request.method not in safe_methods:
-            if request.is_json():
+            if request.is_json:
                 # API requests with JSON body => token in header
                 if session["nonce"] != request.headers.get("CSRF-Token"):
                     abort(403)

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -332,7 +332,7 @@ def init_request_processors(app):
     def tokens():
         token = request.headers.get("Authorization")
         if token and (
-            request.mimetype == "application/json"
+            request.is_json()
             # Specially allow multipart/form-data for file uploads
             or (
                 request.endpoint == "api.files_files_list"
@@ -381,7 +381,7 @@ def init_request_processors(app):
         if not session.get("nonce"):
             session["nonce"] = generate_nonce()
         if request.method not in safe_methods:
-            if request.content_type == "application/json":
+            if request.is_json():
                 # API requests with JSON body => token in header
                 if session["nonce"] != request.headers.get("CSRF-Token"):
                     abort(403)

--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -385,7 +385,7 @@ def init_request_processors(app):
                 # API requests with JSON body => token in header
                 if session["nonce"] != request.headers.get("CSRF-Token"):
                     abort(403)
-            if request.content_type != "application/json":
+            if not request.is_json:
                 # Form submissions => token in form body
                 if session["nonce"] != request.form.get("nonce"):
                     abort(403)

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -24,7 +24,7 @@ def get_current_user():
         if session_hash:
             if session_hash != hmac(user.password):
                 logout_user()
-                if request.is_json():
+                if request.is_json:
                     error = 401
                 else:
                     error = redirect(url_for("auth.login", next=request.full_path))

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -24,7 +24,7 @@ def get_current_user():
         if session_hash:
             if session_hash != hmac(user.password):
                 logout_user()
-                if request.content_type == "application/json":
+                if request.is_json():
                     error = 401
                 else:
                     error = redirect(url_for("auth.login", next=request.full_path))


### PR DESCRIPTION
Currently, if a user sends a request with the Content-Type `application/json;charset=utf-8`, the `request.content_type == "application/json"` check fails. This PR aims to make the check more robust by simply replacing all such checks with `request.is_json`.