### PR TITLE
Add length validation for affiliation and website fields

### DIFF
--- a/CTFd/schemas/users.py
+++ b/CTFd/schemas/users.py
@@ -47,11 +47,23 @@ class UserSchema(ma.ModelSchema):
                 schemes={"http", "https"},
             )(website)
             if website
-            else True
+            else True,
+            validate.Length(
+                max=128, error="Website must be less than 128 characters"
+            ),
         ],
     )
     language = field_for(Users, "language", validate=[validate_language])
     country = field_for(Users, "country", validate=[validate_country_code])
+    affiliation = field_for(
+        Users,
+        "affiliation",
+        validate=[
+            validate.Length(
+                max=128, error="Affiliation must be less than 128 characters"
+            ),
+        ],
+    )
     password = field_for(Users, "password", required=True, allow_none=False)
     bracket_id = field_for(Users, "bracket_id")
     fields = Nested(

--- a/tests/users/test_users.py
+++ b/tests/users/test_users.py
@@ -149,3 +149,37 @@ def test_num_users_limit():
             assert r.status_code == 302
             assert Users.query.count() == 3
     destroy_ctfd(app)
+
+
+def test_affiliation_length_validation():
+    """Users should not be able to set an affiliation longer than 128 characters"""
+    app = create_ctfd()
+    with app.app_context():
+        with login_as_user(app, name="admin") as client:
+            # Try creating a user with a very long affiliation
+            r = client.post(
+                "/api/v1/users",
+                json={
+                    "name": "long_affiliation_user",
+                    "email": "longaff@examplectf.com",
+                    "password": "password",
+                    "affiliation": "A" * 129,
+                },
+            )
+            assert r.status_code == 400
+            resp = r.get_json()
+            assert resp["success"] == False
+            assert "affiliation" in resp["errors"]
+
+            # Normal affiliation should work fine
+            r = client.post(
+                "/api/v1/users",
+                json={
+                    "name": "normal_user",
+                    "email": "normal@examplectf.com",
+                    "password": "password",
+                    "affiliation": "My University",
+                },
+            )
+            assert r.status_code == 200
+    destroy_ctfd(app)


### PR DESCRIPTION
Hey! Was setting up a CTF for my university and one of the participants managed to crash the user creation by submitting a super long affiliation name. Turns out the affiliation and website fields in UserSchema have no length validation even though theyre limited to 128 chars in the database.

If you submit an affiliation or website longer than 128 chars, you get a 500 from the database instead of a proper validation error. This PR adds Length validators to match the DB column size.

Changes:
- Added validate.Length(max=128) to affiliation field
- Added validate.Length(max=128) to website field
- Added test for affiliation length validation