### PR TITLE
Add a safety check so that null value is accepted for initial, minimum, decay

### DIFF
--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -139,7 +139,7 @@ class BaseChallenge(object):
         data = request.form or request.get_json()
         for attr, value in data.items():
             # We need to set these to floats so that the next operations don't operate on strings
-            if attr in ("initial", "minimum", "decay"):
+            if attr in ("initial", "minimum", "decay") and value is not None:
                 try:
                     value = float(value)
                 except (ValueError, TypeError):


### PR DESCRIPTION
Fix an issue where `initial`, `minimum`, and `decay` do not properly round trip as NULL even though the challenge function is static and the values aren't needed. 