### PR TITLE
fix rare 500 on users create

### DIFF
--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -2,7 +2,6 @@ from typing import List
 
 from flask import abort, request, session
 from flask_restx import Namespace, Resource
-from sqlalchemy.exc import IntegrityError
 
 from CTFd.api.v1.helpers.request import validate_args
 from CTFd.api.v1.helpers.schemas import sqlalchemy_to_pydantic
@@ -172,20 +171,7 @@ class UserList(Resource):
             return {"success": False, "errors": response.errors}, 400
 
         db.session.add(response.data)
-        try:
-            db.session.commit()
-        except IntegrityError:
-            db.session.rollback()
-            return (
-                {
-                    "success": False,
-                    "errors": {
-                        "email": ["A user with this name or email already exists"],
-                        "name": ["A user with this name or email already exists"],
-                    },
-                },
-                400,
-            )
+        db.session.commit()
 
         if request.args.get("notify"):
             name = response.data.name

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -2,6 +2,7 @@ from typing import List
 
 from flask import abort, request, session
 from flask_restx import Namespace, Resource
+from sqlalchemy.exc import IntegrityError
 
 from CTFd.api.v1.helpers.request import validate_args
 from CTFd.api.v1.helpers.schemas import sqlalchemy_to_pydantic
@@ -171,7 +172,20 @@ class UserList(Resource):
             return {"success": False, "errors": response.errors}, 400
 
         db.session.add(response.data)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return (
+                {
+                    "success": False,
+                    "errors": {
+                        "email": ["A user with this name or email already exists"],
+                        "name": ["A user with this name or email already exists"],
+                    },
+                },
+                400,
+            )
 
         if request.args.get("notify"):
             name = response.data.name

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -68,7 +68,7 @@ class UserSchema(ma.ModelSchema):
         existing_user = Users.query.filter_by(name=name).first()
         current_user = get_current_user()
         if is_admin():
-            user_id = data.get("id")
+            user_id = data.get("id") or (self.instance.id if self.instance else None)
             if user_id:
                 if existing_user and existing_user.id != user_id:
                     raise ValidationError(
@@ -76,15 +76,9 @@ class UserSchema(ma.ModelSchema):
                     )
             else:
                 if existing_user:
-                    if current_user:
-                        if current_user.id != existing_user.id:
-                            raise ValidationError(
-                                "User name has already been taken", field_names=["name"]
-                            )
-                    else:
-                        raise ValidationError(
-                            "User name has already been taken", field_names=["name"]
-                        )
+                    raise ValidationError(
+                        "User name has already been taken", field_names=["name"]
+                    )
         else:
             if name == current_user.name:
                 return data
@@ -109,7 +103,7 @@ class UserSchema(ma.ModelSchema):
         existing_user = Users.query.filter_by(email=email).first()
         current_user = get_current_user()
         if is_admin():
-            user_id = data.get("id")
+            user_id = data.get("id") or (self.instance.id if self.instance else None)
             if user_id:
                 if existing_user and existing_user.id != user_id:
                     raise ValidationError(
@@ -117,16 +111,9 @@ class UserSchema(ma.ModelSchema):
                     )
             else:
                 if existing_user:
-                    if current_user:
-                        if current_user.id != existing_user.id:
-                            raise ValidationError(
-                                "Email address has already been used",
-                                field_names=["email"],
-                            )
-                    else:
-                        raise ValidationError(
-                            "Email address has already been used", field_names=["email"]
-                        )
+                    raise ValidationError(
+                        "Email address has already been used", field_names=["email"]
+                    )
         else:
             if email == current_user.email:
                 return data

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -68,7 +68,10 @@ class UserSchema(ma.ModelSchema):
         existing_user = Users.query.filter_by(name=name).first()
         current_user = get_current_user()
         if is_admin():
-            user_id = data.get("id") or (self.instance.id if self.instance else None)
+            # Set to the user_id we are targetting or the instance id for self updates
+            user_id = data.get("id")
+            if user_id is None and self.instance:
+                user_id = self.instance.id
             if user_id:
                 if existing_user and existing_user.id != user_id:
                     raise ValidationError(
@@ -103,7 +106,10 @@ class UserSchema(ma.ModelSchema):
         existing_user = Users.query.filter_by(email=email).first()
         current_user = get_current_user()
         if is_admin():
-            user_id = data.get("id") or (self.instance.id if self.instance else None)
+            # Set to the user_id we are targetting or the instance id for self updates
+            user_id = data.get("id")
+            if user_id is None and self.instance:
+                user_id = self.instance.id
             if user_id:
                 if existing_user and existing_user.id != user_id:
                     raise ValidationError(

--- a/tests/api/v1/test_users.py
+++ b/tests/api/v1/test_users.py
@@ -174,6 +174,28 @@ def test_api_users_post_admin_duplicate_information():
     destroy_ctfd(app)
 
 
+def test_api_users_post_admin_duplicate_admin_email():
+    """Creating a user with an email matching the calling admin's returns 400, not 500"""
+    app = create_ctfd()
+    with app.app_context():
+        admin = Users.query.filter_by(id=1).first()
+        with login_as_user(app, "admin") as client:
+            r = client.post(
+                "/api/v1/users",
+                json={
+                    "name": "newuser",
+                    "email": admin.email,
+                    "password": "password",
+                },
+            )
+            assert r.status_code == 400
+            resp = r.get_json()
+            assert resp["success"] is False
+            assert resp["errors"]
+            assert Users.query.count() == 1
+    destroy_ctfd(app)
+
+
 def test_api_users_patch_admin_duplicate_information():
     """Can an admin modify a user with duplicate information"""
     app = create_ctfd()

--- a/tests/users/test_users.py
+++ b/tests/users/test_users.py
@@ -149,3 +149,26 @@ def test_num_users_limit():
             assert r.status_code == 302
             assert Users.query.count() == 3
     destroy_ctfd(app)
+
+
+def test_api_users_post_admin_duplicate_admin_name():
+    """Creating a user with a name matching the calling admin's returns 400, not 500"""
+    app = create_ctfd()
+    with app.app_context():
+        admin = Users.query.filter_by(id=1).first()
+        admin_name = admin.name
+        with login_as_user(app, "admin") as client:
+            r = client.post(
+                "/api/v1/users",
+                json={
+                    "name": admin_name,
+                    "email": "admin2@examplectf.com",
+                    "password": "password",
+                },
+            )
+            assert r.status_code == 400
+            resp = r.get_json()
+            assert resp["success"] is False
+            assert resp["errors"]
+            assert Users.query.count() == 1
+    destroy_ctfd(app)


### PR DESCRIPTION
Creating a user via the API can cause a 500 error in a rare scenario where the email is a duplicate of the caller's email. Catch the error properly and return a 400 instead of 500.