### PR TITLE
Avoid 500 when concurrent requests race on the same Tracking row

### DIFF
--- a/CTFd/utils/initialization/__init__.py
+++ b/CTFd/utils/initialization/__init__.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from flask import abort, redirect, render_template, request, session, url_for
-from sqlalchemy.exc import IntegrityError, InvalidRequestError
+from sqlalchemy.exc import IntegrityError, InvalidRequestError, OperationalError
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from CTFd.cache import clear_user_recent_ips
@@ -278,6 +278,12 @@ def init_request_processors(app):
                     db.session.rollback()
                     db.session.close()
                     logout_user()
+                except OperationalError:
+                    # Concurrent requests within the same session can race to
+                    # update the same Tracking row (e.g. MySQL error 1020 or a
+                    # deadlock). Visit tracking is best-effort, so roll back and
+                    # continue serving the request instead of returning a 500.
+                    db.session.rollback()
                 else:
                     clear_user_recent_ips(user_id=session["id"])
 


### PR DESCRIPTION
## Problem

Visit tracking commits a `Tracking` row on every authenticated `POST`/`PATCH`/`PUT`/`DELETE` request (`init_request_processors` in `CTFd/utils/initialization/__init__.py`). When a single session fires **concurrent** mutating requests, both handlers read and update the **same** `(user_id, ip)` `Tracking` row, and the second commit fails with an `OperationalError`:

```
sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError)
(1020, "Record has changed since last read in table 'tracking'; try restarting transaction")
```

The surrounding `try/except` only catches `InvalidRequestError` and `IntegrityError`, so the `OperationalError` propagates and the whole request returns **500** — and the intended action is rolled back.

## Reproduction

Log in as admin and delete several challenges at once (the admin UI fires the `DELETE /api/v1/challenges/<id>` calls in parallel). One request completes; the others return 500 and their challenges are **not** deleted. The same shape happens for any bulk admin action, or any two concurrent mutating requests from one session, on MySQL/MariaDB.

Note this only affects concurrent requests **within a single session** (same `user_id` + `ip`). Separate users racing each other touch different rows and are unaffected.

## Fix

Catch `OperationalError` around the tracking commit and roll it back. Visit tracking is best-effort, so a dropped tracking write should not fail the underlying request. No behavior change for the normal (sequential) path.

## Notes

A deterministic unit test is awkward because the failure depends on a real concurrent commit against MySQL/MariaDB, so this PR is the minimal defensive change. Happy to add a test if you can point me at a preferred pattern for exercising concurrent request handling.
