### PR TITLE
Fix error where subdirectory deployment cookies would be erased if a non subdirectory path was accessed

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -201,6 +201,16 @@ def init_events(app):
 
 
 def init_request_processors(app):
+    application_root = app.config.get("APPLICATION_ROOT")
+    if application_root != "/":
+        # Do application_root check first to prevent issues with cookie paths
+        @app.before_request
+        def force_subdirectory_redirect():
+            if request.path.startswith(application_root) is False:
+                return redirect(
+                    application_root + request.script_root + request.full_path
+                )
+
     @app.url_defaults
     def inject_theme(endpoint, values):
         if "theme" not in values and app.url_map.is_endpoint_expecting(
@@ -397,14 +407,5 @@ def init_request_processors(app):
         )
         return response
 
-    application_root = app.config.get("APPLICATION_ROOT")
     if application_root != "/":
-
-        @app.before_request
-        def force_subdirectory_redirect():
-            if request.path.startswith(application_root) is False:
-                return redirect(
-                    application_root + request.script_root + request.full_path
-                )
-
         app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {application_root: app})

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -123,6 +123,40 @@ def test_that_ctfd_can_be_deployed_in_subdir():
     destroy_ctfd(app)
 
 
+def test_that_ctfd_subdir_redirects_work():
+    """Test that subdirectory deployments don't break when a regular path is accessed"""
+
+    class ApplicationRootConfig(TestingConfig):
+        APPLICATION_ROOT = "/ctf"
+
+    app = create_ctfd(config=ApplicationRootConfig, application_root="/ctf")
+    with app.app_context():
+        with app.test_client():
+            remote = {"environ_base": {"REMOTE_ADDR": "127.0.0.1"}}
+            c = Client(app)
+            # Test that we are in a subdir deployment
+            response = c.get("/random", **remote)
+            headers = dict(response.headers)
+            assert response.status == "302 FOUND"
+            assert headers["Location"] == "/ctf/random?"
+
+            # A session cookie should be set on the first request
+            response = c.get("/ctf/login", **remote)
+            headers = dict(response.headers)
+            assert headers["Set-Cookie"]
+
+            # The session cookie should not be regenerated on non subdir requests
+            response = c.get("/random", **remote)
+            headers = dict(response.headers)
+            assert headers.get("Set-Cookie") is None
+
+            # The session cookie should not be regenerated on subdir requests
+            response = c.get("/ctf/login", **remote)
+            headers = dict(response.headers)
+            assert headers.get("Set-Cookie") is None
+    destroy_ctfd(app)
+
+
 def test_that_request_path_hijacking_works_properly():
     """Test that the CTFdRequest subclass correctly mimics the Flask Request when it should"""
     app = create_ctfd(setup=False, application_root="/ctf")


### PR DESCRIPTION
* If a non-subdirectory path was accessed with a CTFd instance configured for subdirectory deployments the cookie would be erased by the csrf before_request handler. This adjusts the before_request handlers so that subdirectory redirection happens before others. 
* Related to #2906