### PR TITLE
fix: pass challenge read() output to view template renderer

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -586,6 +586,7 @@ class Challenge(Resource):
             max_attempts=chal.max_attempts,
             attempts=attempts,
             challenge=chal,
+            challenge_data=response,
         )
 
         if (


### PR DESCRIPTION
Fixes #2889

**Problem**: plugin-overridden fields from `challenge_class.read()` (e.g. `connection_info` generated per-user URLs) were not visible in the challenge view template, because the template renderer only received the base `chal` object.

**Fix**: pass the `read()` output (`response`) to `render_template` as `challenge_data`, keeping `challenge=chal` for backward compatibility with existing templates.

**Verification**: `python -m py_compile` passes.