### PR TITLE
Make ratelimits configurable

### DIFF
--- a/CTFd/api/v1/exports.py
+++ b/CTFd/api/v1/exports.py
@@ -14,7 +14,7 @@ exports_namespace = Namespace("exports", description="Endpoint to retrieve Expor
 @exports_namespace.route("/raw")
 class ExportList(Resource):
     @admins_only
-    @ratelimit(method="POST", limit=10, interval=60)
+    @ratelimit(method="POST", rl_key="RL_EXPORT")
     def post(self):
         req = request.get_json()
         export_type = req.get("type", "_")

--- a/CTFd/api/v1/users.py
+++ b/CTFd/api/v1/users.py
@@ -514,7 +514,7 @@ class UserEmails(Resource):
         description="Endpoint to email a User object",
         responses={200: ("Success", "APISimpleSuccessResponse")},
     )
-    @ratelimit(method="POST", limit=10, interval=60)
+    @ratelimit(method="POST", rl_key="RL_EMAIL_USER")
     def post(self, user_id):
         req = request.get_json()
         text = req.get("text", "").strip()

--- a/CTFd/auth.py
+++ b/CTFd/auth.py
@@ -34,7 +34,7 @@ auth = Blueprint("auth", __name__)
 
 @auth.route("/confirm", methods=["POST", "GET"])
 @auth.route("/confirm/<data>", methods=["POST", "GET"])
-@ratelimit(method="POST", limit=10, interval=60)
+@ratelimit(method="POST", rl_key="RL_CONFIRM")
 def confirm(data=None):
     # If we can't send mails our behavior depends on verify_emails
     if not can_send_mail():
@@ -116,7 +116,7 @@ def confirm(data=None):
 
 @auth.route("/reset_password", methods=["POST", "GET"])
 @auth.route("/reset_password/<data>", methods=["POST", "GET"])
-@ratelimit(method="POST", limit=10, interval=60)
+@ratelimit(method="POST", rl_key="RL_RESET_PASSWORD")
 def reset_password(data=None):
     if config.can_send_mail() is False and data is None:
         return render_template(
@@ -233,7 +233,7 @@ def reset_password(data=None):
 
 @auth.route("/register", methods=["POST", "GET"])
 @check_registration_visibility
-@ratelimit(method="POST", limit=10, interval=5)
+@ratelimit(method="POST", rl_key="RL_REGISTER")
 def register():
     errors = get_errors()
     if current_user.authed():
@@ -438,7 +438,7 @@ def register():
 
 
 @auth.route("/login", methods=["POST", "GET"])
-@ratelimit(method="POST", limit=10, interval=5)
+@ratelimit(method="POST", rl_key="RL_LOGIN")
 def login():
     errors = get_errors()
     if request.method == "POST":
@@ -543,7 +543,7 @@ def oauth_login():
 
 
 @auth.route("/redirect", methods=["GET"])
-@ratelimit(method="GET", limit=10, interval=60)
+@ratelimit(method="GET", rl_key="RL_OAUTH_REDIRECT")
 def oauth_redirect():
     oauth_code = request.args.get("code")
     state = request.args.get("state")

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -139,7 +139,7 @@ RL_DISABLE_COMPLETELY = false
 # Fallback ratelimit
 #   - if the given key was not found in this config
 #   - and if the given key has no built-in default in config.py (backwards compat)
-RL_DEFAULT = 1,60
+RL_DEFAULT = 10,60
 # POST to /confirm and /confirm/data
 RL_CONFIRM = 10,60
 # POST to /reset_password and /reset_password/<data>

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -125,6 +125,41 @@ PERMANENT_SESSION_LIFETIME = 604800
 # Setting for the Cross-Origin-Opener-Policy response header. Defaults to same-origin-allow-popups
 CROSS_ORIGIN_OPENER_POLICY =
 
+
+[ratelimits]
+# RL_DISABLE_COMPLETELY
+# Controls whether the ratelimit functionality is used at all.
+# setting this to true overrides all RL settings below
+RL_DISABLE_COMPLETELY = false
+
+# All of the following RL configs follow the same format
+# format: key = limit,interval
+# users may send <limit> calls in <interval> seconds (both int!)
+
+# Fallback ratelimit
+#   - if the given key was not found in this config
+#   - and if the given key has no built-in default in config.py (backwards compat)
+RL_DEFAULT = 1,60
+# POST to /confirm and /confirm/data
+RL_CONFIRM = 10,60
+# POST to /reset_password and /reset_password/<data>
+RL_RESET_PASSWORD = 10,60
+# POST to /register
+RL_REGISTER = 10,5
+# POST to /login
+RL_LOGIN = 10,5
+# GET /redirect
+RL_OAUTH_REDIRECT = 10,60
+# POST to /teams/join
+RL_JOIN_TEAM = 10,5
+# POST to the exports/raw endpoint
+RL_EXPORT = 10,60
+# POST to users/<userid>/email (sending an email to a user)
+RL_EMAIL_USER = 10,60
+# GET /events
+RL_EVENTS = 150,60
+
+
 [email]
 # MAILFROM_ADDR
 # The email address that emails are sent from if not overridden in the configuration panel.

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -139,7 +139,7 @@ RL_DISABLE_COMPLETELY = false
 # Fallback ratelimit
 #   - if the given key was not found in this config
 #   - and if the given key has no built-in default in config.py (backwards compat)
-RL_DEFAULT = 10,60
+RL_DEFAULT = 50,300
 # POST to /confirm and /confirm/data
 RL_CONFIRM = 10,60
 # POST to /reset_password and /reset_password/<data>

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -201,17 +201,17 @@ class ServerConfig(object):
     ]
 
     # === RATELIMIT ===
-    RL_DISABLE_COMPLETELY = process_boolean_str(config_ini["ratelimits"].get("RL_DISABLE_COMPLETELY", "")) if config_ini.has_section("ratelimits") else False
-    RL_DEFAULT = int_tuple_cast(config_ini["ratelimits"].get("RL_DEFAULT", "")) if config_ini.has_section("ratelimits") else (50,300)
-    RL_CONFIRM = int_tuple_cast(config_ini["ratelimits"].get("RL_CONFIRM", "")) if config_ini.has_section("ratelimits") else (10,60)
-    RL_RESET_PASSWORD = int_tuple_cast(config_ini["ratelimits"].get("RL_RESET_PASSWORD", "")) if config_ini.has_section("ratelimits") else (10,60)
-    RL_REGISTER = int_tuple_cast(config_ini["ratelimits"].get("RL_REGISTER", "")) if config_ini.has_section("ratelimits") else (10,5)
-    RL_LOGIN = int_tuple_cast(config_ini["ratelimits"].get("RL_LOGIN", "")) if config_ini.has_section("ratelimits") else (10,5)
-    RL_OAUTH_REDIRECT = int_tuple_cast(config_ini["ratelimits"].get("RL_OAUTH_REDIRECT", "")) if config_ini.has_section("ratelimits") else (10,60)
-    RL_JOIN_TEAM = int_tuple_cast(config_ini["ratelimits"].get("RL_JOIN_TEAM", "")) if config_ini.has_section("ratelimits") else (10,5)
-    RL_EXPORT = int_tuple_cast(config_ini["ratelimits"].get("RL_EXPORT", "")) if config_ini.has_section("ratelimits") else (10,60)
-    RL_EMAIL_USER = int_tuple_cast(config_ini["ratelimits"].get("RL_EMAIL_USER", "")) if config_ini.has_section("ratelimits") else (10,60)
-    RL_EVENTS = int_tuple_cast(config_ini["ratelimits"].get("RL_EVENTS", "")) if config_ini.has_section("ratelimits") else (150,60)
+    RL_DISABLE_COMPLETELY = process_boolean_str(config_ini["ratelimits"].get("RL_DISABLE_COMPLETELY", "false")) if config_ini.has_section("ratelimits") else False
+    RL_DEFAULT = int_tuple_cast(config_ini["ratelimits"].get("RL_DEFAULT", "50,300")) if config_ini.has_section("ratelimits") else (50,300)
+    RL_CONFIRM = int_tuple_cast(config_ini["ratelimits"].get("RL_CONFIRM", "10,60")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_RESET_PASSWORD = int_tuple_cast(config_ini["ratelimits"].get("RL_RESET_PASSWORD", "10,60")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_REGISTER = int_tuple_cast(config_ini["ratelimits"].get("RL_REGISTER", "10,5")) if config_ini.has_section("ratelimits") else (10,5)
+    RL_LOGIN = int_tuple_cast(config_ini["ratelimits"].get("RL_LOGIN", "10,5")) if config_ini.has_section("ratelimits") else (10,5)
+    RL_OAUTH_REDIRECT = int_tuple_cast(config_ini["ratelimits"].get("RL_OAUTH_REDIRECT", "10,60")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_JOIN_TEAM = int_tuple_cast(config_ini["ratelimits"].get("RL_JOIN_TEAM", "10,5")) if config_ini.has_section("ratelimits") else (10,5)
+    RL_EXPORT = int_tuple_cast(config_ini["ratelimits"].get("RL_EXPORT", "10,60")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_EMAIL_USER = int_tuple_cast(config_ini["ratelimits"].get("RL_EMAIL_USER", "10,60")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_EVENTS = int_tuple_cast(config_ini["ratelimits"].get("RL_EVENTS", "150,60")) if config_ini.has_section("ratelimits") else (150,60)
 
     # === EMAIL ===
     MAILFROM_ADDR: str = config_ini["email"]["MAILFROM_ADDR"] \

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -202,7 +202,7 @@ class ServerConfig(object):
 
     # === RATELIMIT ===
     RL_DISABLE_COMPLETELY = process_boolean_str(config_ini["ratelimits"].get("RL_DISABLE_COMPLETELY", "")) if config_ini.has_section("ratelimits") else False
-    RL_DEFAULT = int_tuple_cast(config_ini["ratelimits"].get("RL_DEFAULT", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_DEFAULT = int_tuple_cast(config_ini["ratelimits"].get("RL_DEFAULT", "")) if config_ini.has_section("ratelimits") else (50,300)
     RL_CONFIRM = int_tuple_cast(config_ini["ratelimits"].get("RL_CONFIRM", "")) if config_ini.has_section("ratelimits") else (10,60)
     RL_RESET_PASSWORD = int_tuple_cast(config_ini["ratelimits"].get("RL_RESET_PASSWORD", "")) if config_ini.has_section("ratelimits") else (10,60)
     RL_REGISTER = int_tuple_cast(config_ini["ratelimits"].get("RL_REGISTER", "")) if config_ini.has_section("ratelimits") else (10,5)

--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -66,6 +66,21 @@ def empty_str_cast(value, default=None):
     return value
 
 
+def int_tuple_cast(value: str, num_ints: int = 2):
+    values: list[str] = value.split(",")
+    ints: list[int] = []
+    try:
+        for i in range(len(values)):
+            ints.append(int(values[i].strip()))
+    except ValueError:
+        return None
+
+    if len(ints) != num_ints:
+        return None
+
+    return ints
+
+
 def gen_secret_key():
     # Attempt to read the secret from the secret file
     # This will fail if the secret has not been written
@@ -184,6 +199,19 @@ class ServerConfig(object):
         r"^172\.(1[6-9]|2[0-9]|3[0-1])\.",
         r"^192\.168\.",
     ]
+
+    # === RATELIMIT ===
+    RL_DISABLE_COMPLETELY = process_boolean_str(config_ini["ratelimits"].get("RL_DISABLE_COMPLETELY", "")) if config_ini.has_section("ratelimits") else False
+    RL_DEFAULT = int_tuple_cast(config_ini["ratelimits"].get("RL_DEFAULT", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_CONFIRM = int_tuple_cast(config_ini["ratelimits"].get("RL_CONFIRM", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_RESET_PASSWORD = int_tuple_cast(config_ini["ratelimits"].get("RL_RESET_PASSWORD", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_REGISTER = int_tuple_cast(config_ini["ratelimits"].get("RL_REGISTER", "")) if config_ini.has_section("ratelimits") else (10,5)
+    RL_LOGIN = int_tuple_cast(config_ini["ratelimits"].get("RL_LOGIN", "")) if config_ini.has_section("ratelimits") else (10,5)
+    RL_OAUTH_REDIRECT = int_tuple_cast(config_ini["ratelimits"].get("RL_OAUTH_REDIRECT", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_JOIN_TEAM = int_tuple_cast(config_ini["ratelimits"].get("RL_JOIN_TEAM", "")) if config_ini.has_section("ratelimits") else (10,5)
+    RL_EXPORT = int_tuple_cast(config_ini["ratelimits"].get("RL_EXPORT", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_EMAIL_USER = int_tuple_cast(config_ini["ratelimits"].get("RL_EMAIL_USER", "")) if config_ini.has_section("ratelimits") else (10,60)
+    RL_EVENTS = int_tuple_cast(config_ini["ratelimits"].get("RL_EVENTS", "")) if config_ini.has_section("ratelimits") else (150,60)
 
     # === EMAIL ===
     MAILFROM_ADDR: str = config_ini["email"]["MAILFROM_ADDR"] \

--- a/CTFd/events/__init__.py
+++ b/CTFd/events/__init__.py
@@ -9,7 +9,7 @@ events = Blueprint("events", __name__)
 
 @events.route("/events")
 @authed_only
-@ratelimit(method="GET", limit=150, interval=60)
+@ratelimit(method="GET", rl_key="RL_EVENTS")
 def subscribe():
     @stream_with_context
     def gen():

--- a/CTFd/teams.py
+++ b/CTFd/teams.py
@@ -124,7 +124,7 @@ def invite():
 @teams.route("/teams/join", methods=["GET", "POST"])
 @authed_only
 @require_team_mode
-@ratelimit(method="POST", limit=10, interval=5)
+@ratelimit(method="POST", rl_key="RL_JOIN_TEAM")
 def join():
     infos = get_infos()
     errors = get_errors()

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -160,7 +160,16 @@ def require_team(f):
     return require_team_wrapper
 
 
-def ratelimit(method: str = "POST", rl_key: str = "RL_DEFAULT"):
+def ratelimit(
+    method: str = "POST",
+    limit=-1,
+    interval=-1,
+    rl_key: str = "RL_DEFAULT",
+    key_prefix="rl",
+):
+    # still accept these keyword args if requested by decorator arguments
+    limit_old, interval_old = limit, interval
+
     def ratelimit_decorator(f):
         @functools.wraps(f)
         def ratelimit_function(*args, **kwargs):
@@ -169,14 +178,19 @@ def ratelimit(method: str = "POST", rl_key: str = "RL_DEFAULT"):
                 return f(*args, **kwargs)
 
             # figure out limit and interval values
-            fallback = current_app.config.get("RL_DEFAULT") or (50, 300)
-            value = current_app.config.get(rl_key) or fallback
-            limit, interval = value[0], value[1]  # value is a tuple (lim,interval)
+            if limit_old != -1 and interval_old != -1:
+                # use provided values if requested by decorator args
+                limit = limit_old
+                interval = interval_old
+            else:
+                fallback = current_app.config.get("RL_DEFAULT") or (50, 300)
+                value = current_app.config.get(rl_key) or fallback
+                limit, interval = value[0], value[1]  # value is a tuple (lim,interval)
 
             # IMO the following code is not doing what the timeout response claims it does...
 
             ip_address = current_user.get_ip()
-            key = f"ratelimit:{ip_address}:{request.endpoint}"
+            key = "{}:{}:{}".format(key_prefix, ip_address, request.endpoint)
             current = cache.get(key)
 
             if request.method == method:

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -161,10 +161,11 @@ def require_team(f):
 
 def ratelimit(
     method: str = "POST",
-    limit=-1,
-    interval=-1,
+    limit: int = -1,
+    interval: int = -1,
+    key_prefix: str = "rl",
+    *,
     rl_key: str = "RL_DEFAULT",
-    key_prefix="rl",
 ):
     # still accept these keyword args if requested by decorator arguments
     limit_old, interval_old = limit, interval
@@ -177,14 +178,17 @@ def ratelimit(
                 return f(*args, **kwargs)
 
             # figure out limit and interval values
-            if limit_old != -1 and interval_old != -1:
-                # use provided values if requested by decorator args
+            # use provided values if requested by decorator args
+            fallback = current_app.config.get("RL_DEFAULT") or (50, 300)
+            value = current_app.config.get(rl_key) or fallback
+            if limit_old != -1:
                 limit = limit_old
+            else:
+                limit = value[0]
+            if interval_old != -1:
                 interval = interval_old
             else:
-                fallback = current_app.config.get("RL_DEFAULT") or (50, 300)
-                value = current_app.config.get(rl_key) or fallback
-                limit, interval = value[0], value[1]  # value is a tuple (lim,interval)
+                interval = value[1]
 
             # IMO the following code is not doing what the timeout response claims it does...
 

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -169,7 +169,7 @@ def ratelimit(method: str = "POST", rl_key: str = "RL_DEFAULT"):
                 return f(*args, **kwargs)
 
             # figure out limit and interval values
-            fallback = current_app.config.get("RL_DEFAULT") or (10, 60)
+            fallback = current_app.config.get("RL_DEFAULT") or (50, 300)
             value = current_app.config.get(rl_key) or fallback
             limit, interval = value[0], value[1]  # value is a tuple (lim,interval)
 

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -8,7 +8,6 @@ from CTFd.utils import config, get_config
 from CTFd.utils import user as current_user
 from CTFd.utils.config import is_teams_mode
 from CTFd.utils.dates import ctf_ended, ctf_started, ctftime, view_after_ctf
-from CTFd.utils.logging import log
 from CTFd.utils.user import authed, get_current_team, get_current_user, is_admin
 
 

--- a/CTFd/utils/decorators/__init__.py
+++ b/CTFd/utils/decorators/__init__.py
@@ -1,6 +1,6 @@
 import functools
 
-from flask import abort, jsonify, redirect, request, url_for
+from flask import abort, current_app, jsonify, redirect, request, url_for
 from flask_babel import gettext
 
 from CTFd.cache import cache
@@ -8,6 +8,7 @@ from CTFd.utils import config, get_config
 from CTFd.utils import user as current_user
 from CTFd.utils.config import is_teams_mode
 from CTFd.utils.dates import ctf_ended, ctf_started, ctftime, view_after_ctf
+from CTFd.utils.logging import log
 from CTFd.utils.user import authed, get_current_team, get_current_user, is_admin
 
 
@@ -159,12 +160,23 @@ def require_team(f):
     return require_team_wrapper
 
 
-def ratelimit(method="POST", limit=50, interval=300, key_prefix="rl"):
+def ratelimit(method: str = "POST", rl_key: str = "RL_DEFAULT"):
     def ratelimit_decorator(f):
         @functools.wraps(f)
         def ratelimit_function(*args, **kwargs):
+            # config option to skip RL entirely
+            if current_app.config.get("RL_DISABLE_COMPLETELY", False):
+                return f(*args, **kwargs)
+
+            # figure out limit and interval values
+            fallback = current_app.config.get("RL_DEFAULT") or (10, 60)
+            value = current_app.config.get(rl_key) or fallback
+            limit, interval = value[0], value[1]  # value is a tuple (lim,interval)
+
+            # IMO the following code is not doing what the timeout response claims it does...
+
             ip_address = current_user.get_ip()
-            key = "{}:{}:{}".format(key_prefix, ip_address, request.endpoint)
+            key = f"ratelimit:{ip_address}:{request.endpoint}"
             current = cache.get(key)
 
             if request.method == method:


### PR DESCRIPTION
### Summary:
currently, it is not possible to configure or disable the ratelimit system.
This poses an issue for our events where many (30+) users may share a single IP address.
In these cases features like flag submission immediately run into rate limits for all users.
This issue was previously discussed in #1091, but did not lead to a PR at the time.

### Change:
This PR moves the configuration of rate limits from the sourcecode to the config.ini file. (excerpt see below)
It also adds a new RL_DISABLE_COMPLETELY option that disables ratelimits outright.

### Backwards Compatibility:
Plugins using the syntax `@ratelimit(method="POST", limit=10, interval=60)` still work because I only add (optional!) keyword args. If these Values are provided, the new logic uses them instead of falling back to `RL_DEFAULT`.
The decorator `@ratelimit(method="POST")` now uses the configured default ratelimit.

Note that the `RL_DISABLE_COMPLETELY` config option overrides the ratelimit decorator for exiing plugins too.

```ini
...
[ratelimits]
# RL_DISABLE_COMPLETELY
# Controls whether the ratelimit functionality is used at all.
# setting this to true overrides all RL settings below
RL_DISABLE_COMPLETELY = false

# All of the following RL configs follow the same format
# format: key = limit,interval
# users may send <limit> calls in <interval> seconds (both int!)

# Fallback ratelimit
#   - if the given key was not found in this config
#   - and if the given key has no built-in default in config.py (backwards compat)
RL_DEFAULT = 10,60
# POST to /confirm and /confirm/data
RL_CONFIRM = 10,60
# POST to /reset_password and /reset_password/<data>
RL_RESET_PASSWORD = 10,60
# POST to /register
RL_REGISTER = 10,5
# POST to /login
RL_LOGIN = 10,5
# GET /redirect
RL_OAUTH_REDIRECT = 10,60
# POST to /teams/join
RL_JOIN_TEAM = 10,5
# POST to the exports/raw endpoint
RL_EXPORT = 10,60
# POST to users/<userid>/email (sending an email to a user)
RL_EMAIL_USER = 10,60
# GET /events
RL_EVENTS = 150,60
...
```