### PR TITLE
Mark 3.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 3.8.4 / 2026-04-20
+
+**Security**
+
+- Fix issue where partially attacker controlled links could be served to other users possibly resulting in arbitrary JavaScript execution if those links are clicked
+- Fix issue where the safe URL redirect validator could be bypassed possibly allowing an attacker the ability to phish other users
+
+**Deployment**
+
+- The `REVERSE_PROXY` config when set to `true` will now default to `1,1,1,1,0` instead of `1,1,1,1,1`
+- Update Pillow version to 12.2.0
+- Update mako version to 1.3.11
+
 # 3.8.3 / 2026-04-10
 
 **General**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -33,7 +33,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.8.3"
+__version__ = "3.8.4"
 __channel__ = "oss"
 
 


### PR DESCRIPTION
# 3.8.4 / 2026-04-20

**Security**

- Fix issue where partially attacker controlled links could be served to other users possibly resulting in arbitrary JavaScript execution if those links are clicked
- Fix issue where the safe URL redirect validator could be bypassed possibly allowing an attacker the ability to phish other users

**Deployment**

- The `REVERSE_PROXY` config when set to `true` will now default to `1,1,1,1,0` instead of `1,1,1,1,1`
- Update Pillow version to 12.2.0
- Update mako version to 1.3.11