### PR TITLE
Mark 3.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 3.8.5 / 2026-05-19
+
+**Security**
+
+- Fix issue where the safe URL redirect validator could be bypassed on certain browsers possibly allowing an attacker the ability to phish other users
+
+**Translations**
+
+- Add Indonesian translations
+
+**API**
+
+- Fix issue when updating a challenge where `initial`, `minimum`, and `decay` could not be set to `NULL` even if the challenge function is `static`
+
+**Deployment**
+
+- Fix issue with subdirectory deployments where users could not authenticate on certain server configurations
+
 # 3.8.4 / 2026-04-20
 
 **Security**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -33,7 +33,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.8.4"
+__version__ = "3.8.5"
 __channel__ = "oss"
 
 


### PR DESCRIPTION
# 3.8.5 / 2026-05-19

**Security**

- Fix issue where the safe URL redirect validator could be bypassed on certain browsers possibly allowing an attacker the ability to phish other users

**Translations**

- Add Indonesian translations

**API**

- Fix issue when updating a challenge where `initial`, `minimum`, and `decay` could not be set to `NULL` even if the challenge function is `static`

**Deployment**

- Fix issue with subdirectory deployments where users could not authenticate on certain server configurations