### PR TITLE
Fix 500 error on user creation with invalid request body

### DIFF
--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -164,6 +164,15 @@ class UserList(Resource):
     )
     def post(self):
         req = request.get_json()
+        if req is None:
+            return (
+                {
+                    "success": False,
+                    "errors": {"": ["Request body must be valid JSON"]},
+                },
+                400,
+            )
+
         schema = UserSchema("admin")
         response = schema.load(req)
 

--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -64,6 +64,7 @@ class UserSchema(ma.ModelSchema):
         if name is None:
             return
         name = name.strip()
+        data["name"] = name
 
         existing_user = Users.query.filter_by(name=name).first()
         current_user = get_current_user()
@@ -105,6 +106,7 @@ class UserSchema(ma.ModelSchema):
         if email is None:
             return
         email = email.strip()
+        data["email"] = email
 
         existing_user = Users.query.filter_by(email=email).first()
         current_user = get_current_user()

--- a/tests/api/v1/users/test_users.py
+++ b/tests/api/v1/users/test_users.py
@@ -19,6 +19,41 @@ def test_api_self_ban():
     destroy_ctfd(app)
 
 
+def test_api_create_user_empty_json_body():
+    """POST /api/v1/users should return 400 instead of 500 when request body is missing or not JSON"""
+    app = create_ctfd()
+    with app.app_context():
+        with login_as_user(app, name="admin") as client:
+            # Send POST without JSON body (no Content-Type header)
+            r = client.post(
+                "/api/v1/users",
+                data="not json",
+                content_type="text/plain",
+            )
+            assert r.status_code == 400
+            resp = r.get_json()
+            assert resp["success"] == False
+
+
+def test_api_create_user_whitespace_name():
+    """POST /api/v1/users should reject a name that is only whitespace"""
+    app = create_ctfd()
+    with app.app_context():
+        with login_as_user(app, name="admin") as client:
+            r = client.post(
+                "/api/v1/users",
+                json={
+                    "name": "   ",
+                    "email": "test@examplectf.com",
+                    "password": "password",
+                },
+            )
+            assert r.status_code == 400
+            resp = r.get_json()
+            assert resp["success"] == False
+    destroy_ctfd(app)
+
+
 def test_api_modify_user_type():
     """Can a user patch /api/v1/users/<user_id> to promote a user to admin and demote them to user"""
     app = create_ctfd()


### PR DESCRIPTION
Hey! I was scripting some user creation for my CTF and accidentally sent a POST to /api/v1/users without a JSON body (wrong Content-Type header). Got a 500 instead of a proper error message.

Turns out request.get_json() returns None when the body isnt valid JSON, and the schema loader chokes on it. This PR adds a check for that case and returns a proper 400 error.

Also noticed that validate_name and validate_email pre_load methods strip whitespace for duplicate checking but never update the actual data dict. Fixed that by updating data after stripping.

Related to #3032