### PR TITLE
Fix admin-only plugin asset directory access

### DIFF
--- a/CTFd/plugins/__init__.py
+++ b/CTFd/plugins/__init__.py
@@ -38,6 +38,9 @@ def register_plugin_assets_directory(app, base_path, admins_only=False, endpoint
     def assets_handler(path):
         return send_from_directory(base_path, path)
 
+    if admins_only:
+        assets_handler = admins_only_wrapper(assets_handler)
+
     rule = "/" + base_path + "/<path:path>"
     app.add_url_rule(rule=rule, endpoint=endpoint, view_func=assets_handler)
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -55,6 +55,26 @@ def test_register_plugin_assets_directory():
     destroy_ctfd(app)
 
 
+def test_register_admin_only_plugin_assets_directory():
+    """Test that admin-only plugin directories are not publicly accessible"""
+    app = create_ctfd(setup=False)
+    register_plugin_assets_directory(
+        app, base_path="/plugins/", admins_only=True, endpoint="admin_plugins"
+    )
+    app = setup_ctfd(app)
+    with app.app_context():
+        with app.test_client() as client:
+            r = client.get("/plugins/__init__.py")
+            assert r.status_code == 302
+            assert r.location.startswith("/login")
+
+        with login_as_user(app, name="admin") as client:
+            r = client.get("/plugins/__init__.py")
+            assert r.status_code == 200
+            assert len(r.get_data(as_text=True)) > 0
+    destroy_ctfd(app)
+
+
 def test_override_template():
     """Does override_template work properly for regular themes when used from a plugin"""
     app = create_ctfd()


### PR DESCRIPTION
## Summary

- Enforce the existing `admins_only=True` option for plugin asset directories.
- Add a regression test covering anonymous and administrator access.

## Security impact

`register_plugin_assets_directory` accepted `admins_only=True` but ignored it, leaving registered directories publicly accessible. A plugin using this option could unintentionally expose admin-only assets.

## Verification

- `py -m py_compile CTFd\\plugins\\__init__.py tests\\test_plugin_utils.py`
- Isolated authorization check passed.
- The focused pytest run is blocked in this environment because the pinned dependency set targets Python 3.11 and the available interpreter is Python 3.14; installing the pinned `cffi` dependency requires MSVC.