### PR TITLE
Add user status filter to admin users page

### DIFF
--- a/CTFd/admin/users.py
+++ b/CTFd/admin/users.py
@@ -13,6 +13,7 @@ from CTFd.utils.modes import TEAMS_MODE
 def users_listing():
     q = request.args.get("q")
     field = request.args.get("field")
+    status = request.args.get("status")
     page = abs(request.args.get("page", 1, type=int))
     filters = []
     users = []
@@ -22,10 +23,22 @@ def users_listing():
         if Users.__mapper__.has_property(field):
             filters.append(getattr(Users, field).like("%{}%".format(q)))
 
+    # Apply status filters
+    if status == "active":
+        filters.append(Users.banned == False)
+        filters.append(Users.hidden == False)
+    elif status == "banned":
+        filters.append(Users.banned == True)
+    elif status == "hidden":
+        filters.append(Users.hidden == True)
+    elif status == "unverified":
+        filters.append(Users.verified == False)
+
     if q and field == "ip":
         users = (
             Users.query.join(Tracking, Users.id == Tracking.user_id)
             .filter(Tracking.ip.like("%{}%".format(q)))
+            .filter(*filters)
             .order_by(Users.id.asc())
             .paginate(page=page, per_page=50, error_out=False)
         )
@@ -46,6 +59,7 @@ def users_listing():
         next_page=url_for(request.endpoint, page=users.next_num, **args),
         q=q,
         field=field,
+        status=status,
     )
 
 

--- a/CTFd/themes/admin/templates/users/users.html
+++ b/CTFd/themes/admin/templates/users/users.html
@@ -27,6 +27,13 @@
                         <h6 class="text-muted text-center pb-3">
                                 Page {{ users.page }} of {{ users.total }} results
                         </h6>
+                        {% elif status %}
+                        <h5 class="text-muted text-center">
+                                Filtering by status: <strong>{{ status }}</strong>
+                        </h5>
+                        <h6 class="text-muted text-center pb-3">
+                                Page {{ users.page }} of {{ users.total }} results
+                        </h6>
                         {% endif %}
 
                         {% with form = Forms.users.UserSearchForm(field=field, q=q) %}

--- a/CTFd/themes/admin/templates/users/users.html
+++ b/CTFd/themes/admin/templates/users/users.html
@@ -5,170 +5,179 @@
 
 {% block content %}
 <div class="jumbotron">
-	<div class="container">
-		<h1>Users
-			<span class="create-team" role="button" data-toggle="tooltip" title="Create User">
-				<a href="{{ url_for('admin.users_new') }}" style="color: inherit;">
-					<i class="btn-fa fas fa-plus-circle"></i>
-				</a>
-			</span>
-		</h1>
-	</div>
+        <div class="container">
+                <h1>Users
+                        <span class="create-team" role="button" data-toggle="tooltip" title="Create User">
+                                <a href="{{ url_for('admin.users_new') }}" style="color: inherit;">
+                                        <i class="btn-fa fas fa-plus-circle"></i>
+                                </a>
+                        </span>
+                </h1>
+        </div>
 </div>
 
 <div class="container">
 
-	<div class="row">
-		<div class="col-md-12">
-			{% if q and field %}
-			<h5 class="text-muted text-center">
-				Searching for users with <strong>{{ field }}</strong> matching <strong>{{ q }}</strong>
-			</h5>
-			<h6 class="text-muted text-center pb-3">
-				Page {{ users.page }} of {{ users.total }} results
-			</h6>
-			{% endif %}
+        <div class="row">
+                <div class="col-md-12">
+                        {% if q and field %}
+                        <h5 class="text-muted text-center">
+                                Searching for users with <strong>{{ field }}</strong> matching <strong>{{ q }}</strong>
+                        </h5>
+                        <h6 class="text-muted text-center pb-3">
+                                Page {{ users.page }} of {{ users.total }} results
+                        </h6>
+                        {% endif %}
 
-			{% with form = Forms.users.UserSearchForm(field=field, q=q) %}
-			<form method="GET" class="form-inline">
-				<div class="form-group col-md-2">
-					{{ form.field(class="form-control custom-select w-100") }}
-				</div>
-				<div class="form-group col-md-8">
-					{{ form.q(class="form-control w-100", placeholder="Search for matching users") }}
-				</div>
-				<div class="form-group col-md-2">
-					<button type="submit" class="btn btn-primary w-100">
-						<i class="fas fa-search" aria-hidden="true"></i>
-					</button>
-				</div>
-			</form>
-			{% endwith %}
-		</div>
-	</div>
+                        {% with form = Forms.users.UserSearchForm(field=field, q=q) %}
+                        <form method="GET" class="form-inline">
+                                <div class="form-group col-md-2">
+                                        {{ form.field(class="form-control custom-select w-100") }}
+                                </div>
+                                <div class="form-group col-md-6">
+                                        {{ form.q(class="form-control w-100", placeholder="Search for matching users") }}
+                                </div>
+                                <div class="form-group col-md-2">
+                                        <select name="status" class="form-control custom-select w-100">
+                                                <option value="">All Status</option>
+                                                <option value="active" {% if status == 'active' %}selected{% endif %}>Active</option>
+                                                <option value="banned" {% if status == 'banned' %}selected{% endif %}>Banned</option>
+                                                <option value="hidden" {% if status == 'hidden' %}selected{% endif %}>Hidden</option>
+                                                <option value="unverified" {% if status == 'unverified' %}selected{% endif %}>Unverified</option>
+                                        </select>
+                                </div>
+                                <div class="form-group col-md-2">
+                                        <button type="submit" class="btn btn-primary w-100">
+                                                <i class="fas fa-search" aria-hidden="true"></i>
+                                        </button>
+                                </div>
+                        </form>
+                        {% endwith %}
+                </div>
+        </div>
 
-	<hr>
+        <hr>
 
-	<div class="row">
-		<div class="col-md-12">
-			<div class="float-right pb-3">
-				<div class="btn-group" role="group">
-					<button type="button" class="btn btn-outline-secondary" data-toggle="tooltip" title="Edit Users" id="users-edit-button">
-						<i class="btn-fa fas fa-pencil-alt"></i>
-					</button>
-					<button type="button" class="btn btn-outline-danger" data-toggle="tooltip" title="Delete Users" id="users-delete-button">
-						<i class="btn-fa fas fa-trash-alt"></i>
-					</button>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-md-12 table-responsive">
-			<table id="teamsboard" class="table table-striped border">
-				<thead>
-					<tr>
-						<th class="border-right" data-checkbox>
-							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
-							</div>
-						</th>
-						<th class="sort-col text-center"><b>ID</b></th>
-						<th class="sort-col text-center"><b>User</b></th>
-						<th class="sort-col text-center"><b>Email</b></th>
-						<th class="sort-col text-center"><b>Country</b></th>
-						<th class="sort-col text-center px-0"><b>Admin</b></th>
-						<th class="sort-col text-center px-0"><b>Verified</b></th>
-						<th class="sort-col text-center px-0"><b>Hidden</b></th>
-						<th class="sort-col text-center px-0"><b>Banned</b></th>
-					</tr>
-				</thead>
-				<tbody>
-					{% for user in users.items %}
-					<tr name="{{ user.id }}" data-href="{{ url_for('admin.users_detail', user_id=user.id) }}">
-						<td class="border-right" data-checkbox>
-							<div class="form-check text-center">
-								<input type="checkbox" class="form-check-input" autocomplete="off" value="{{ user.id }}" data-user-id="{{ user.id }}">&nbsp;
-							</div>
-						</td>
-						<td class="team-id text-center" value="{{ user.id }}">{{ user.id }}</td>
-						<td class="team-name" value="{{ user.name }}">
-							<a href="{{ url_for('admin.users_detail', user_id=user.id) }}">
-								{{ user.name | truncate(32) }}
-							</a>
-							{% if user.bracket_id %}
-								<span class="badge badge-secondary">{{ user.bracket.name }}</span>
-							{% endif %}
-							{% if user.oauth_id %}
-								<a href="https://majorleaguecyber.org/u/{{ user.name }}">
-									<span class="badge badge-primary">Official</span>
-								</a>
-							{% endif %}
-							{% if user.website %}
-								<a href="{{ user.website }}" target="_blank" class="badge badge-info" rel="noopener">
-									<i class="btn-fa fas fa-external-link-alt" data-toggle="tooltip" data-placement="top"
-									   title="{{ user.website }}" aria-hidden="true"></i>
-								</a>
-							{% endif %}
-							{% if user.affiliation %}
-								<span class="d-block text-muted"><small>{{ user.affiliation | truncate(20) }}</small></span>
-							{% endif %}
-						</td>
-						<td class="team-email d-none d-md-table-cell d-lg-table-cell" value="{{ user.email }}">
-							{% if user.email %}
-								<a href="mailto:{{ user.email }}" target="_blank">{{ user.email | truncate(32) }}</a>
-							{% endif %}
-						</td>
-						<td class="team-country text-center" value="{{ user.country if user.country is not none }}">
-							<span>
-								{% if user.country %}
-									<i class="flag-{{ user.country.lower() }}"></i>
-									<small>{{ lookup_country_code(user.country) }}</small>
-								{% endif %}
-							</span>
-						</td>
-						<td class="team-admin d-md-table-cell d-lg-table-cell text-center" value="{{ user.type }}">
-							{% if user.type == 'admin' %}
-								<span class="badge badge-primary">admin</span>
-							{% endif %}
-						</td>
-						<td class="team-verified d-md-table-cell d-lg-table-cell text-center" value="{{ user.verified }}">
-							{% if user.verified %}
-								<span class="badge badge-success">verified</span>
-							{% endif %}
-						</td>
-						<td class="team-hidden d-md-table-cell d-lg-table-cell text-center" value="{{ user.hidden }}">
-							{% if user.hidden %}
-								<span class="badge badge-danger">hidden</span>
-							{% endif %}
-						</td>
-						<td class="team-banned d-md-table-cell d-lg-table-cell text-center" value="{{ user.banned }}">
-							{% if user.banned %}
-								<span class="badge badge-danger">banned</span>
-							{% endif %}
-						</td>
-					</tr>
-					{% endfor %}
-				</tbody>
-			</table>
-			{% if users.pages > 1 %}
-			<div class="text-center">Page
-				<br>
-				{% if users.page != 1 %}
-				<a href="{{ prev_page }}">&lt;&lt;&lt;</a>
-				{% endif %}
-				<select class="page-select">
-					{% for page in range(1, users.pages + 1) %}
-					<option {% if users.page == page %}selected{% endif %}>{{ page }}</option>
-					{% endfor %}
-				</select>
-				{% if users.next_num %}
-				<a href="{{ next_page }}">&gt;&gt;&gt;</a>
-				{% endif %}
-			</div>
-			{% endif %}
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="float-right pb-3">
+                                <div class="btn-group" role="group">
+                                        <button type="button" class="btn btn-outline-secondary" data-toggle="tooltip" title="Edit Users" id="users-edit-button">
+                                                <i class="btn-fa fas fa-pencil-alt"></i>
+                                        </button>
+                                        <button type="button" class="btn btn-outline-danger" data-toggle="tooltip" title="Delete Users" id="users-delete-button">
+                                                <i class="btn-fa fas fa-trash-alt"></i>
+                                        </button>
+                                </div>
+                        </div>
+                </div>
+        </div>
+        <div class="row">
+                <div class="col-md-12 table-responsive">
+                        <table id="teamsboard" class="table table-striped border">
+                                <thead>
+                                        <tr>
+                                                <th class="border-right" data-checkbox>
+                                                        <div class="form-check text-center">
+                                                                <input type="checkbox" class="form-check-input" autocomplete="off" data-checkbox-all>&nbsp;
+                                                        </div>
+                                                </th>
+                                                <th class="sort-col text-center"><b>ID</b></th>
+                                                <th class="sort-col text-center"><b>User</b></th>
+                                                <th class="sort-col text-center"><b>Email</b></th>
+                                                <th class="sort-col text-center"><b>Country</b></th>
+                                                <th class="sort-col text-center px-0"><b>Admin</b></th>
+                                                <th class="sort-col text-center px-0"><b>Verified</b></th>
+                                                <th class="sort-col text-center px-0"><b>Hidden</b></th>
+                                                <th class="sort-col text-center px-0"><b>Banned</b></th>
+                                        </tr>
+                                </thead>
+                                <tbody>
+                                        {% for user in users.items %}
+                                        <tr name="{{ user.id }}" data-href="{{ url_for('admin.users_detail', user_id=user.id) }}">
+                                                <td class="border-right" data-checkbox>
+                                                        <div class="form-check text-center">
+                                                                <input type="checkbox" class="form-check-input" autocomplete="off" value="{{ user.id }}" data-user-id="{{ user.id }}">&nbsp;
+                                                        </div>
+                                                </td>
+                                                <td class="team-id text-center" value="{{ user.id }}">{{ user.id }}</td>
+                                                <td class="team-name" value="{{ user.name }}">
+                                                        <a href="{{ url_for('admin.users_detail', user_id=user.id) }}">
+                                                                {{ user.name | truncate(32) }}
+                                                        </a>
+                                                        {% if user.bracket_id %}
+                                                                <span class="badge badge-secondary">{{ user.bracket.name }}</span>
+                                                        {% endif %}
+                                                        {% if user.oauth_id %}
+                                                                <a href="https://majorleaguecyber.org/u/{{ user.name }}">
+                                                                        <span class="badge badge-primary">Official</span>
+                                                                </a>
+                                                        {% endif %}
+                                                        {% if user.website %}
+                                                                <a href="{{ user.website }}" target="_blank" class="badge badge-info" rel="noopener">
+                                                                        <i class="btn-fa fas fa-external-link-alt" data-toggle="tooltip" data-placement="top"
+                                                                           title="{{ user.website }}" aria-hidden="true"></i>
+                                                                </a>
+                                                        {% endif %}
+                                                        {% if user.affiliation %}
+                                                                <span class="d-block text-muted"><small>{{ user.affiliation | truncate(20) }}</small></span>
+                                                        {% endif %}
+                                                </td>
+                                                <td class="team-email d-none d-md-table-cell d-lg-table-cell" value="{{ user.email }}">
+                                                        {% if user.email %}
+                                                                <a href="mailto:{{ user.email }}" target="_blank">{{ user.email | truncate(32) }}</a>
+                                                        {% endif %}
+                                                </td>
+                                                <td class="team-country text-center" value="{{ user.country if user.country is not none }}">
+                                                        <span>
+                                                                {% if user.country %}
+                                                                        <i class="flag-{{ user.country.lower() }}"></i>
+                                                                        <small>{{ lookup_country_code(user.country) }}</small>
+                                                                {% endif %}
+                                                        </span>
+                                                </td>
+                                                <td class="team-admin d-md-table-cell d-lg-table-cell text-center" value="{{ user.type }}">
+                                                        {% if user.type == 'admin' %}
+                                                                <span class="badge badge-primary">admin</span>
+                                                        {% endif %}
+                                                </td>
+                                                <td class="team-verified d-md-table-cell d-lg-table-cell text-center" value="{{ user.verified }}">
+                                                        {% if user.verified %}
+                                                                <span class="badge badge-success">verified</span>
+                                                        {% endif %}
+                                                </td>
+                                                <td class="team-hidden d-md-table-cell d-lg-table-cell text-center" value="{{ user.hidden }}">
+                                                        {% if user.hidden %}
+                                                                <span class="badge badge-danger">hidden</span>
+                                                        {% endif %}
+                                                </td>
+                                                <td class="team-banned d-md-table-cell d-lg-table-cell text-center" value="{{ user.banned }}">
+                                                        {% if user.banned %}
+                                                                <span class="badge badge-danger">banned</span>
+                                                        {% endif %}
+                                                </td>
+                                        </tr>
+                                        {% endfor %}
+                                </tbody>
+                        </table>
+                        {% if users.pages > 1 %}
+                        <div class="text-center">Page
+                                <br>
+                                {% if users.page != 1 %}
+                                <a href="{{ prev_page }}">&lt;&lt;&lt;</a>
+                                {% endif %}
+                                <select class="page-select">
+                                        {% for page in range(1, users.pages + 1) %}
+                                        <option {% if users.page == page %}selected{% endif %}>{{ page }}</option>
+                                        {% endfor %}
+                                </select>
+                                {% if users.next_num %}
+                                <a href="{{ next_page }}">&gt;&gt;&gt;</a>
+                                {% endif %}
+                        </div>
+                        {% endif %}
+                </div>
+        </div>
 </div>
 {% endblock %}
 
@@ -176,5 +185,5 @@
 {% endblock %}
 
 {% block entrypoint %}
-	{{ Assets.js("assets/js/pages/users.js", theme="admin") }}
+        {{ Assets.js("assets/js/pages/users.js", theme="admin") }}
 {% endblock %}

--- a/tests/admin/test_users.py
+++ b/tests/admin/test_users.py
@@ -47,3 +47,52 @@ def test_admin_user_ip_search():
             assert "user3" in resp
             assert "user4" in resp
     destroy_ctfd(app)
+
+
+def test_admin_user_status_filter():
+    """Can an admin filter users by status"""
+    app = create_ctfd()
+    with app.app_context():
+        u1 = gen_user(app.db, name="active_user", email="active@examplectf.com")
+        u2 = gen_user(
+            app.db, name="banned_user", email="banned@examplectf.com", banned=True
+        )
+        u3 = gen_user(
+            app.db, name="hidden_user", email="hidden@examplectf.com", hidden=True
+        )
+        u4 = gen_user(
+            app.db,
+            name="unverified_user",
+            email="unverified@examplectf.com",
+            verified=False,
+        )
+
+        with login_as_user(app, name="admin", password="password") as admin:
+            # Filter by banned
+            r = admin.get("/admin/users?status=banned")
+            resp = r.get_data(as_text=True)
+            assert "banned_user" in resp
+            assert "active_user" not in resp
+            assert "hidden_user" not in resp
+
+            # Filter by hidden
+            r = admin.get("/admin/users?status=hidden")
+            resp = r.get_data(as_text=True)
+            assert "hidden_user" in resp
+            assert "active_user" not in resp
+            assert "banned_user" not in resp
+
+            # Filter by unverified
+            r = admin.get("/admin/users?status=unverified")
+            resp = r.get_data(as_text=True)
+            assert "unverified_user" in resp
+            assert "active_user" not in resp
+            assert "banned_user" not in resp
+
+            # Filter by active - should exclude banned and hidden
+            r = admin.get("/admin/users?status=active")
+            resp = r.get_data(as_text=True)
+            assert "active_user" in resp
+            assert "banned_user" not in resp
+            assert "hidden_user" not in resp
+    destroy_ctfd(app)


### PR DESCRIPTION
Hey! I was setting up a CTF for my university last month and found it really annoying to manage users — especially when trying to find banned or hidden accounts. The admin users page shows the status badges but there was no way to actually filter by them.

This PR adds a status filter dropdown to the admin users listing page. You can now filter by:
- **Active** (not banned, not hidden)
- **Banned** 
- **Hidden**
- **Unverified**

The filter works alongside the existing search, so you can combine text search with status filtering. Also added a label that shows which status filter is active.

Changes:
- Added `status` query param to the admin `/admin/users` route
- Added a status dropdown in the users.html template
- Added a test for the status filter

Related to #3012