### PR TITLE
Pass challenge read() output to the template renderer

### DIFF
--- a/CTFd/admin/challenges.py
+++ b/CTFd/admin/challenges.py
@@ -2,7 +2,11 @@ from flask import abort, render_template, request, url_for
 
 from CTFd.admin import admin
 from CTFd.models import Challenges, Flags, Solves
-from CTFd.plugins.challenges import CHALLENGE_CLASSES, get_chal_class
+from CTFd.plugins.challenges import (
+    CHALLENGE_CLASSES,
+    ChallengeRenderData,
+    get_chal_class,
+)
 from CTFd.schemas.tags import TagSchema
 from CTFd.utils.decorators import admins_only
 from CTFd.utils.security.signing import serialize
@@ -104,7 +108,9 @@ def challenges_preview(challenge_id):
         hints=challenge.hints,
         max_attempts=challenge.max_attempts,
         attempts=0,
-        challenge=challenge,
+        challenge=ChallengeRenderData(
+            challenge=challenge, data=chal_class.read(challenge)
+        ),
         rating=None,
         ratings=None,
     )

--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -31,7 +31,11 @@ from CTFd.models import (
     db,
 )
 from CTFd.models import ChallengeTopics as ChallengeTopicsModel
-from CTFd.plugins.challenges import CHALLENGE_CLASSES, get_chal_class
+from CTFd.plugins.challenges import (
+    CHALLENGE_CLASSES,
+    ChallengeRenderData,
+    get_chal_class,
+)
 from CTFd.schemas.challenges import ChallengeSchema
 from CTFd.schemas.flags import FlagSchema
 from CTFd.schemas.hints import HintSchema
@@ -585,7 +589,7 @@ class Challenge(Resource):
             ratings=rating_info,
             max_attempts=chal.max_attempts,
             attempts=attempts,
-            challenge=chal,
+            challenge=ChallengeRenderData(challenge=chal, data=response),
         )
 
         if (

--- a/CTFd/plugins/challenges/__init__.py
+++ b/CTFd/plugins/challenges/__init__.py
@@ -47,6 +47,25 @@ class ChallengeResponse:
         yield self.message
 
 
+class ChallengeRenderData(object):
+    """
+    Template-facing representation of a challenge that prefers values returned
+    by a challenge type's read() method (e.g. per-user overrides such as
+    connection strings) while falling back to the underlying Challenges model
+    for everything else (e.g. computed properties like html and byline).
+    """
+
+    def __init__(self, challenge, data):
+        self._challenge = challenge
+        self._data = data or {}
+
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except (KeyError, IndexError, TypeError):
+            return getattr(self._challenge, name)
+
+
 def calculate_value(challenge):
     f = DECAY_FUNCTIONS.get(challenge.function, logarithmic)
     value = f(challenge)

--- a/tests/challenges/test_challenge_read_render.py
+++ b/tests/challenges/test_challenge_read_render.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from CTFd.plugins.challenges import CHALLENGE_CLASSES, CTFdStandardChallenge
+from tests.helpers import (
+    create_ctfd,
+    destroy_ctfd,
+    login_as_user,
+    register_user,
+)
+
+
+def test_challenge_read_output_reaches_rendered_view():
+    """Test that a custom challenge type's read() output is used when rendering the challenge view"""
+    app = create_ctfd()
+    with app.app_context():
+        register_user(app)
+        admin_client = login_as_user(app, name="admin", password="password")
+
+        class ReadOverrideChallenge(CTFdStandardChallenge):
+            id = "read_override"
+            name = "read_override"
+
+            @classmethod
+            def read(cls, challenge):
+                data = super().read(challenge)
+                data["connection_info"] = "nc overridden.connection 1337"
+                return data
+
+        CHALLENGE_CLASSES["read_override"] = ReadOverrideChallenge
+        try:
+            challenge_data = {
+                "name": "read_override",
+                "category": "category",
+                "description": "read override description",
+                "value": 100,
+                "state": "visible",
+                "type": "read_override",
+            }
+            r = admin_client.post("/api/v1/challenges", json=challenge_data)
+            assert r.status_code == 200
+            challenge_id = r.get_json()["data"]["id"]
+
+            # The API response should contain the read() override...
+            user_client = login_as_user(app)
+            r = user_client.get(f"/api/v1/challenges/{challenge_id}")
+            assert r.status_code == 200
+            data = r.get_json()["data"]
+            assert data["connection_info"] == "nc overridden.connection 1337"
+
+            # ...and so should the rendered view template
+            assert "nc overridden.connection 1337" in data["view"]
+
+            # Model-backed properties (e.g. html) must still render correctly
+            assert "read override description" in data["view"]
+
+            # The admin preview renders the same view template and should
+            # receive the read() output as well
+            r = admin_client.get(f"/admin/challenges/preview/{challenge_id}")
+            assert r.status_code == 200
+            assert b"nc overridden.connection 1337" in r.data
+        finally:
+            del CHALLENGE_CLASSES["read_override"]
+    destroy_ctfd(app)
+
+
+def test_standard_challenge_render_unchanged():
+    """Test that the default challenge types still render without read() overrides"""
+    app = create_ctfd()
+    with app.app_context():
+        register_user(app)
+        admin_client = login_as_user(app, name="admin", password="password")
+
+        challenge_data = {
+            "name": "standard_name",
+            "category": "category",
+            "description": "standard description",
+            "value": 100,
+            "state": "visible",
+            "type": "standard",
+        }
+        r = admin_client.post("/api/v1/challenges", json=challenge_data)
+        assert r.status_code == 200
+        challenge_id = r.get_json()["data"]["id"]
+
+        user_client = login_as_user(app)
+        r = user_client.get(f"/api/v1/challenges/{challenge_id}")
+        assert r.status_code == 200
+        data = r.get_json()["data"]
+        assert data["name"] == "standard_name"
+        assert "standard description" in data["view"]
+    destroy_ctfd(app)


### PR DESCRIPTION
Custom challenge types that override `read()` to inject per-user data (e.g. tokenized connection strings) currently see their values in the API JSON but not in the rendered view, because `render_template` receives the base `Challenges` model instead of the `read()` result. This fixes both render sites — the user-facing challenge endpoint (`CTFd/api/v1/challenges.py`) and the admin preview (`CTFd/admin/challenges.py`) — by passing the `read()` output to the template through a small `ChallengeRenderData` wrapper that prefers `read()` values and falls back to the model for anything else (including computed properties like `html`/`byline`).

Default challenge types are unaffected since `BaseChallenge.read()` returns the same fields the model exposes. Includes regression tests covering a custom type's override reaching the rendered response for both users and admins.

Fixes #2889
