### PR TITLE
Mark 3.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.8.7 / 2026-08-19
+
+**Security**
+
+- Fix issue where the REST API could return the values of Custom Fields despite the field not being set to public
+- Fix issue where a race condition could allow a user to submit more attempts than allowed by a challenge's max attempts setting
+
+**API**
+
+- Deprecate passing a list of fields as the `view` argument to schemas
+
 # 3.8.6 / 2026-06-16
 
 **Security**

--- a/CTFd/__init__.py
+++ b/CTFd/__init__.py
@@ -33,7 +33,7 @@ from CTFd.utils.sessions import CachingSessionInterface
 from CTFd.utils.updates import update_check
 from CTFd.utils.user import get_locale
 
-__version__ = "3.8.6"
+__version__ = "3.8.7"
 __channel__ = "oss"
 
 


### PR DESCRIPTION
# 3.8.7 / 2026-08-19

**Security**

- Fix issue where the REST API could return the values of Custom Fields despite the field not being set to public
- Fix issue where a race condition could allow a user to submit more attempts than allowed by a challenge's max attempts setting

**API**

- Deprecate passing a list of fields as the `view` argument to schemas